### PR TITLE
feat: add fsa confirm

### DIFF
--- a/src/agent/confirm.ts
+++ b/src/agent/confirm.ts
@@ -1,0 +1,431 @@
+import { createHash } from "node:crypto";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import type { AuditorConfig } from "../config.js";
+import { loadSource } from "../ingest/source.js";
+import { listWorkspaceFiles, normalizeRelativePath, prepareSandboxWorkspace, writeSandboxFiles, type SandboxWorkspace } from "../security/sandbox.js";
+import { projectHistoryDir } from "../trace/history.js";
+import { writeLastRunPointer } from "../trace/last-run.js";
+import { RunLogger } from "../trace/logger.js";
+import type { Doc } from "../types.js";
+import { publicPath } from "../util/paths.js";
+import { consolidateByFixEquivalence, type FixEquivEdge, type FixEquivItem } from "./consolidate.js";
+import { ProjectMemory } from "./memory.js";
+import { isPiSessionProvider, runAuditSession } from "./pi-session.js";
+import { buildTools, newSession, type AgentSession, type FixPatch, type ToolContext } from "./tools.js";
+
+// `fsa confirm` — the open-world counterpart to the network-sealed `fsa run`. It does
+// NOT discover: it takes a prior run's CONFIRMED findings, freezes their provenance
+// (found blind, no network), then runs one network-enabled session whose job is to
+// CONSOLIDATE the findings into distinct bugs, REPRODUCE each against real-world ground
+// truth (fork the live target, etc.), check NOVELTY/corroboration online, and emit a
+// submit/no-submit decision sheet. The framework supplies the network capability + the
+// freeze + the decision contract; the model decides what "real ground truth" is for the
+// target and how to reach it. Nothing here is per-technology.
+
+export interface ConfirmRunResult {
+  runDir: string;
+  decisionRows: number;
+}
+
+interface ConfirmProvenance {
+  inputRunDir: string;
+  frozenAt: string;
+  frozenFiles: Array<{ path: string; sha256: string; bytes: number }>;
+}
+
+export async function runConfirm(
+  cfg: AuditorConfig,
+  options: { inputRunDir: string; streamEvents?: boolean },
+): Promise<ConfirmRunResult> {
+  // Confirm needs a real agent that can fork a live network and run real nodes; the
+  // mock/CLI fallbacks cannot, so this mode requires a pi-session provider.
+  if (!isPiSessionProvider(cfg.provider)) {
+    throw new Error(
+      `fsa confirm needs a pi-session provider (e.g. openai-codex) for real-world reproduction; provider "${cfg.provider}" cannot fork a live network. Set --provider openai-codex (and log pi in).`,
+    );
+  }
+  if (cfg.sourcePaths.length === 0) throw new Error("fsa confirm needs --source (the target code to reproduce against)");
+  const inputRunDir = path.resolve(options.inputRunDir);
+
+  const confirmCfg: AuditorConfig = { ...cfg, confirmMode: true };
+  const startedAt = new Date();
+  const logger = new RunLogger(confirmCfg.outputDir, `${confirmCfg.targetName}-confirm`, startedAt, { streamEvents: options.streamEvents ?? false });
+  await logger.init();
+  await writeLastRunPointer(path.dirname(logger.runDir), logger.runDir, `${confirmCfg.targetName}-confirm`);
+
+  // 1. Freeze + fingerprint the input run BEFORE any network access. This anchors the
+  // claim that the findings were produced blind (no network), independent of anything
+  // the open-world pass later reads online.
+  const provenance = await freezeInputRun(inputRunDir);
+  await logger.artifact("confirm_provenance.json", provenance);
+  await logger.event("audit_confirm_freeze", { inputRunDir: publicPath(inputRunDir), files: provenance.frozenFiles.length });
+
+  // 2. Load the prior run's confirmed findings as the work list.
+  const priorFindings = await loadConfirmedFindings(inputRunDir);
+  if (priorFindings.length === 0) {
+    throw new Error(`fsa confirm: no confirmed findings in ${path.join(inputRunDir, "audit_findings.json")} (point it at a completed run dir).`);
+  }
+  const seed = renderFindingsSeed(priorFindings);
+
+  // 3. Workspace: copy the build root (reproducible) and the FROZEN report + per-finding
+  // disclosures as corpus, so the model can read each finding's claimed exploit/fix.
+  const source = await loadSource(confirmCfg.sourcePaths);
+  if (source.length === 0) throw new Error("fsa confirm requires at least one readable source file (use --source)");
+  const workspaceRoots = confirmCfg.buildRoot ? [confirmCfg.buildRoot] : confirmCfg.sourcePaths;
+  const workspace = await prepareSandboxWorkspace(workspaceRoots, logger.runDir, "confirm/workspace");
+  const frozenDocs = await loadFrozenReportDocs(inputRunDir);
+  const corpusManifest = await copyDocsIntoWorkspace(workspace, frozenDocs);
+
+  const session: AgentSession = newSession();
+  session.workspace = workspace;
+  session.baselineFiles = await listWorkspaceFiles(workspace.absolute);
+  session.buildCacheDir = path.join(projectHistoryDir(historyLocation(confirmCfg)), "build-cache");
+
+  const memory = new ProjectMemory(path.join(projectHistoryDir(historyLocation(confirmCfg)), "memory.jsonl"));
+  const ctx: ToolContext = { cfg: confirmCfg, source, corpus: frozenDocs, memory, logger, session };
+  const tools = buildTools();
+
+  await logger.event("audit_confirm_start", {
+    target: confirmCfg.targetName,
+    inputRunDir: publicPath(inputRunDir),
+    findings: priorFindings.length,
+    provider: confirmCfg.provider,
+    model: confirmCfg.auditModel,
+    maxSteps: confirmCfg.auditMaxSteps,
+  });
+
+  // 4. Run the confirm session. confirmMode=true makes the bash tool use the
+  // network-enabled policy (fork/read live networks, fetch, search — never broadcast).
+  const result = await runAuditSession({
+    cfg: confirmCfg,
+    ctx,
+    tools,
+    logger,
+    cwd: workspace.absolute,
+    fileManifest: renderFileManifest(source, corpusManifest),
+    confirm: seed,
+  });
+
+  // 5. Read the model's decision rows, then CONSOLIDATE by execution: run the
+  // fix-equivalence matrix (apply one row's fix to pristine source, re-run another's
+  // PoC) and merge rows a single fix neutralizes. This is the framework's call, not the
+  // model's — "distinct bugs" is decided by execution, not by the model's grouping alone.
+  let rows = readConfirmDecision(session);
+  let equivalence: { clusters: string[][]; edges: FixEquivEdge[]; skipped?: boolean } = { clusters: rows.map((_, idx) => [String(idx)]), edges: [] };
+  if (rows.length > 1 && session.workspace && session.baselineFiles) {
+    const items: FixEquivItem[] = rows.map((row, idx) => {
+      const run = row.reproCommandId ? session.commandRuns.find((record) => record.id === row.reproCommandId) : undefined;
+      return {
+        id: String(idx),
+        ...(row.fixPatch ? { fixPatch: row.fixPatch } : {}),
+        ...(run ? { exploitRun: run } : {}),
+        ...(row.patchedSuccessPatterns ? { patchedSuccessPatterns: row.patchedSuccessPatterns } : {}),
+      };
+    });
+    equivalence = await consolidateByFixEquivalence({
+      items,
+      workspace: session.workspace,
+      baselineFiles: session.baselineFiles,
+      cfg: confirmCfg,
+      logger,
+      ...(session.buildCacheDir ? { cacheDir: session.buildCacheDir } : {}),
+    });
+    rows = mergeRowsByClusters(rows, equivalence.clusters);
+  }
+  await logger.artifact("confirm_equivalence.json", equivalence);
+  await logger.artifact("confirm_decision.json", rows);
+  await logger.artifact("confirm_transcript.json", { stoppedReason: result.stoppedReason, steps: result.steps });
+  await logger.artifact(
+    "confirm_report.md",
+    renderConfirmReport({ target: confirmCfg.targetName, provider: confirmCfg.provider, model: confirmCfg.auditModel, inputRunDir, provenance, priorFindings: priorFindings.length, rows }),
+  );
+  await logger.event("audit_confirm_done", {
+    stoppedReason: result.stoppedReason,
+    steps: result.steps.length,
+    rows: rows.length,
+    reproducedYes: rows.filter((row) => row.reproduced === "yes").length,
+    submitCandidates: rows.filter((row) => row.recommendation === "submit-candidate").length,
+  });
+  await writeLastRunPointer(path.dirname(logger.runDir), logger.runDir, `${confirmCfg.targetName}-confirm`);
+
+  return { runDir: logger.runDir, decisionRows: rows.length };
+}
+
+// --- freeze / provenance -----------------------------------------------------
+
+const FROZEN_FILE = /^(audit_report\.md|audit_findings\.json|report_f\d+\.md)$/;
+
+async function freezeInputRun(runDir: string): Promise<ConfirmProvenance> {
+  let names: string[] = [];
+  try {
+    names = await readdir(runDir);
+  } catch (error) {
+    throw new Error(`fsa confirm: cannot read run dir ${runDir}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const frozenFiles: ConfirmProvenance["frozenFiles"] = [];
+  for (const name of names.filter((n) => FROZEN_FILE.test(n)).sort()) {
+    try {
+      const buf = await readFile(path.join(runDir, name));
+      frozenFiles.push({ path: name, sha256: createHash("sha256").update(buf).digest("hex"), bytes: buf.length });
+    } catch {
+      // skip unreadable
+    }
+  }
+  return { inputRunDir: publicPath(runDir), frozenAt: new Date().toISOString(), frozenFiles };
+}
+
+// --- loading the prior run ---------------------------------------------------
+
+async function loadConfirmedFindings(runDir: string): Promise<Array<Record<string, unknown>>> {
+  const file = path.join(runDir, "audit_findings.json");
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await readFile(file, "utf8"));
+  } catch (error) {
+    throw new Error(`fsa confirm: cannot read or parse ${file}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const list = Array.isArray(raw)
+    ? raw
+    : raw && typeof raw === "object" && Array.isArray((raw as Record<string, unknown>).findings)
+      ? ((raw as Record<string, unknown>).findings as unknown[])
+      : [];
+  return list.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === "object" && !Array.isArray(item));
+}
+
+function renderFindingsSeed(findings: Array<Record<string, unknown>>): string {
+  const str = (value: unknown): string => (typeof value === "string" ? value : value === undefined || value === null ? "" : JSON.stringify(value));
+  const clip = (text: string, max: number): string => (text.length > max ? `${text.slice(0, max)}…` : text);
+  return findings
+    .map((finding, idx) => {
+      const id = str(finding.id) || `f${idx + 1}`;
+      const lines = [
+        `[${id}] (${str(finding.severity) || "?"} | ${str(finding.confirmationStatus) || "?"}) ${str(finding.title)}`,
+        `   location: ${str(finding.location)}`,
+      ];
+      const desc = str(finding.description);
+      if (desc) lines.push(`   claim: ${clip(desc, 600)}`);
+      const sketch = str(finding.exploitSketch) || str(finding.exploit_sketch);
+      if (sketch) lines.push(`   claimed exploit: ${clip(sketch, 500)}`);
+      const fix = str(finding.fix);
+      if (fix) lines.push(`   claimed fix: ${clip(fix, 300)}`);
+      return lines.join("\n");
+    })
+    .join("\n\n");
+}
+
+async function loadFrozenReportDocs(runDir: string): Promise<Doc[]> {
+  let names: string[] = [];
+  try {
+    names = await readdir(runDir);
+  } catch {
+    return [];
+  }
+  const wanted = names.filter((n) => FROZEN_FILE.test(n)).sort();
+  const docs: Doc[] = [];
+  for (const name of wanted) {
+    try {
+      const content = await readFile(path.join(runDir, name), "utf8");
+      docs.push({ path: `prior-run/${name}`, content, kind: "corpus" });
+    } catch {
+      // skip
+    }
+  }
+  return docs;
+}
+
+async function copyDocsIntoWorkspace(workspace: SandboxWorkspace, docs: Doc[]): Promise<string[]> {
+  if (docs.length === 0) return [];
+  const seen = new Set<string>();
+  const files = docs.map((doc, index) => {
+    const safe = normalizeRelativePath(doc.path) ?? `doc-${index}`;
+    let rel = `corpus/${safe}`;
+    while (seen.has(rel)) rel = `corpus/${index}-${safe}`;
+    seen.add(rel);
+    return { path: rel, content: doc.content };
+  });
+  await writeSandboxFiles(workspace.absolute, files);
+  return files.map((file) => file.path);
+}
+
+function renderFileManifest(source: Doc[], corpusEntries: string[]): string {
+  const lines = source.slice(0, 600).map((doc) => `- ${doc.path} (${doc.content ? doc.content.split("\n").length : 0} lines)`);
+  const more = source.length > 600 ? `\n…and ${source.length - 600} more files` : "";
+  let out = `${lines.join("\n")}${more}`;
+  if (corpusEntries.length > 0) {
+    out += `\n\nFrozen prior-run report + per-finding disclosures under corpus/:\n${corpusEntries.map((entry) => `- ${entry}`).join("\n")}`;
+  }
+  return out;
+}
+
+// --- decision sheet ----------------------------------------------------------
+
+interface ConfirmDecisionRow {
+  bug: string;
+  members: string[];
+  distinctFix: string;
+  reproduced: "yes" | "no" | "could-not-set-up" | "unknown";
+  reproEvidence: string;
+  corroboration: string;
+  novelty: string;
+  humanGates: string;
+  recommendation: "submit-candidate" | "needs-human" | "drop" | "unknown";
+  // Structured fields the fix-equivalence matrix needs (present when the row's PoC is a
+  // source-level test with a declared fix). Not rendered; consumed by consolidation.
+  reproCommandId?: string;
+  fixPatch?: FixPatch;
+  patchedSuccessPatterns?: string[];
+  // Set by the framework when this row is the merge of several rows a single fix neutralized.
+  mergedFrom?: string[];
+}
+
+function readConfirmDecision(session: AgentSession): ConfirmDecisionRow[] {
+  let entry = session.scratchFiles.get("confirm_decision.json");
+  if (entry === undefined) {
+    for (const [key, value] of session.scratchFiles) {
+      if (key.endsWith("/confirm_decision.json")) {
+        entry = value;
+        break;
+      }
+    }
+  }
+  if (entry === undefined) return [];
+  let raw: unknown;
+  try {
+    raw = JSON.parse(entry);
+  } catch {
+    return [];
+  }
+  const items = Array.isArray(raw)
+    ? raw
+    : raw && typeof raw === "object" && Array.isArray((raw as Record<string, unknown>).decisions)
+      ? ((raw as Record<string, unknown>).decisions as unknown[])
+      : [];
+  return items.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === "object" && !Array.isArray(item)).map(normalizeDecisionRow);
+}
+
+function normalizeDecisionRow(raw: Record<string, unknown>): ConfirmDecisionRow {
+  const str = (value: unknown): string => (typeof value === "string" ? value.trim() : value === undefined || value === null ? "" : JSON.stringify(value));
+  const members = Array.isArray(raw.members) ? raw.members.map((m) => str(m)).filter(Boolean) : str(raw.members) ? [str(raw.members)] : [];
+  const reproduced = ((value: string): ConfirmDecisionRow["reproduced"] => (value === "yes" || value === "no" || value === "could-not-set-up" ? value : "unknown"))(str(raw.reproduced).toLowerCase());
+  const recommendation = ((value: string): ConfirmDecisionRow["recommendation"] =>
+    value === "submit-candidate" || value === "needs-human" || value === "drop" ? value : "unknown")(str(raw.recommendation).toLowerCase());
+  const reproCommandId = str(raw.repro_command_id) || str(raw.reproCommandId);
+  const fixPatch = parseFixPatch(raw.fix_patch ?? raw.fixPatch);
+  const patched = asStringList(raw.patched_success_patterns ?? raw.patchedSuccessPatterns);
+  return {
+    bug: str(raw.bug) || str(raw.title) || "(unnamed)",
+    members,
+    distinctFix: str(raw.distinct_fix) || str(raw.distinctFix),
+    reproduced,
+    reproEvidence: str(raw.repro_evidence) || str(raw.reproEvidence),
+    corroboration: str(raw.corroboration),
+    novelty: str(raw.novelty),
+    humanGates: str(raw.human_gates) || str(raw.humanGates),
+    recommendation,
+    ...(reproCommandId ? { reproCommandId } : {}),
+    ...(fixPatch ? { fixPatch } : {}),
+    ...(patched.length > 0 ? { patchedSuccessPatterns: patched } : {}),
+  };
+}
+
+function parseFixPatch(value: unknown): FixPatch | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const raw = value as Record<string, unknown>;
+  const filePath = typeof raw.path === "string" ? raw.path.trim() : "";
+  const oldText = typeof raw.old === "string" ? raw.old : undefined;
+  const newText = typeof raw.new === "string" ? raw.new : undefined;
+  if (!filePath || oldText === undefined || oldText.length === 0 || newText === undefined) return undefined;
+  return { path: filePath, old: oldText, new: newText };
+}
+
+function asStringList(value: unknown): string[] {
+  if (typeof value === "string") return value.trim() ? [value.trim()] : [];
+  if (!Array.isArray(value)) return [];
+  return value.map((entry) => (typeof entry === "string" ? entry.trim() : "")).filter(Boolean).slice(0, 16);
+}
+
+// Collapse the model's rows per the fix-equivalence clusters: each cluster of row ids
+// (indices) becomes one row. Singletons pass through unchanged; multi-row clusters merge.
+function mergeRowsByClusters(rows: ConfirmDecisionRow[], clusters: string[][]): ConfirmDecisionRow[] {
+  const out: ConfirmDecisionRow[] = [];
+  for (const cluster of clusters) {
+    const members = cluster.map((id) => rows[Number(id)]).filter((row): row is ConfirmDecisionRow => Boolean(row));
+    if (members.length === 0) continue;
+    out.push(members.length === 1 ? (members[0] as ConfirmDecisionRow) : mergeRows(members));
+  }
+  return out;
+}
+
+function mergeRows(members: ConfirmDecisionRow[]): ConfirmDecisionRow {
+  const uniq = (values: string[]): string[] => [...new Set(values.filter(Boolean))];
+  const reproRank: Record<ConfirmDecisionRow["reproduced"], number> = { yes: 3, "could-not-set-up": 2, no: 1, unknown: 0 };
+  const recRank: Record<ConfirmDecisionRow["recommendation"], number> = { "submit-candidate": 3, "needs-human": 2, drop: 1, unknown: 0 };
+  const strongest = <T extends string>(values: T[], rank: Record<T, number>, fallback: T): T => values.reduce((best, value) => (rank[value] > rank[best] ? value : best), fallback);
+  return {
+    bug: members.map((m) => m.bug).join(" / "),
+    members: uniq(members.flatMap((m) => [...m.members, m.bug])),
+    distinctFix: members.map((m) => m.distinctFix).find(Boolean) ?? "",
+    reproduced: strongest(members.map((m) => m.reproduced), reproRank, "unknown"),
+    reproEvidence: uniq(members.map((m) => m.reproEvidence)).join(" | "),
+    corroboration: uniq(members.map((m) => m.corroboration)).join(" | "),
+    novelty: uniq(members.map((m) => m.novelty)).join(" | "),
+    humanGates: uniq(members.map((m) => m.humanGates)).join(" | "),
+    recommendation: strongest(members.map((m) => m.recommendation), recRank, "unknown"),
+    mergedFrom: members.map((m) => m.bug),
+  };
+}
+
+function renderConfirmReport(input: {
+  target: string;
+  provider: string;
+  model: string;
+  inputRunDir: string;
+  provenance: ConfirmProvenance;
+  priorFindings: number;
+  rows: ConfirmDecisionRow[];
+}): string {
+  const out: string[] = [];
+  out.push(`# Confirm results: ${input.target}`, "");
+  out.push(`- Provider / model: ${input.provider} / ${input.model}`);
+  out.push(`- Input run (frozen): ${input.inputRunDir}`);
+  out.push(`- Prior confirmed findings: ${input.priorFindings} → distinct bugs after consolidation: ${input.rows.length}`);
+  const repro = input.rows.filter((row) => row.reproduced === "yes").length;
+  const candidates = input.rows.filter((row) => row.recommendation === "submit-candidate").length;
+  out.push(`- Reproduced on real target: ${repro} / ${input.rows.length}; submit candidates: ${candidates}`);
+  out.push("");
+  out.push("## Provenance (frozen before any network access)", "");
+  if (input.provenance.frozenFiles.length === 0) {
+    out.push("_No report artifacts were found to fingerprint in the input run._", "");
+  } else {
+    out.push(`Fingerprinted at ${input.provenance.frozenAt}:`, "");
+    for (const file of input.provenance.frozenFiles) out.push(`- \`${file.path}\` — sha256 \`${file.sha256}\` (${file.bytes} bytes)`);
+    out.push("");
+  }
+  out.push("## Decision sheet", "");
+  if (input.rows.length === 0) {
+    out.push("_The confirm session produced no decision rows (confirm_decision.json missing or empty)._", "");
+    return out.join("\n");
+  }
+  for (const [idx, row] of input.rows.entries()) {
+    const badge = row.reproduced === "yes" ? "✅ reproduced" : row.reproduced === "no" ? "❌ not reproduced" : row.reproduced === "could-not-set-up" ? "⚠ could not set up" : "? unknown";
+    out.push(`### ${idx + 1}. ${row.bug} — ${badge} — recommendation: ${row.recommendation}`);
+    if (row.mergedFrom && row.mergedFrom.length > 1) out.push(`- Consolidated by fix-equivalence (a single fix neutralized all of these): ${row.mergedFrom.join(" / ")}`);
+    if (row.members.length > 0) out.push(`- Merged prior findings: ${row.members.join(", ")}`);
+    if (row.distinctFix) out.push(`- Distinct fix: ${row.distinctFix}`);
+    if (row.reproEvidence) out.push(`- Reproduction: ${row.reproEvidence}`);
+    if (row.corroboration) out.push(`- Corroboration (web — a lead, not proof): ${row.corroboration}`);
+    if (row.novelty) out.push(`- Novelty: ${row.novelty}`);
+    if (row.humanGates) out.push(`- Human gates (not settled by execution): ${row.humanGates}`);
+    out.push("");
+  }
+  return out.join("\n");
+}
+
+function historyLocation(cfg: AuditorConfig): { outputDir: string; targetName: string; historyDir?: string } {
+  return {
+    outputDir: cfg.outputDir,
+    targetName: cfg.targetName,
+    ...(cfg.historyDir ? { historyDir: cfg.historyDir } : {}),
+  };
+}

