### PR TITLE
docs(skill): rewrite whitehat-auditor as an operating manual (Agent S…

### DIFF
--- a/skills/whitehat-auditor/SKILL.md
+++ b/skills/whitehat-auditor/SKILL.md
@@ -1,40 +1,90 @@
-# White-Hat Auditor
+---
+name: whitehat-auditor
+description: Drives security audits with the full-stack-auditor (fsa) framework — an autonomous, execution-grounded auditor where the model investigates source with read/write/edit/bash tools and proves bugs with local tests. Use when auditing source code for security vulnerabilities (smart contracts, ZK/proof-system circuits, protocols, consensus, cryptography, or application/infrastructure code), when reproducing or refuting a suspected bug against a real target such as a mainnet fork, or when deciding whether a finding is worth disclosing. Covers the sealed `fsa run` discovery pass (found blind, no network), the open-world `fsa confirm` reproduction pass, and the `fsa_run` / `fsa_confirm` pi tools.
+---
 
-Use this skill when auditing source code for security bugs across application, infrastructure, protocol, cryptography, proof-system, smart-contract, consensus, or value-integrity domains.
+# Security auditing with full-stack-auditor (fsa)
 
-## Rules
+`fsa` is an autonomous, execution-grounded security auditor. The **model** drives the investigation: it reads source, writes and runs local tests with `read`/`write`/`edit`/`bash` tools, and proves bugs by execution. The framework supplies capability and a confirmation gate — **not** a checklist and **not** bug answers. A finding is real because a local test ran, never because code "looks wrong" or "matches upstream".
 
-- Work only on code the user is authorized to audit.
-- `fsa run` discovery is network-sealed and local-only: unit tests, regtest, devnet, or forked local node. `fsa confirm` reproduction may fork and read live networks, but never broadcasts a transaction to a live one.
-- Never broadcast transactions or run exploit flows against a live network; replay only against a local fork.
-- Generate the smallest reproduction needed to prove or refute the invariant.
-- Prefer private disclosure report drafts over public exploit writeups.
+Two passes, used in order:
 
-## Workflow
+- **`fsa run` — sealed discovery.** Runs with no network access, so a finding is provably *found blind*, not looked up. The model maps the attack surface, deep-audits it scope by scope, and confirms bugs with local tests.
+- **`fsa confirm` — open-world reproduction.** Takes a finished run's findings and reproduces each against **real ground truth** (e.g. a mainnet fork of the deployed contract), consolidates duplicates into distinct bugs, checks novelty online, and emits a submit/no-submit decision sheet.
 
-1. Ingest source plus specs, protocol docs, papers, and implementation guides.
-2. Build or review the project context: assets, attacker capabilities, trust boundaries, invariants, focus areas, and out-of-scope areas.
-3. Use `fsa run` as the default workflow: let the agent decide what to read, search, test, remember, and report.
-4. Treat optional project profiles, source indexes, provenance facts, and bug-class references as tools or context only.
-5. Do not require a fixed checklist, failure-mode taxonomy, search schedule, rounds, or trials before the agent can investigate.
-6. Confirm strong hypotheses with local-only tests through the sandbox.
-7. Record findings privately with exact source evidence and confirmation status.
-8. To take a finished run to a real-world standard, use `fsa confirm <run-dir> --source <paths...>`: it reproduces each finding against real ground truth (e.g. a mainnet fork), consolidates duplicates, checks novelty online, and emits a submit/no-submit decision sheet. A finding clears the bar only if it triggers on the real target with attacker-real capabilities and an exhibited effect — not by argument.
+> Found blind (`run`), then reproduced open (`confirm`).
 
-## Failure Modes
+## When to use
 
-- Missing constraints in circuits or proof systems.
-- Supply or balance integrity violations.
-- Double-spend/nullifier/replay failures.
-- Spec-implementation mismatches.
-- Consensus divergence.
-- Integer overflow, truncation, and unchecked arithmetic.
-- Input validation, injection, SSRF, path traversal, deserialization, and parser safety.
-- Authorization gaps, tenant isolation, and privilege-boundary failures.
-- Reentrancy.
-- Cryptographic misuse.
-- Race conditions and idempotency failures.
-- Secret exposure and dependency supply-chain trust.
-- DoS/resource amplification.
+- Auditing source for security bugs: smart contracts, ZK / proof-system circuits, protocols, consensus, cryptography, or application / infrastructure code.
+- Reproducing or refuting a suspected vulnerability against the real target.
+- Deciding whether a finding is worth disclosing to the project.
 
-Findings must come from the agent's own investigation grounded in specific code evidence. The framework provides capability and confirmation guarantees (sandboxed tools, a toolchain warm-up, and an execution-confirmation gate), not a checklist or a way to tell the model how to think.
+## Running fsa
+
+`fsa` ships as the `full-stack-auditor` npm package (it installs an `fsa` binary). Two ways to drive it:
+
+**CLI** (the primary surface):
+
+```bash
+npm install -g full-stack-auditor          # or run via: npx full-stack-auditor <verb> ...
+fsa run --target <name> --source <code> --corpus <specs> --provider openai-codex
+```
+
+The default provider `openai-codex` is a pi-session provider and needs a one-time interactive `pi` `/login`. `fsa confirm` **requires** a pi-session provider (it forks a live network); the mock/CLI fallbacks cannot.
+
+**As pi tools** (when fsa is loaded into another pi agent via `pi -e full-stack-auditor`): call the `fsa_run` and `fsa_confirm` tools. They mirror the `fsa run` / `fsa confirm` verbs, so a pi agent can orchestrate discover→reproduce. Parameters are in [reference/commands.md](reference/commands.md).
+
+## Core workflow
+
+Copy this checklist and track progress:
+
+```
+Audit progress:
+- [ ] 1. Gather materials: the buildable target source + the project's real specs/docs
+- [ ] 2. Discover (sealed): fsa run → findings proven by local tests
+- [ ] 3. Triage: keep confirmed-executable / confirmed-differential findings
+- [ ] 4. Reproduce (open-world): fsa confirm <run-dir> → decision sheet
+- [ ] 5. Decide: submit only submit-candidate rows, each with a faithful PoC
+```
+
+**1. Materials.** Point `--source` at the buildable target (or add `--build-root <dir>` for the workspace root — a buildable target is what separates `confirmed` from `suspected`). Point `--corpus` at the project's REAL specs, whitepapers, prior audits, or a strictly factual incident brief. Corpus is context, never the answer: it must not name the bug, its location, or its mechanism, and you must not author it yourself. Give the spec; let the model find the gap.
+
+**2. Discover.** `fsa run --target <name> --source <code> --build-root . --corpus <specs> --provider openai-codex`. This enumerates a scored scope inventory, then deep-audits the top scopes obligation by obligation. It is network-sealed. Budgets are unbounded by default — let a dig finish; a decisive obligation can surface late in its budget. The run is resumable: re-running skips the already-audited scopes.
+
+**3. Triage.** Read `audit_report.md` / `audit_findings.json`. A finding's status is the framework's verdict from execution, not the model's claim (see [Confirmation ladder](#confirmation-ladder)).
+
+**4. Reproduce.** `fsa confirm <run-dir> --source <code> --build-root . --provider openai-codex`. It freezes the findings (pre-network provenance), reproduces each on the real target, consolidates by fix-equivalence, checks novelty, and writes `confirm_report.md`. Unbounded by default; auto-resumes if interrupted.
+
+**5. Decide.** Submit only the rows the decision sheet marks `submit-candidate`, each with an exhibited effect (a drained balance, a forged output, an accepted invalid input) — never an argument.
+
+## White-hat rules (non-negotiable)
+
+- **MUST** audit only code you are authorized to audit, or public bug-bounty scope.
+- **`fsa run` is local-only and network-sealed**: unit tests, regtest, devnet, or a forked local node — never any live network.
+- **`fsa confirm` may fork and READ a live network, but MUST NEVER broadcast** a transaction to a non-local network, move funds, or write to any live system. Replay the exploit against a *local* fork only.
+- Build the PoC the way a real attacker would: assume only attacker-real capabilities; never grant yourself behavior the deployed system would deny.
+- Generate the smallest reproduction that proves or refutes the property.
+- Prefer private disclosure drafts over public exploit writeups.
+
+## Confirmation ladder
+
+A finding is only as strong as the execution behind it:
+
+- `suspected` — a candidate with no passing local test. Not submittable.
+- `confirmed-executable` — a cited `purpose=confirm` local test actually passed.
+- `confirmed-differential` — the model's fix, applied to pristine source, blocks the exploit.
+
+An independent skeptic re-judges every confirmation: a **vacuous** PoC — one that only triggers by giving a trusted or pinned component behavior a real attacker cannot cause — is downgraded and flagged (a downgraded finding gets one appeal). "Looks standard" / "matches upstream" never clears a finding; only the property and its execution do.
+
+## Command summary
+
+| Verb | Use |
+|---|---|
+| `fsa run` | default audit: map → deep-audit in one pass (`--quick` = a single breadth pass) |
+| `fsa map` | enumerate the scope inventory only |
+| `fsa audit <region>` / `--scope <id,...>` / `--verify <file>` | deep-audit a pinned region, inventory scopes, or confirm-or-refute given claims |
+| `fsa confirm <run-dir>` | open-world reproduction + submit/no-submit decision sheet |
+
+- Full flags, providers, budgets, resume, outputs, and pi-tool parameters: **[reference/commands.md](reference/commands.md)**.
+- Concrete worked audits (EVM rollup, ZK circuit): **[reference/examples.md](reference/examples.md)**.

--- a/skills/whitehat-auditor/reference/commands.md
+++ b/skills/whitehat-auditor/reference/commands.md
@@ -1,0 +1,137 @@
+# fsa command reference
+
+Complete flag, provider, budget, output, and pi-tool reference for `fsa`. The [SKILL.md](../SKILL.md) overview and workflow come first; read this when you need exact flags or behavior.
+
+## Contents
+
+- [Verbs](#verbs)
+- [Sealed vs open-world](#sealed-vs-open-world)
+- [Materials options](#materials-options)
+- [Model and provider options](#model-and-provider-options)
+- [Budgets and coverage (run / map / audit)](#budgets-and-coverage-run--map--audit)
+- [audit selectors](#audit-selectors)
+- [confirm options](#confirm-options)
+- [pi tools (fsa_run / fsa_confirm)](#pi-tools-fsa_run--fsa_confirm)
+- [Providers and auth](#providers-and-auth)
+- [Outputs (artifacts)](#outputs-artifacts)
+- [Confirmation ladder](#confirmation-ladder)
+
+## Verbs
+
+| Verb | What it does |
+|---|---|
+| `fsa run --target <name> --source <paths...>` | Sealed audit: **map → deep-audit** in one pass. `--quick` makes it a single breadth pass instead. The default real audit. |
+| `fsa map --target <name> --source <paths...>` | Enumerate + persist the scope inventory only (writes `audit_scopes.json`), no dig. Inspect/curate scopes before auditing. |
+| `fsa audit [<region> \| --scope <id,...> \| --verify <file>] --source <paths...>` | Deep-audit a pinned region, specific inventory scopes, or confirm-or-refute given claims. With no selector, digs the existing inventory. |
+| `fsa confirm <run-dir> --source <paths...>` | Open-world: reproduce a finished run's findings on the real target and emit a decision sheet. |
+| `fsa history import-run --target <name> --run <dir>` | Import an external run directory into the target's durable history. |
+
+## Sealed vs open-world
+
+`run` / `map` / `audit` are **network-sealed**: the model finds and proves bugs blind, with no network access (provably no online lookup). `confirm` is the **open-world** counterpart: it freezes a prior run's findings, then *with* the network reproduces each against real ground truth (e.g. a mainnet fork), consolidates duplicates, checks novelty, and emits a submit/no-submit decision sheet.
+
+## Materials options
+
+| Flag | Meaning |
+|---|---|
+| `--source <paths...>` | Code under audit; the model reads (not modifies) these. Point at a buildable root (or use `--build-root`) to enable execution confirmation. |
+| `--build-root <dir>` | Directory copied into the sandbox so the target compiles (e.g. a workspace root); defaults to `--source`. A buildable target is what separates `confirmed` from `suspected`. |
+| `--corpus <paths...>` | Design/reference **materials** the model reads to derive what the code MUST enforce: real specs, whitepapers, design notes, prior audits, or a strictly factual incident brief. Context, not answers — never the bug, its location, or its mechanism; do not author it yourself. |
+| `--target <name>` | Run/artifact name and durable-memory key. |
+| `--config <file>` | JSON config with project context, models, and paths. Optional and off by default; only seeds a known vulnerability class. CLI flags override it. |
+| `--scope-note <text>` | One-line authorized-scope hint surfaced to the agent. |
+
+## Model and provider options
+
+| Flag | Meaning |
+|---|---|
+| `--provider <name>` | pi-ai provider. Default `openai-codex` (a pi-session provider). `codex-cli` / `claude-code` are CLI fallbacks. |
+| `--model <name>` | Set the audit model. |
+| `--thinking <level>` | `minimal` \| `low` \| `medium` \| `high` \| `xhigh`. |
+| `--out <dir>` | Artifact output directory (default `runs`). |
+| `--history-dir <dir>` | Project history directory (default `<out>/history`). |
+| `--mock-llm` | Use the deterministic mock model (offline; cannot fork a network — discovery smoke test only). |
+| `--no-prepare` | Skip the toolchain warm-up (deps fetch/build). |
+| `--prepare-timeout-ms <n>` | Per-command timeout for the warm-up (default 600000). |
+| `--no-refute` / `--no-appeal` | Skip the independent-refutation / one-appeal passes on confirmed findings. |
+
+## Budgets and coverage (run / map / audit)
+
+Budgets are **UNBOUNDED by default** — a run ends when the model emits done, not at a step count. A fixed budget silently truncates a productive dig, so cap a phase only when you mean to.
+
+| Flag | Meaning |
+|---|---|
+| `--quick` | `run` only: a single breadth pass instead of map → audit. |
+| `--max-steps <n>` | Cap agent turns for a breadth pass / pinned audit (default UNBOUNDED). |
+| `--map-steps <n>` | Cap the map phase (default UNBOUNDED). |
+| `--dig-steps <n>` | Cap each scope's dig (default UNBOUNDED; the dig stops when its obligations are discharged). |
+| `--dig-samples <n>` | Independent dig passes per scope, findings unioned (raises recall). Default 1. |
+| `--dig-concurrency <n>` | Scopes deep-audited in parallel, each in an isolated workspace. Default 1. |
+| `--max-scopes <n>` | Un-audited scopes the dig audits per run. Default 10. |
+| `--remap` | Re-enumerate scopes from scratch (default resumes the persisted inventory). |
+
+**Resume.** The scope inventory persists with per-scope status. A map → dig run audits the highest-scored not-yet-audited scopes up to `--max-scopes`; the rest stay `pending`. Re-running `fsa run` (or `fsa audit` against the inventory) skips MAP and audits the next batch. The inventory is checkpointed right after MAP and after each dig, so a run killed mid-way also resumes — redoing only the one in-flight dig.
+
+## audit selectors
+
+Choose one; default digs the existing inventory.
+
+| Selector | Meaning |
+|---|---|
+| `<region>` | Deep-audit one pinned region, e.g. `src/Foo.sol:120-180` (no map needed). |
+| `--scope <id[,id...]>` | Deep-audit specific scope id(s) from the inventory (run `fsa map` first). |
+| `--verify <file>` | Confirm-or-refute given suspected finding(s) by execution. `<file>` is JSON — one finding or an array; each: `title`, `location`, `description`, `exploit_sketch?`, `fix_patch?`. Writes a PoC, builds, and runs it through the confirmation gate + differential, marking each `confirmed-differential` / `confirmed-executable` / `REFUTED`. Needs a buildable target. |
+
+## confirm options
+
+`fsa confirm <run-dir> --source <paths...>` — `<run-dir>` is a finished `fsa run` directory (it must contain `audit_findings.json` with confirmed findings).
+
+| Flag | Meaning |
+|---|---|
+| `--source <paths...>` | The target code to reproduce against (required). `--build-root` recommended for buildable reproduction. |
+| `--max-steps <n>` | Cap turns. **Unbounded by default** (reproduction is heavy; ends when the model is done). |
+| `--fresh` | Ignore a prior interrupted confirm of the same run and start over. Default: **auto-resume**, carrying already-settled rows forward and reproducing only the rest. |
+
+Confirm **requires** a pi-session provider (e.g. `openai-codex`); it cannot run on the mock/CLI fallbacks because it forks a live network.
+
+## pi tools (fsa_run / fsa_confirm)
+
+When fsa is loaded as a pi extension (`pi -e full-stack-auditor`), it registers two tools that mirror the verbs. The narrower postures (`map`, `audit <region>/--scope/--verify`, `history`) stay CLI-only.
+
+**`fsa_run`** — sealed map→dig audit. Parameters: `target`, `sourcePaths`, `corpusPaths?`, `provider?`, `model?`, `maxSteps?` (default unbounded; when set, caps each phase), `scopeNote?`, `outputDir?`, `historyDir?`.
+
+**`fsa_confirm`** — open-world reproduction of a finished run. Parameters: `target`, `runDir`, `sourcePaths`, `buildRoot?`, `corpusPaths?`, `provider?` (must be a pi-session provider), `model?`, `maxSteps?` (default unbounded), `fresh?` (default auto-resume), `outputDir?`, `historyDir?`.
+
+## Providers and auth
+
+- Default provider is `openai-codex`, a pi-session provider that runs a continuous agent session. It needs a one-time interactive `pi` `/login` before headless runs work.
+- `fsa confirm` and the `fsa_confirm` tool require a pi-session provider — the mock and plain CLI fallbacks cannot fork a live network.
+- `--mock-llm` runs the deterministic offline model: useful only as a discovery smoke test, never for confirm.
+
+## Outputs (artifacts)
+
+Each `fsa run` writes (under `<out>/<target>-<timestamp>/`):
+
+- `audit_findings.json` — raw agent-reported findings with confirmation status.
+- `audit_scopes.json` — the scored scope inventory (also produced by `fsa map`).
+- `audit_report.md` — consolidated results (findings, hypotheses, scope coverage).
+- `summary.json` — ranked finding summary and coverage.
+- `audit_transcript.json`, `events.jsonl`, `calls/*.json` — replayable trace and model-call records.
+- `<out>/history/<target>/memory.jsonl` — durable per-target memory across runs.
+
+Each `fsa confirm` writes (under `<out>/<target>-confirm-<timestamp>/`):
+
+- `confirm_provenance.json` — sha256 + timestamp of the run findings, frozen before any network access.
+- `confirm_decision.json` — the decision sheet: one row per distinct bug (reproduced?, evidence, novelty, recommendation).
+- `confirm_report.md` — the human-readable decision sheet.
+- `confirm_equivalence.json` — the fix-equivalence matrix (which fixes block which PoCs) and the resulting clusters.
+
+Run artifacts are private by default — redact before sharing outside the trusted project context.
+
+## Confirmation ladder
+
+- `suspected` — a candidate without a passing cited local test. Not submittable.
+- `confirmed-executable` — the agent cited a `purpose=confirm` `bash` record that actually passed. The framework checks the recorded result; the model cannot upgrade a finding by assertion.
+- `confirmed-differential` — the model's fix, applied to pristine source, blocks the exploit (and the original PoC still fails against the fix).
+
+An independent refutation skeptic re-judges every confirmation; a vacuous PoC is downgraded and flagged, with one appeal allowed. "Looks standard" / "matches upstream" never clears a finding — only the security property and its execution do.

--- a/skills/whitehat-auditor/reference/examples.md
+++ b/skills/whitehat-auditor/reference/examples.md
@@ -1,0 +1,65 @@
+# fsa worked examples
+
+Two concrete end-to-end audits showing the discover → reproduce flow. Replace paths and target names with your own. See [reference/commands.md](commands.md) for every flag.
+
+## Example 1 — EVM rollup, cold audit then open-world confirm
+
+Audit a deployed Solidity rollup with only the real contracts and the official specs — no hint that any bug exists.
+
+```bash
+# 1. Discover (sealed): map the decode/settlement surface, then deep-audit it.
+fsa run \
+  --target rollup-audit \
+  --source ./contracts --build-root . \
+  --corpus ./docs/specs \
+  --provider openai-codex \
+  --map-steps 60 --dig-steps 60 --dig-samples 2
+```
+
+The run enumerates a scored scope inventory, deep-audits the top scopes obligation by obligation, and writes findings to `runs/rollup-audit-<timestamp>/`. A real unbound-input bug (e.g. a field not bound to the verifier's public-input hash) can reach `confirmed-differential` here — the model writes the proof-of-malleability PoC, the framework builds and runs it, then applies the model's fix and re-runs to show it blocks the exploit.
+
+```bash
+# 2. Reproduce (open-world): take that run to a real-world standard.
+fsa confirm runs/rollup-audit-<timestamp> \
+  --source ./contracts --build-root . \
+  --provider openai-codex
+```
+
+Confirm forks mainnet (`forge test --fork-url …`) against the **real deployed contract and its real verifier**, flips one attacker-controllable input, and marks the finding `reproduced` only if the effect is exhibited on-chain. It also execution-*refutes* any finding whose PoC only worked against a mocked component. Read the decision sheet at `confirm_report.md`.
+
+## Example 2 — ZK circuit soundness (stack-agnostic)
+
+Audit a Rust ZK circuit crate for an under-constrained-witness bug.
+
+```bash
+# Map enumerates the circuit's constraints (including operands the spec treats as given);
+# the dig writes a MockProver malicious-witness test.
+fsa run \
+  --target circuit-audit \
+  --source ./crate --build-root ./workspace \
+  --corpus ./docs/circuit-spec \
+  --provider openai-codex \
+  --dig-samples 2
+```
+
+A subtle soundness gap often needs a pinned, repeated dig rather than blind breadth:
+
+```bash
+# After a map, deep-audit one suspicious scope several times and union the findings.
+fsa map   --target circuit-audit --source ./crate --build-root ./workspace --corpus ./docs/circuit-spec --provider openai-codex
+fsa audit --scope <id> --source ./crate --build-root ./workspace --provider openai-codex --dig-samples 3
+```
+
+A crate-internal soundness bug can reach `confirmed-differential`: the model writes the exploit witness, the framework runs it through `MockProver`, then applies the model's constraint fix and re-runs to show the malicious witness no longer verifies.
+
+## Confirm-or-refute a specific suspicion
+
+When you already suspect a concrete bug and just want execution to settle it:
+
+```bash
+# claims.json: [{ "title": "...", "location": "src/Foo.sol:120", "description": "...",
+#                "exploit_sketch": "...", "fix_patch": { ... } }]
+fsa audit --verify claims.json --source ./contracts --build-root . --provider openai-codex
+```
+
+Each claim comes back `confirmed-differential`, `confirmed-executable`, or `REFUTED` — by execution, not argument.


### PR DESCRIPTION
…kills best practices)

The skill had NO YAML frontmatter (so it could not be discovered) and read as a philosophy note rather than a usable manual for the fsa tools. Rewrite it to the Agent Skills best practices so another agent can install it and learn to drive fsa.

- Add required frontmatter: name + a third-person description (697 chars) that states what the skill does and when to trigger it (key terms: smart contracts, ZK circuits, mainnet fork, disclosing; tool names: fsa run/confirm, fsa_run/_confirm).
- SKILL.md is now a concise operating manual (91 lines): what fsa is, when to use, how to run it (CLI + pi tools, install, provider/login), a copyable discover→ reproduce workflow checklist, the non-negotiable white-hat rules, the confirmation ladder, a verb summary, and one-level-deep pointers to the references.
- Progressive disclosure: reference/commands.md (full flags/providers/budgets/ resume/outputs/pi-tool params, with a TOC) and reference/examples.md (concrete EVM-rollup and ZK-circuit worked audits). All references link directly from SKILL.md.
- Drop the self-contradicting 13-item "Failure Modes" checklist (the framework is deliberately not a checklist); fold scope breadth into "When to use". Consistent terminology, forward-slash paths, no time-sensitive info.