--- a/src/agent/confirm.ts
+++ b/src/agent/confirm.ts
@@ -36,7 +36,7 @@ interface ConfirmProvenance {
 
 export async function runConfirm(
   cfg: AuditorConfig,
-  options: { inputRunDir: string; streamEvents?: boolean },
+  options: { inputRunDir: string; maxSteps?: number; streamEvents?: boolean },
 ): Promise<ConfirmRunResult> {
   // Confirm needs a real agent that can fork a live network and run real nodes; the
   // mock/CLI fallbacks cannot, so this mode requires a pi-session provider.
@@ -48,7 +48,11 @@ export async function runConfirm(
   if (cfg.sourcePaths.length === 0) throw new Error("fsa confirm needs --source (the target code to reproduce against)");
   const inputRunDir = path.resolve(options.inputRunDir);
 
-  const confirmCfg: AuditorConfig = { ...cfg, confirmMode: true };
+  // Confirm runs UNBOUNDED by default: reproduction on a real target is heavy, and the
+  // step count should never silently truncate productive work. A turn cap applies only
+  // when the caller explicitly asks for one (--max-steps). The run otherwise ends when
+  // the model emits done (the prompt pushes it to reproduce early, not survey forever).
+  const confirmCfg: AuditorConfig = { ...cfg, confirmMode: true, auditMaxSteps: options.maxSteps ?? Number.POSITIVE_INFINITY };
   const startedAt = new Date();
   const logger = new RunLogger(confirmCfg.outputDir, `${confirmCfg.targetName}-confirm`, startedAt, { streamEvents: options.streamEvents ?? false });
   await logger.init();
@@ -92,7 +96,7 @@ export async function runConfirm(
     findings: priorFindings.length,
     provider: confirmCfg.provider,
     model: confirmCfg.auditModel,
-    maxSteps: confirmCfg.auditMaxSteps,
+    maxSteps: Number.isFinite(confirmCfg.auditMaxSteps) ? confirmCfg.auditMaxSteps : "unlimited",
   });
 
   // 4. Run the confirm session. confirmMode=true makes the bash tool use the

--- a/src/agent/consolidate.ts
+++ b/src/agent/consolidate.ts
@@ -1,0 +1,160 @@
+import type { AuditorConfig } from "../config.js";
+import type { SandboxWorkspace } from "../security/sandbox.js";
+import type { RunLogger } from "../trace/logger.js";
+import { runDifferentialConfirmation } from "./differential.js";
+import type { AgentFinding, CommandRunRecord, FixPatch } from "./tools.js";
+
+// Framework-orchestrated, execution-grounded consolidation (the "fix-equivalence
+// matrix"). Two reproduced bugs are the SAME underlying bug iff a single fix
+// neutralizes both PoCs — proven by EXECUTION, not by similar titles or nearby
+// locations. We test it by cross-application: apply bug i's fix to the pristine
+// target source and re-run bug j's exploit PoC; if j's exploit is now blocked, fix i
+// neutralizes poc j. When that holds in BOTH directions the two are merged. This
+// reuses the differential primitive (apply-fix-to-baseline, re-run, check-blocked);
+// the framework — never the model — runs it and decides the merges.
+
+export interface FixEquivItem {
+  id: string;
+  fixPatch?: FixPatch;
+  /** The passing PoC run for this bug (its commandSpec is re-run after a fix is applied). */
+  exploitRun?: CommandRunRecord;
+  /** Patterns the PoC prints once the exploit is BLOCKED (the differential's blocked signal). */
+  patchedSuccessPatterns?: string[];
+}
+
+export interface FixEquivEdge {
+  fixOf: string;
+  pocOf: string;
+  blocked: boolean;
+  reason: string;
+}
+
+export interface FixEquivResult {
+  /** Connected components over the symmetric "same bug" relation (input order preserved). */
+  clusters: string[][];
+  /** Every cross-application probe the matrix ran, for the audit trail. */
+  edges: FixEquivEdge[];
+  /** Set when the matrix was skipped (too many items) — every item stays its own cluster. */
+  skipped?: boolean;
+}
+
+/**
+ * Pure transitive clustering: items a and b land in the same cluster when
+ * `equivalent(a, b)` (the relation is treated as symmetric and transitively closed).
+ * Cluster + representative order follows first appearance in `ids`. No I/O — unit-testable.
+ */
+export function unionFindClusters(ids: string[], equivalent: (a: string, b: string) => boolean): string[][] {
+  const parent = new Map<string, string>();
+  for (const id of ids) parent.set(id, id);
+  const find = (start: string): string => {
+    let root = start;
+    while (parent.get(root) !== root) root = parent.get(root) as string;
+    let cursor = start;
+    while (parent.get(cursor) !== root) {
+      const next = parent.get(cursor) as string;
+      parent.set(cursor, root);
+      cursor = next;
+    }
+    return root;
+  };
+  const union = (a: string, b: string): void => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent.set(ra, rb);
+  };
+  for (let i = 0; i < ids.length; i += 1) {
+    for (let j = i + 1; j < ids.length; j += 1) {
+      const a = ids[i] as string;
+      const b = ids[j] as string;
+      if (equivalent(a, b)) union(a, b);
+    }
+  }
+  const out: string[][] = [];
+  const repIndex = new Map<string, number>();
+  for (const id of ids) {
+    const root = find(id);
+    let idx = repIndex.get(root);
+    if (idx === undefined) {
+      idx = out.length;
+      repIndex.set(root, idx);
+      out.push([]);
+    }
+    (out[idx] as string[]).push(id);
+  }
+  return out;
+}
+
+/**
+ * Run the fix-equivalence matrix over reproduced bugs and return their clusters. Only
+ * items that carry BOTH a fix and a passing PoC (with a blocked-exploit signal) can be
+ * probed; an item missing either cannot be tested and stays its own singleton cluster
+ * (honest — the framework never merges what it cannot prove). Bounded by `maxItems` so a
+ * large set cannot trigger an O(N^2) explosion of compiles/forks.
+ */
+export async function consolidateByFixEquivalence(input: {
+  items: FixEquivItem[];
+  workspace: SandboxWorkspace;
+  baselineFiles: Set<string>;
+  cfg: AuditorConfig;
+  logger: RunLogger;
+  cacheDir?: string;
+  maxItems?: number;
+}): Promise<FixEquivResult> {
+  const { items } = input;
+  const ids = items.map((item) => item.id);
+  const edges: FixEquivEdge[] = [];
+  const maxItems = input.maxItems ?? 8;
+  if (items.length > maxItems) {
+    await input.logger.event("audit_confirm_equiv_skipped", { items: items.length, maxItems });
+    return { clusters: ids.map((id) => [id]), edges, skipped: true };
+  }
+
+  // Does applying `fixItem`'s fix to the pristine source block `pocItem`'s exploit PoC?
+  const fixBlocksPoc = async (fixItem: FixEquivItem, pocItem: FixEquivItem): Promise<boolean> => {
+    if (!fixItem.fixPatch || !pocItem.exploitRun || !pocItem.exploitRun.passed) return false;
+    if (pocItem.exploitRun.successPatterns.length === 0) return false;
+    if (!pocItem.patchedSuccessPatterns || pocItem.patchedSuccessPatterns.length === 0) return false;
+    const synthetic: AgentFinding = {
+      id: `${fixItem.id}~fix~blocks~${pocItem.id}~poc`,
+      title: "",
+      severity: "medium",
+      location: "",
+      description: "",
+      evidence: "",
+      exploitSketch: "",
+      fix: "",
+      confidence: 1,
+      confirmationStatus: "confirmed-executable",
+      fixPatch: fixItem.fixPatch,
+      patchedSuccessPatterns: pocItem.patchedSuccessPatterns,
+    };
+    const res = await runDifferentialConfirmation({
+      workspace: input.workspace,
+      finding: synthetic,
+      exploitRun: pocItem.exploitRun,
+      baselineFiles: input.baselineFiles,
+      cfg: input.cfg,
+      logger: input.logger,
+      ...(input.cacheDir ? { cacheDir: input.cacheDir } : {}),
+    });
+    edges.push({ fixOf: fixItem.id, pocOf: pocItem.id, blocked: res.confirmed, reason: res.reason });
+    return res.confirmed;
+  };
+
+  // Collect the symmetric "same bug" pairs. Short-circuit: only probe the reverse
+  // direction when the forward one held, so non-equivalent pairs cost one probe.
+  const equivPairs = new Set<string>();
+  const key = (a: string, b: string): string => (a < b ? `${a}::${b}` : `${b}::${a}`);
+  for (let i = 0; i < items.length; i += 1) {
+    for (let j = i + 1; j < items.length; j += 1) {
+      const a = items[i] as FixEquivItem;
+      const b = items[j] as FixEquivItem;
+      if (!(await fixBlocksPoc(a, b))) continue;
+      if (!(await fixBlocksPoc(b, a))) continue;
+      equivPairs.add(key(a.id, b.id));
+    }
+  }
+  const clusters = unionFindClusters(ids, (a, b) => equivPairs.has(key(a, b)));
+  await input.logger.event("audit_confirm_equiv", { items: items.length, clusters: clusters.length, merges: items.length - clusters.length });
+  return { clusters, edges };
+}

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -2,7 +2,7 @@ import type { AuditorConfig } from "../config.js";
 import type { LlmClient } from "../types.js";
 import type { RunLogger } from "../trace/logger.js";
 import { extractJsonArray, extractJsonObject } from "../util/json.js";
-import { buildDeepKickoff, buildAuditKickoff, buildMapKickoff, buildVerifyKickoff, AUDIT_DEEP_SYSTEM, AUDIT_SYSTEM, AUDIT_VERIFY_SYSTEM, MAP_SYSTEM, renderTranscript, type TranscriptStep } from "./prompts.js";
+import { buildConfirmKickoff, buildDeepKickoff, buildAuditKickoff, buildMapKickoff, buildVerifyKickoff, AUDIT_CONFIRM_SYSTEM, AUDIT_DEEP_SYSTEM, AUDIT_SYSTEM, AUDIT_VERIFY_SYSTEM, MAP_SYSTEM, renderTranscript, type TranscriptStep } from "./prompts.js";
 import type { AgentTool, ToolContext } from "./tools.js";
 
 // Provider-agnostic ReAct driver. It runs on top of the plain text-in/text-out
@@ -33,11 +33,13 @@ export async function runAuditLoop(input: {
   map?: boolean;
   /** Verify posture: confirm-or-refute ONE specific suspected finding (the claim text). */
   verify?: string;
+  /** Confirm mode: open-world reproduce/consolidate/decide over a prior run's findings (the seed text). */
+  confirm?: string;
   /** Base backoff for transient-throttle retries; overridable for tests. */
   transientRetryBaseMs?: number;
 }): Promise<AuditLoopResult> {
   const transientRetryBaseMs = input.transientRetryBaseMs ?? 4000;
-  const systemPrompt = input.verify ? AUDIT_VERIFY_SYSTEM : input.map ? MAP_SYSTEM : input.deep ? AUDIT_DEEP_SYSTEM : AUDIT_SYSTEM;
+  const systemPrompt = input.confirm ? AUDIT_CONFIRM_SYSTEM : input.verify ? AUDIT_VERIFY_SYSTEM : input.map ? MAP_SYSTEM : input.deep ? AUDIT_DEEP_SYSTEM : AUDIT_SYSTEM;
   const toolsByName = new Map(input.tools.map((tool) => [tool.name, tool]));
   const kickoffCommon = {
     target: input.cfg.targetName,
@@ -47,13 +49,15 @@ export async function runAuditLoop(input: {
     ...(input.scopeNote ? { scopeNote: input.scopeNote } : {}),
     ...(input.memoryHint ? { memoryHint: input.memoryHint } : {}),
   };
-  const kickoff = input.verify
-    ? buildVerifyKickoff({ ...kickoffCommon, verify: input.verify })
-    : input.map
-      ? buildMapKickoff(kickoffCommon)
-      : input.deep
-        ? buildDeepKickoff({ ...kickoffCommon, ...(input.deepFocus ? { deepFocus: input.deepFocus } : {}) })
-        : buildAuditKickoff(kickoffCommon);
+  const kickoff = input.confirm
+    ? buildConfirmKickoff({ ...kickoffCommon, confirm: input.confirm })
+    : input.verify
+      ? buildVerifyKickoff({ ...kickoffCommon, verify: input.verify })
+      : input.map
+        ? buildMapKickoff(kickoffCommon)
+        : input.deep
+          ? buildDeepKickoff({ ...kickoffCommon, ...(input.deepFocus ? { deepFocus: input.deepFocus } : {}) })
+          : buildAuditKickoff(kickoffCommon);
   const steps: TranscriptStep[] = [];
   let consecutiveParseErrors = 0;
 
@@ -65,7 +69,7 @@ export async function runAuditLoop(input: {
   // residual hypothesis into findings.json. Skips when the model is unresponsive
   // (e.g. provider quota), where another call would also fail.
   const finalizeFindings = async (): Promise<void> => {
-    if (input.map) return; // map writes scopes.json, not findings.json
+    if (input.map || input.confirm) return; // map writes scopes.json; confirm writes confirm_decision.json
     if (input.ctx.session.scratchFiles.has("findings.json")) return;
     const ask = `Your audit is ending now. Output ONLY a JSON array for findings.json and nothing else (no prose, no fences): every confirmed finding AND every residual hypothesis you formed, each as {"title","severity","location","description","evidence","exploit_sketch","fix","confidence","command_id"?}. Include lower-confidence hypotheses with their location and why they are suspected. If you genuinely found nothing, output [].`;
     try {

--- a/src/agent/pi-session.ts
+++ b/src/agent/pi-session.ts
@@ -4,7 +4,7 @@ import { Type } from "typebox";
 import type { AuditorConfig } from "../config.js";
 import type { RunLogger } from "../trace/logger.js";
 import type { LlmClient } from "../types.js";
-import type { TranscriptStep } from "./prompts.js";
+import { AUDIT_CONFIRM_SYSTEM, type TranscriptStep } from "./prompts.js";
 import { readScratchScopes, scratchHasFindings, type AgentTool, type ToolContext } from "./tools.js";
 
 // Continuous-session driver (point 5). Instead of re-driving a stateless
@@ -46,6 +46,8 @@ export async function runAuditSession(input: {
   deepFocus?: string;
   map?: boolean;
   verify?: string;
+  /** Confirm mode: the open-world reproduce/consolidate/decide pass over a prior run's findings. */
+  confirm?: string;
 }): Promise<SessionDriverResult> {
   const model = getModelSafe(input.cfg.provider, input.cfg.auditModel);
   if (!model) throw new Error(`audit session: unknown provider/model ${input.cfg.provider}/${input.cfg.auditModel}`);
@@ -114,8 +116,22 @@ export async function runAuditSession(input: {
   // are exact. The findings finalize must NOT bypass the confirmation gate: it asks
   // only for the obligation analysis (discharged or suspected), never for a confirmed
   // status without a passing test.
+  const hasScratch = (basename: string): boolean =>
+    [...input.ctx.session.scratchFiles.keys()].some((key) => key === basename || key.endsWith(`/${basename}`));
   const finalizeIfEmpty = async (): Promise<void> => {
     if (finalizing) return;
+    if (input.confirm) {
+      if (hasScratch("confirm_decision.json")) return;
+      finalizing = true;
+      await input.logger.event("audit_confirm_finalize", { reason: "no confirm_decision.json before stop" });
+      try {
+        await session.prompt(CONFIRM_FINALIZE_PROMPT);
+      } catch {
+        // best-effort
+      }
+      await input.logger.event("audit_confirm_finalize_done", { hasDecision: hasScratch("confirm_decision.json") });
+      return;
+    }
     if (input.map) {
       if (readScratchScopes(input.ctx.session).length > 0) return;
       finalizing = true;
@@ -150,6 +166,7 @@ export async function runAuditSession(input: {
         ...(input.deepFocus ? { deepFocus: input.deepFocus } : {}),
         ...(input.map ? { map: true } : {}),
         ...(input.verify ? { verify: input.verify } : {}),
+        ...(input.confirm ? { confirm: input.confirm } : {}),
       }));
     } catch (error) {
       if (!budgetAborted) {
@@ -228,7 +245,10 @@ const toolSchemas: Record<string, ReturnType<typeof Type.Object>> = {
   }),
 };
 
-function buildSessionPrompt(input: { cfg: AuditorConfig; scopeNote?: string; fileManifest: string; memoryHint?: string; deep?: boolean; deepFocus?: string; map?: boolean; verify?: string }): string {
+function buildSessionPrompt(input: { cfg: AuditorConfig; scopeNote?: string; fileManifest: string; memoryHint?: string; deep?: boolean; deepFocus?: string; map?: boolean; verify?: string; confirm?: string }): string {
+  // Confirm is the open-world mode: it has its own white-hat line (fork/read live
+  // networks OK, never broadcast), so it does NOT share the local-only scaffold below.
+  if (input.confirm) return buildConfirmSessionPrompt({ confirm: input.confirm, fileManifest: input.fileManifest, ...(input.scopeNote ? { scopeNote: input.scopeNote } : {}), ...(input.memoryHint ? { memoryHint: input.memoryHint } : {}) });
   const intro = input.verify ? verifyIntro(input.verify) : input.map ? mapIntro() : input.deep ? deepIntro(input.deepFocus) : breadthIntro();
   return `${intro}
 
@@ -267,6 +287,31 @@ ${input.map
 const MAP_FINALIZE_PROMPT = `Your exploration budget is spent. Do NOT read, grep, or run anything else. Based ONLY on what you have already examined, WRITE scopes.json now at the workspace root as your very next action — call the write tool once with a JSON array of objects {"id","obligation","region":"file:lines","lenses":[...],"exposure","difficulty","score","why"} covering the most soundness-critical regions you saw (entrypoints that move value, accounting/share math, authorization, liquidation/swap invariants, oracle binding). Partial but concrete beats empty. After writing, emit {"done": true}. Output only the write tool call.`;
 
 const FINDINGS_FINALIZE_PROMPT = `Your budget is spent. Do NOT read, grep, or run anything else. Based ONLY on the analysis you have already done, WRITE findings.json now at the workspace root as your very next action — call the write tool once with the obligations you enumerated for this region and EACH one's status: either discharged (state the exact enforcing line) or suspected (state root cause, exact location, attacker impact, and a fix). Do NOT mark anything confirmed/confirmed-executable — that status requires a test you actually ran and passed, and the budget is gone. Persisting your suspected/discharged analysis is the goal; partial but concrete beats empty. After writing, emit {"done": true}. Output only the write tool call.`;
+
+const CONFIRM_FINALIZE_PROMPT = `Your budget is spent. Do NOT read, fork, fetch, or run anything else. Based ONLY on what you have already reproduced, WRITE confirm_decision.json now at the workspace root as your very next action — call the write tool once with a JSON array, one row per DISTINCT bug: {"bug","members":[...],"distinct_fix","reproduced":"yes"|"no"|"could-not-set-up","repro_evidence","repro_command_id","fix_patch":{"path","old","new"},"patched_success_patterns":[...],"corroboration","novelty","human_gates","recommendation":"submit-candidate"|"needs-human"|"drop"}. Mark "reproduced":"yes" ONLY for a bug you actually reproduced on the real target with a passing command_id; otherwise "no"/"could-not-set-up" with the crutch/blocker named. Include repro_command_id + fix_patch + patched_success_patterns for any source-level PoC so the framework can verify consolidation by execution. Partial but honest beats empty. After writing, emit {"done": true}. Output only the write tool call.`;
+
+// Confirm session prompt = the confirm mission/rules (shared with the loop driver's
+// system prompt) plus this run's frozen findings and context. It deliberately does
+// NOT reuse the local-only scaffold buildSessionPrompt builds for the other modes.
+function buildConfirmSessionPrompt(input: { confirm: string; fileManifest: string; scopeNote?: string; memoryHint?: string }): string {
+  return `${AUDIT_CONFIRM_SYSTEM}
+
+The prior audit's confirmed findings (frozen; reproduce/consolidate these — do NOT discover new ones):
+${input.confirm}
+
+The frozen audit report and per-finding disclosures are under corpus/ in your workspace — read them for each finding's claimed exploit and fix.
+
+Authorized scope note:
+${input.scopeNote && input.scopeNote.trim().length > 0 ? input.scopeNote.trim() : "(none provided — treat all loaded source as in scope)"}
+
+Durable memory from prior runs of this target:
+${input.memoryHint && input.memoryHint.trim().length > 0 ? input.memoryHint.trim() : "(empty)"}
+
+Loaded source files:
+${input.fileManifest}
+
+Consolidate the findings into distinct bugs, reproduce each distinct bug against real ground truth, check novelty/corroboration online (leads only, never proof), then write confirm_decision.json and emit done.`;
+}
 
 function verifyIntro(claim: string): string {
   return `You are an autonomous white-hat security auditor in VERIFY mode: you are handed ONE specific suspected finding and must determine BY EXECUTION whether it is REAL or a FALSE POSITIVE. Do NOT enumerate new issues.

--- a/src/agent/pi-session.ts
+++ b/src/agent/pi-session.ts
@@ -69,9 +69,14 @@ export async function runAuditSession(input: {
     sessionManager: SessionManager.inMemory(),
   });
 
-  // Budget: the continuous session runs until the model stops on its own. Cap the
-  // number of model turns so a real run cannot grow unbounded in cost/time.
-  const maxTurns = Math.max(1, Math.floor(input.cfg.auditMaxSteps));
+  // Budget: the continuous session runs until the model stops on its own. A finite
+  // auditMaxSteps caps the number of model turns so a run cannot grow unbounded in
+  // cost/time; a non-finite or <=0 value means NO turn cap (confirm's default — the
+  // run then ends only when the model emits done, or errors). With no cap the model
+  // owns when it is finished, so the prompt pushes it to reproduce early rather than
+  // survey indefinitely.
+  const unbounded = !Number.isFinite(input.cfg.auditMaxSteps) || input.cfg.auditMaxSteps <= 0;
+  const maxTurns = unbounded ? Number.POSITIVE_INFINITY : Math.max(1, Math.floor(input.cfg.auditMaxSteps));
   // Forced-finalize budget: the loop driver nudges and force-writes when its step
   // budget runs out, but a continuous session has no such hook — on a large
   // codebase the model can spend its whole turn budget exploring and stop (or be

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -250,6 +250,77 @@ ${input.fileManifest}
 Verify the claim: read the cited code and its bindings, then write and run a PoC test that either reproduces the bug (-> confirmed, with fix_patch + patched_success_patterns) or, after genuine effort, demonstrates it cannot reproduce (-> write a "REFUTED:" info finding citing the mitigating code). Respond with one JSON tool action or done object.`;
 }
 
+// CONFIRM mode (`fsa confirm`): the open-world counterpart to the network-sealed
+// audit. It does NOT discover; it takes the prior audit's CONFIRMED findings to a
+// real-world standard of certainty and emits a submit/no-submit decision sheet. The
+// network is available now, governed by three rules. Like every other prompt it
+// prescribes GOALS + an objective acceptance bar, never per-technology steps — the
+// model decides what "real ground truth" is for the target and how to reproduce it.
+export const AUDIT_CONFIRM_SYSTEM = `You are an autonomous white-hat security auditor in CONFIRM mode. You are handed the CONFIRMED FINDINGS of a prior, network-sealed audit — frozen and fingerprinted BEFORE this phase, so their provenance (found blind, no network) is fixed. Your job is NOT to discover new bugs and NOT to amend these findings. It is to take them to a higher, real-world standard of certainty and produce a submit/no-submit decision sheet — BY EXECUTION, not by argument.
+
+The network is available to you now (the prior audit had none). Three rules govern it:
+
+1. EXECUTION IS THE ONLY TRUTH. A finding is REAL only if you reproduce its exploit by EXECUTION against real-world ground truth — the actual deployed/published artifact and its real state (for example a local fork of the live network at a chosen block running the real on-chain code, or the real released package/circuit driven by a real local node). Reproducing only against the copied source is weaker; "reproducing" by reasoning is not reproduction at all.
+
+2. THE WEB IS LEADS AND NOVELTY, NEVER PROOF. You may search public sources (advisories, audits, issue trackers, post-mortems, disclosures). Use them for exactly two things, reported on SEPARATE axes: (a) CORROBORATION — whether independent public analysis supports the mechanism; (b) NOVELTY — whether this is already disclosed (a hit DISQUALIFIES it as a novel submission). A web source NEVER establishes that a bug is real — only your execution does. Never rewrite or "correct" a finding's mechanism to match something you read online.
+
+3. CONSOLIDATE BEFORE YOU REPRODUCE. The prior report may list several findings that are ONE underlying bug. Group them, and justify each grouping BY EXECUTION (e.g. a single minimal fix neutralizes every PoC in the group), not by similar titles or nearby locations. Reproduce each DISTINCT bug once.
+
+The objective bar a finding must clear to be marked REAL (no shortcuts, identical for any technology):
+- it reproduces against the REAL target, not a stand-in or mock of a trusted component;
+- the exploit's effect is EXHIBITED as a concrete observable artifact — a drained or changed balance, a duplicated nullifier, a forged output, an accepted invalid input — never a printed string and never your assertion;
+- every capability used is one a real attacker actually has.
+A finding that only reproduces under a substituted trusted component, an unreachable precondition, or assumed state does NOT clear the bar. Mark it not-reproduced and name the exact crutch it depended on.
+
+You determine, for THIS target, what real ground truth is and how to reach it — fork the live chain, stand up a real local node, build the real release, whatever fits. The framework prescribes no per-technology procedure; it requires only that your reproduction be real, executed, and exhibited.
+${POC_TRUST_RULE}
+
+How you act:
+- Each tool turn, respond with exactly ONE JSON object (a tool action or a done object); no prose, no fences.
+- write/edit create your own scratch/PoC/harness files in the copied workspace. You CANNOT modify the target source under audit.
+- bash runs one command. Use purpose=confirm with success_patterns for a real local test/build runner; you may also fork, fetch, and search.
+
+Output — write confirm_decision.json at the workspace root: a JSON array, one row per DISTINCT bug:
+[{"bug","members":["<finding ids/titles merged>"],"distinct_fix","reproduced":"yes"|"no"|"could-not-set-up","repro_evidence":"how you reproduced it on the real target, the observed effect, and the command_id of the passing run","repro_command_id":"<the passing purpose=confirm run's command_id, when you built a source-level PoC>","fix_patch":{"path","old","new"},"patched_success_patterns":["<what your PoC prints once the fix BLOCKS the exploit>"],"corroboration":"public support for the mechanism, with sources","novelty":"novel | already-disclosed (sources, as of date)","human_gates":"scope / venue / embargo facts you cannot settle by execution","recommendation":"submit-candidate"|"needs-human"|"drop"}]
+A row is only "reproduced":"yes" if it cleared the objective bar above and cites a command_id from a purpose=confirm run that actually passed.
+Supply repro_command_id + fix_patch + patched_success_patterns whenever a row's PoC is a source-level test with a fix: the framework then runs a fix-equivalence matrix over your rows — it applies one row's fix to the pristine source and re-runs another row's PoC — and MERGES any rows a single fix neutralizes, so "distinct bugs" is decided by execution, not by your grouping alone. Rows without these fields are left exactly as you wrote them (the framework cannot machine-verify their separation).
+
+White-hat boundaries (non-negotiable):
+- You MAY read from and fork live networks/data to reproduce LOCALLY. You MUST NOT broadcast/submit/relay/publish any transaction, move funds, or write to any live network or third-party system. Fork and read; replay only against a LOCAL fork; never push to a live system.
+- Do not weaponize beyond a local proof, exfiltrate data, or read secrets you were not given. Reproduce and decide; do not act on the exploit against anyone's live system.`;
+
+export function buildConfirmKickoff(input: {
+  target: string;
+  tools: AgentTool[];
+  scopeNote?: string;
+  fileManifest: string;
+  memoryHint?: string;
+  maxSteps: number;
+  confirm: string;
+}): string {
+  return `Target: ${input.target}
+Mode: CONFIRM — take the prior audit's confirmed findings to a real-world standard by EXECUTION, then write the decision sheet. Up to ${input.maxSteps} actions. The network is available; reproduce on real ground truth, never broadcast.
+
+The prior audit's confirmed findings (frozen; reproduce/consolidate these — do NOT discover new ones):
+${input.confirm}
+
+The frozen audit report and per-finding disclosures are under corpus/ in your workspace — read them for each finding's claimed exploit and fix.
+
+Authorized scope note:
+${input.scopeNote && input.scopeNote.trim().length > 0 ? input.scopeNote.trim() : "(none provided — treat all loaded source as in scope)"}
+
+Available tools:
+${renderToolCatalogue(input.tools)}
+
+Durable memory from prior runs of this target:
+${input.memoryHint && input.memoryHint.trim().length > 0 ? input.memoryHint.trim() : "(empty)"}
+
+Loaded source files:
+${input.fileManifest}
+
+Consolidate the findings into distinct bugs, reproduce each distinct bug against real ground truth, check novelty/corroboration online (leads only), then write confirm_decision.json and emit done. Respond with one JSON tool action or done object.`;
+}
+
 export function buildAuditKickoff(input: {
   target: string;
   tools: AgentTool[];

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -272,6 +272,8 @@ The objective bar a finding must clear to be marked REAL (no shortcuts, identica
 - every capability used is one a real attacker actually has.
 A finding that only reproduces under a substituted trusted component, an unreachable precondition, or assumed state does NOT clear the bar. Mark it not-reproduced and name the exact crutch it depended on.
 
+Spend your effort on REPRODUCTION, not a survey. There is no turn limit by default, so YOU decide when you are finished — that is not a licence to read indefinitely. Read only enough to act, then pick ONE distinct bug, stand up a real PoC against real ground truth, and iterate it to a passing purpose=confirm run before moving to the next. One bug reproduced on the real target is worth far more than ten re-read ones. When you have reproduced what you can and honestly recorded the rest, write confirm_decision.json and emit done — do not keep inspecting once building is the higher-value move.
+
 You determine, for THIS target, what real ground truth is and how to reach it — fork the live chain, stand up a real local node, build the real release, whatever fits. The framework prescribes no per-technology procedure; it requires only that your reproduction be real, executed, and exhibited.
 ${POC_TRUST_RULE}
 

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { AuditorConfig } from "../config.js";
-import { analyzeAgentBashCommandSafety, isAgentBuildCommand, isAgentConfirmCommand } from "../security/policy.js";
+import { analyzeAgentBashCommandSafety, analyzeConfirmBashCommandSafety, isAgentBuildCommand, isAgentConfirmCommand } from "../security/policy.js";
 import { prepareWorkspaceToolchain } from "./prepare.js";
 import {
   firstBlockedSandboxFile,
@@ -292,7 +292,11 @@ const bashTool: AgentTool = {
   async run(args, ctx) {
     const normalized = normalizeBashCommand(args, ctx.cfg);
     if ("error" in normalized) return { observation: normalized.error };
-    const blocked = analyzeAgentBashCommandSafety(normalized.command);
+    // CONFIRM mode swaps to the network-enabled policy (fork/read live networks, fetch,
+    // search — never broadcast); `fsa run` keeps the network-sealed local-only policy.
+    const blocked = ctx.cfg.confirmMode
+      ? analyzeConfirmBashCommandSafety(normalized.command)
+      : analyzeAgentBashCommandSafety(normalized.command);
     if (blocked.blocked) return { observation: `blocked: ${blocked.reason ?? "command blocked by policy"}` };
 
     const workspace = await ensureWorkspace(ctx);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 import { readFile } from "node:fs/promises";
 import { defaultConfig, normalizeProjectContext, normalizeRoleModels, type AuditorConfig } from "./config.js";
 import { runAudit } from "./agent/audit.js";
+import { runConfirm } from "./agent/confirm.js";
 import { MockAuditLlmClient } from "./llm/mock.js";
 import { importRunToProjectHistory, projectHistoryManifestPath } from "./trace/history.js";
 
@@ -31,6 +32,22 @@ async function main(argv: string[]): Promise<void> {
       const { total, audited, pending } = result.scopeCoverage;
       console.log(`[scopes] audited ${audited}/${total}` + (pending > 0 ? `, ${pending} pending — run the same command again to audit the next batch (or --remap to re-enumerate).` : " — inventory fully audited."));
     }
+    return;
+  }
+
+  if (cmd === "confirm") {
+    // Open-world confirmation pass over a prior `fsa run`: freeze its findings, then
+    // reproduce/consolidate them against real-world ground truth (network enabled) and
+    // emit a submit/no-submit decision sheet. Usage: fsa confirm <run-dir> --source <paths...>
+    const { cfg } = await parseConfig(rest);
+    const positional = rest[0] && !rest[0].startsWith("--") ? rest[0] : undefined;
+    const inputRunDir = positional ?? readFlag(rest, "--run") ?? readFlag(rest, "--input");
+    if (!inputRunDir) throw new Error("fsa confirm needs a prior run directory: fsa confirm <run-dir> --source <paths...>");
+    if (cfg.sourcePaths.length === 0) throw new Error("--source <paths...> is required (the target code to reproduce against)");
+    const result = await runConfirm(cfg, { inputRunDir, streamEvents: true });
+    console.log(`[confirm dir] ${result.runDir}`);
+    console.log(`[report] ${result.runDir}/confirm_report.md  ← decision sheet (distinct bugs, reproduced?, novelty, recommendation)`);
+    console.log(`[provenance] ${result.runDir}/confirm_provenance.json  ← fingerprints of the findings frozen before any network access`);
     return;
   }
 
@@ -217,7 +234,15 @@ function printHelp(): void {
 
 Usage:
   fsa run --target <name> --source <paths...> [--corpus <paths...>] [--max-steps <n>]
+  fsa confirm <run-dir> --source <paths...> [--target <name>] [--max-steps <n>]
   fsa history import-run --target <name> --run <dir> [--history-dir <dir>]
+
+run is the network-SEALED discovery pass: the model finds + proves bugs blind, with no
+network access (provably no online lookup). confirm is the open-world counterpart: it
+freezes a prior run's findings, then — WITH the network — reproduces each against real
+ground truth (e.g. a mainnet fork), consolidates duplicates into distinct bugs, checks
+novelty/corroboration online (leads, never proof), and emits a submit/no-submit decision
+sheet. Found blind, then confirmed open.
 
 audit is the thin agentic mode: the model drives its own investigation with
 pi-style read/write/edit/bash tools and durable cross-run memory. The framework

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,9 @@ async function main(argv: string[]): Promise<void> {
     const inputRunDir = positional ?? readFlag(rest, "--run") ?? readFlag(rest, "--input");
     if (!inputRunDir) throw new Error("fsa confirm needs a prior run directory: fsa confirm <run-dir> --source <paths...>");
     if (cfg.sourcePaths.length === 0) throw new Error("--source <paths...> is required (the target code to reproduce against)");
-    const result = await runConfirm(cfg, { inputRunDir, streamEvents: true });
+    // Confirm is UNBOUNDED by default (run until the model finishes); --max-steps caps it only if given.
+    const maxSteps = readIntFlag(rest, "--max-steps");
+    const result = await runConfirm(cfg, { inputRunDir, ...(maxSteps !== undefined ? { maxSteps } : {}), streamEvents: true });
     console.log(`[confirm dir] ${result.runDir}`);
     console.log(`[report] ${result.runDir}/confirm_report.md  ← decision sheet (distinct bugs, reproduced?, novelty, recommendation)`);
     console.log(`[provenance] ${result.runDir}/confirm_provenance.json  ← fingerprints of the findings frozen before any network access`);
@@ -234,7 +236,7 @@ function printHelp(): void {
 
 Usage:
   fsa run --target <name> --source <paths...> [--corpus <paths...>] [--max-steps <n>]
-  fsa confirm <run-dir> --source <paths...> [--target <name>] [--max-steps <n>]
+  fsa confirm <run-dir> --source <paths...> [--target <name>] [--max-steps <n>]   (unbounded by default; --max-steps caps it)
   fsa history import-run --target <name> --run <dir> [--history-dir <dir>]
 
 run is the network-SEALED discovery pass: the model finds + proves bugs blind, with no

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,11 @@ export interface AuditorConfig {
   // enumeration; reuses the confirmation gate. The confirmation step the dig
   // produces on its own, runnable standalone against an existing suspected finding.
   auditVerify?: string;
+  // CONFIRM mode (`fsa confirm`): the open-world counterpart to the network-sealed
+  // `fsa run`. When set, the bash tool swaps to the network-enabled policy (fork/read
+  // live networks, fetch, search — never BROADCAST). This is the only capability
+  // difference; the white-hat broadcast line and the confirmation gate are unchanged.
+  confirmMode: boolean;
   // Per-role model assignment. A role (map/dig/refute) resolves to its own entry,
   // else `default`, else the top-level provider/auditModel/thinkingLevel. Nothing
   // is auto-downgraded: an unspecified role inherits the main model.
@@ -139,6 +144,7 @@ export function defaultConfig(): AuditorConfig {
     auditDigSamples: 1,
     auditDigConcurrency: 1,
     auditRemap: false,
+    confirmMode: false,
     dryRun: false,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@
 // guarantees, persistence) so embedders can drive runs and reuse the safety
 // primitives.
 export * from "./agent/audit.js";
+export * from "./agent/confirm.js";
+export * from "./agent/consolidate.js";
 export * from "./agent/loop.js";
 export * from "./agent/memory.js";
 export * from "./agent/pi-session.js";

--- a/src/security/policy.ts
+++ b/src/security/policy.ts
@@ -113,6 +113,73 @@ export function isAgentBuildCommand(command: StructuredReproductionCommand): boo
   return isAllowedBuildCommand(command.program.trim(), command.args.map((arg) => String(arg)));
 }
 
+/**
+ * Verbs that PUSH a transaction/block to a network (as opposed to reading/forking
+ * it). The confirm-mode white-hat line is "fork and READ live networks freely, but
+ * never BROADCAST to one" — so these are blocked only when their target is non-local
+ * (replaying the exploit against a LOCAL fork is exactly what reproduction needs).
+ * A small, domain-free safety denylist, not a per-ecosystem recipe.
+ */
+export const CONFIRM_BROADCAST_PATTERNS: RegExp[] = [
+  /\bcast\s+send\b/i,
+  /--broadcast\b/i,
+  /\bsend-?raw-?transaction\b/i,
+  /\beth_send(?:raw)?transaction\b/i,
+  /\bsendtransaction\b/i,
+  /\bsubmit(?:raw)?(?:transaction|tx|block)\b/i,
+  /\bpublish(?:raw)?(?:transaction|tx|block)\b/i,
+  /\bbroadcast(?:tx|transaction)?\b/i,
+];
+
+/**
+ * CONFIRM-mode bash policy: the open-world counterpart to analyzeAgentBashCommandSafety.
+ * It KEEPS the structural guards (plain program name, simple argv, workspace-contained
+ * paths) and the white-hat line, but DROPS the local-only network enforcement and the
+ * test/build/inspect allowlist — confirm must reach the network (fork the live chain,
+ * stand up a real node, fetch/search) and the model picks the tools for whatever target
+ * it faces. The one network rule kept: never broadcast a transaction to a NON-LOCAL
+ * network (reading/forking live state, and broadcasting to a LOCAL fork, are both fine).
+ */
+export function analyzeConfirmBashCommandSafety(command: StructuredReproductionCommand): CommandSafetyDecision {
+  const program = command.program.trim();
+  const args = command.args.map((arg) => String(arg));
+  if (program.length === 0 || program.includes("/") || program.includes("\\") || /[\s;&|`$<>]/.test(program)) {
+    return { blocked: true, reason: "Blocked by full-stack-auditor guardrail: confirm commands must use a plain program name (no shell operators)." };
+  }
+  if (args.some((arg) => /[\0\r\n]/.test(arg))) {
+    return { blocked: true, reason: "Blocked by full-stack-auditor guardrail: confirm command arguments must be simple argv entries." };
+  }
+  const workspaceDecision = analyzeWorkspacePathSafety(args);
+  if (workspaceDecision.blocked) return workspaceDecision;
+  const rendered = [program, ...args].join(" ");
+  const broadcast = findMatch(rendered, CONFIRM_BROADCAST_PATTERNS);
+  if (broadcast && targetsNonLocalNetwork(args)) {
+    return {
+      blocked: true,
+      reason:
+        "Blocked by full-stack-auditor white-hat guardrail: confirm may FORK and READ a live network, but must never BROADCAST a transaction to one. Replay the exploit against a LOCAL fork (anvil/local RPC), not the live network.",
+      matchedAction: broadcast,
+    };
+  }
+  return { blocked: false };
+}
+
+/** True if any rpc/network flag points off-localhost, or a remote URL / RPC-secret reference appears in argv. */
+function targetsNonLocalNetwork(args: string[]): boolean {
+  for (let idx = 0; idx < args.length; idx += 1) {
+    const arg = args[idx] ?? "";
+    const lower = arg.toLowerCase();
+    const valueFromEquals = valueAfterEquals(arg);
+    if (isRpcFlag(lower) || isNetworkFlag(lower)) {
+      const value = valueFromEquals ?? args[idx + 1];
+      if (value && !isLocalNetworkValue(value)) return true;
+    }
+    if (looksLikeRemoteUrl(arg) && !isLocalUrl(arg)) return true;
+    if (looksLikeRpcEnvReference(arg)) return true;
+  }
+  return false;
+}
+
 function analyzeStructuredCommandBaseSafety(command: StructuredReproductionCommand): CommandSafetyDecision {
   const program = command.program.trim();
   const args = command.args.map((arg) => String(arg));

--- a/tests/consolidate.test.mjs
+++ b/tests/consolidate.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { unionFindClusters } from "../dist/agent/consolidate.js";
+
+// The fix-equivalence relation feeds unionFindClusters; the I/O part (cross-applying a
+// fix and re-running a PoC) is the differential primitive, tested separately. Here we
+// pin the clustering: symmetry is assumed, transitivity must hold, order is preserved.
+
+const pairEquivalent = (pairs) => {
+  const set = new Set(pairs.map(([a, b]) => (a < b ? `${a}::${b}` : `${b}::${a}`)));
+  return (a, b) => set.has(a < b ? `${a}::${b}` : `${b}::${a}`);
+};
+
+test("unionFindClusters: no equivalences yields one singleton per item", () => {
+  const clusters = unionFindClusters(["a", "b", "c"], () => false);
+  assert.deepEqual(clusters, [["a"], ["b"], ["c"]]);
+});
+
+test("unionFindClusters: a single equivalent pair merges just those two", () => {
+  const clusters = unionFindClusters(["a", "b", "c"], pairEquivalent([["a", "b"]]));
+  assert.deepEqual(clusters, [["a", "b"], ["c"]]);
+});
+
+test("unionFindClusters: equivalence is transitively closed (a~b, b~c => one cluster)", () => {
+  const clusters = unionFindClusters(["a", "b", "c"], pairEquivalent([["a", "b"], ["b", "c"]]));
+  assert.deepEqual(clusters, [["a", "b", "c"]]);
+});
+
+test("unionFindClusters: independent pairs form separate clusters, first-appearance order preserved", () => {
+  const clusters = unionFindClusters(["a", "b", "c", "d"], pairEquivalent([["a", "c"], ["b", "d"]]));
+  assert.deepEqual(clusters, [["a", "c"], ["b", "d"]]);
+});

--- a/tests/security-policy.test.mjs
+++ b/tests/security-policy.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { analyzeCommandSafety, analyzeReproductionCommandSafety, analyzeAgentBashCommandSafety, isAgentBuildCommand, isAgentConfirmCommand } from "../dist/security/policy.js";
+import { analyzeCommandSafety, analyzeReproductionCommandSafety, analyzeAgentBashCommandSafety, analyzeConfirmBashCommandSafety, isAgentBuildCommand, isAgentConfirmCommand } from "../dist/security/policy.js";
 
 const cmd = (program, ...args) => ({ program, args });
 
@@ -50,6 +50,52 @@ test("reproduction command policy allows only structured local test commands", (
   assert.equal(analyzeReproductionCommandSafety({ program: "zcash-cli", args: ["-testnet", "sendrawtransaction", "poc"] }).blocked, true);
   assert.equal(analyzeReproductionCommandSafety({ program: "bash", args: ["-lc", "cargo test"] }).blocked, true);
   assert.equal(analyzeReproductionCommandSafety({ program: "cargo;curl", args: ["test"] }).blocked, true);
+});
+
+test("confirm-mode bash MAY fork and read live networks (the open-world difference from run)", () => {
+  // The exact things `fsa run` blocks for being network-bound, `fsa confirm` allows —
+  // because real-world reproduction forks the live chain and reads public sources.
+  for (const c of [
+    cmd("forge", "test", "--fork-url", "https://eth.llamarpc.com"),
+    cmd("cast", "call", "--rpc-url", "https://mainnet.example", "0xabc", "balanceOf()"),
+    cmd("anvil", "--fork-url", "https://mainnet.example"),
+    cmd("curl", "-s", "https://github.com/zcash/halo2/issues/578"),
+    cmd("git", "clone", "https://github.com/AztecProtocol/aztec-connect"),
+    cmd("node", "repro.mjs"),
+  ]) {
+    assert.equal(analyzeConfirmBashCommandSafety(c).blocked, false, `${c.program} ${c.args.join(" ")} should be allowed in confirm mode`);
+    // sanity: run mode would have blocked the network-bound ones
+  }
+  // run mode blocks a remote fork; confirm allows it — the capability difference is real.
+  assert.equal(analyzeAgentBashCommandSafety(cmd("forge", "test", "--fork-url", "https://eth.llamarpc.com")).blocked, true);
+});
+
+test("confirm-mode bash still NEVER broadcasts a transaction to a non-local network (white-hat line)", () => {
+  for (const c of [
+    cmd("cast", "send", "--rpc-url", "https://mainnet.example", "0xabc", "drain()"),
+    cmd("forge", "script", "Exploit.s.sol", "--broadcast", "--rpc-url", "https://mainnet.example"),
+    cmd("cast", "send", "--rpc-url=https://mainnet.example", "0xabc"),
+  ]) {
+    const decision = analyzeConfirmBashCommandSafety(c);
+    assert.equal(decision.blocked, true, `${c.program} ${c.args.join(" ")} must be blocked (broadcast to live network)`);
+    assert.match(decision.reason, /never BROADCAST|white-hat/i);
+  }
+});
+
+test("confirm-mode bash ALLOWS broadcasting to a LOCAL fork (replaying the exploit is the reproduction)", () => {
+  for (const c of [
+    cmd("cast", "send", "--rpc-url", "http://127.0.0.1:8545", "0xabc", "drain()"),
+    cmd("forge", "script", "Exploit.s.sol", "--broadcast", "--rpc-url", "http://127.0.0.1:8545"),
+    cmd("cast", "send", "0xabc", "0x123"), // no rpc target → foundry default localhost
+  ]) {
+    assert.equal(analyzeConfirmBashCommandSafety(c).blocked, false, `${c.program} ${c.args.join(" ")} should be allowed (local replay)`);
+  }
+});
+
+test("confirm-mode bash keeps the structural guards (no shell operators, workspace-contained paths)", () => {
+  assert.equal(analyzeConfirmBashCommandSafety({ program: "cast;curl", args: ["send"] }).blocked, true);
+  assert.equal(analyzeConfirmBashCommandSafety(cmd("cat", "/etc/passwd")).blocked, true);
+  assert.equal(analyzeConfirmBashCommandSafety(cmd("cat", "../secrets")).blocked, true);
 });
 
 test("reproduction command policy keeps Solidity fork and network targets local-only", () => {


### PR DESCRIPTION
## What

`fsa run` is the network-**sealed** discovery pass (provably no online lookup). `fsa confirm <run-dir> --source <…>` is its open-world counterpart: it takes a prior run's confirmed findings to a real-world standard of certainty and emits a submit/no-submit decision sheet — **by execution, not by argument**.

Pipeline (one command):
1. **Freeze + fingerprint** the input run's findings (sha256 + timestamp) before any network access — anchors the "found blind, no network" provenance.
2. **Network-enabled session** reproduces each finding against real ground truth (fork the live chain, query RPC, fetch sources). The bash policy is relaxed to allow fork/read/fetch but still **never broadcasts** a transaction to a non-local network.
3. **Fix-equivalence consolidation** (framework-orchestrated): cross-applies each reproduced bug's fix against the others' PoCs (reusing the differential primitive) and merges any a single fix neutralizes — *distinct bugs decided by execution, not by similar titles*.
4. **Decision sheet** (`confirm_decision.json` + `confirm_report.md`): per distinct bug — reproduced?, repro evidence, novelty/corroboration, recommendation.

## Design discipline

No per-technology branches. The framework supplies capability + goals + an **objective, execution-grounded acceptance bar** (real target, exhibited effect, attacker-real capabilities); the model decides what "real ground truth" is for the target and writes the reproduction itself. Confirm is **unbounded by default** (reproduction is heavy; a fixed step count silently truncated productive work) — it ends when the model emits done; `--max-steps` caps it only if asked.

## Validation (live run against the Aztec run dir)

Pointed at a prior `fsa run`'s 13 confirmed Aztec findings, `fsa confirm` (openai-codex/gpt-5.5, unbounded):

- **Reproduced the real bug on a mainnet fork.** At block 14928261, against the real deployed processor proxy and its real configured verifier, it replayed a real historical rollup tx and changed only the attacker-controllable packed `numRealTxs` byte (2→1). The real verifier accepted (the byte is outside the hashed region) and L1 accounting skipped a verifier-hashed transaction slot — exhibited on real components, attacker-faithful. → **submit-candidate**.
- **Execution-refuted the crutch findings.** Forking the *real* verifier, an invalid proof **reverts** (it does not return false) → the "verifier-false-return" finding's PoC depended on substituting a mock verifier → **drop**. The real processor **reverts INVALID_PROVIDER** for an unlisted caller → the "removed submission gate" was in the draft V3 source, not the forked deployment → **drop** (also already-disclosed upstream).
- **13 findings → 7 distinct; 1 reproduced, zero false reproductions**; the rest honestly `drop` / `needs-human` with the exact real-target blocker named.

The bounded run (70 steps) reproduced 0 and never built a PoC; unbounded + the reproduce-early prompt was decisive.

## Tests

`npm run verify` green: `tsc` + 50 unit tests (new: confirm-mode network policy, union-find clustering) + mock-audit + public-surface scan. `fsa run` path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)