### PR TITLE
feat(server): split control plane from execution plane (remote daemon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,14 +261,18 @@ This is the backend the UI reads from; it is written live by each run (not rebui
 ### UI
 
 ```bash
-fsa ui                 # local dashboard at http://127.0.0.1:4500 (--port, --out to change)
+fsa ui                 # dashboard at http://127.0.0.1:4500 + a co-located executor daemon
+fsa ui --no-daemon     # control plane only — connect your own daemon(s) elsewhere
+fsa daemon --server http://<server>:4500 --token <token>   # run the executor on another machine
 ```
 
-A localhost-only web dashboard to track and drive audits across projects: per-project scope coverage (mapped vs audited, live), findings with their status timeline, and the bugs actually **confirmed** on the real target, updating in real time via SSE. Create a project, **Start/Continue** an audit (resume — next batch of scopes), **Restart** (re-map), **Run…** (map / audit a region / confirm), **Edit config**, or stop a running run — all from the UI. It binds to localhost only (it runs audits in-process and reads local code).
+A web dashboard to track and drive audits across projects: per-project scope coverage (mapped vs audited vs deferred, live), findings with their status timeline, and the bugs actually **confirmed** on the real target, updating in real time via SSE. Create a project, **Start/Continue** an audit (resume — next batch of scopes), **Restart** (re-map), **Run…** (map / audit a region / confirm), **Edit config**, or stop a running run — all from the UI.
+
+Execution is **decoupled** from the dashboard: the `fsa ui` server is a **control plane** (REST API + SQLite + a job queue) and the audit actually runs on a **daemon**, so the target code and provider keys stay on the daemon's machine. `fsa ui` spawns a co-located daemon by default; pass `--no-daemon` and run `fsa daemon` elsewhere (with a token from `fsa db mint-token`) to execute on a different host. The server binds to `127.0.0.1` by default; the daemon protocol is bearer-token-authenticated.
 
 ### HTTP API (agent-drivable)
 
-The UI is just one client of a REST API the `fsa ui` server exposes. **Every** operation the UI performs is an API call, so an agent can drive the whole workflow without the UI. The API is **self-describing**: `GET /api` returns a catalog of every resource and endpoint (method, path, params, body) — an agent fetches it once to learn the surface, then calls it.
+The UI is just one client of a REST API the `fsa ui` server exposes. **Every** operation the UI performs is an API call, so an agent can drive the whole workflow without the UI. The API is **self-describing**: `GET /api` returns a catalog of every resource and endpoint (method, path, params, body) — an agent fetches it once to learn the surface, then calls it. (The machine-to-machine `/api/daemon/*` protocol the executor uses is bearer-authenticated and omitted from the catalog.)
 
 ```bash
 curl localhost:4500/api                                   # catalog of every endpoint
@@ -279,7 +283,7 @@ curl 'localhost:4500/api/projects/p/findings?status=confirmed-differential'
 curl 'localhost:4500/api/projects/p/confirm-decisions?reproduced=yes'  # the confirmed bugs
 ```
 
-Resources: **project** (CRUD: `GET/POST /api/projects`, `GET/PATCH/DELETE /api/projects/:name`), **run** (`POST /api/projects/:name/runs` to launch — `verb` run/map/audit/confirm with `remap`/`fresh`/`quick`/`region`/`scope`/`inputRunDir`; `GET /api/runs/:id`; `POST /api/runs/:id/stop`), **scope** / **finding** / **confirm-decision** (read, paginated + filterable). `GET /api/stream` is an SSE feed for live updates, and `GET /api/runs/:id/log` streams a run's live activity (the model's thinking/output + tool calls). The server runs the library (`runAudit`/`runConfirm`) **in-process** — not the CLI — so `GET /api/runs/:id` returns the rich `AuditRunResult`/`ConfirmRunResult` (full findings, summary, coverage) for runs it launched. A formal/published API can grow from this surface; for now it is localhost-only.
+Resources: **project** (CRUD: `GET/POST /api/projects`, `GET/PATCH/DELETE /api/projects/:name`), **run** (`POST /api/projects/:name/runs` **enqueues a job** — `verb` run/map/audit/confirm with `remap`/`fresh`/`quick`/`region`/`scope`/`inputRunDir` — and returns its `jobId`; a connected daemon claims and runs it; `GET /api/runs/:id`; `POST /api/runs/:id/stop`), **scope** / **finding** / **confirm-decision** (read, paginated + filterable). `GET /api/stream` is an SSE feed for live updates, and `GET /api/runs/:id/log` streams a run's live token-level activity (the model's thinking/output + tool calls), fed by the executing daemon. A formal/published API can grow from this surface.
 
 ## Library API
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,7 @@ The main layers are:
 - Provider adapters: `src/llm/pi-ai.ts`, with explicit local CLI fallbacks in `src/llm/codex-cli.ts` and `src/llm/claude-code.ts`.
 - Pi integration: `src/pi/extension.ts` registers the `fsa_run` and `fsa_confirm` tools and the shell guardrail.
 - Tracking store: `src/db/store.ts` records every run's metadata to SQLite (see [Tracking, API, and UI](#tracking-api-and-ui)).
-- Server / UI: `src/server/` (run-manager + localhost REST API + web dashboard).
+- Server / UI: `src/server/` (control-plane REST API `app.ts` + execution-plane `daemon.ts` + web dashboard).
 
 ## Audit Flow
 
@@ -188,23 +188,22 @@ A second surface tracks and drives audits across projects. It is additive: the a
 
 ```mermaid
 flowchart LR
-  UI["Web dashboard (SPA)"] -->|HTTP / SSE| SRV["server (src/server/app.ts)"]
+  UI["Web dashboard (SPA)"] -->|HTTP / SSE| SRV["control plane — src/server/app.ts<br/>REST API + SQLite + job queue"]
   AGENT["AI agent"] -->|REST + GET /api catalog| SRV
-  SRV --> MGR["run-manager (src/server/run-manager.ts)"]
-  MGR -->|in-process| LIB["runAudit / runConfirm"]
-  LIB -->|RunRecorder| DB[("SQLite (src/db) — fsa.db")]
-  LIB --> FILES["run dir: events.jsonl, audit_findings.json, reports"]
-  SRV -->|read| DB
-  SRV -->|tail events.jsonl| FILES
+  SRV --- DB[("fsa.db (src/db)")]
+  SRV <-->|"SSE (poll/cancel) · HTTP (claim, progress, activity)"| DAE["execution plane — src/server/daemon.ts"]
+  DAE -->|in-process| LIB["runAudit / runConfirm"]
+  LIB -->|"RemoteTracker → HTTP"| SRV
+  LIB --> FILES["run dir on the daemon: events.jsonl, findings, reports"]
 ```
 
-**Tracking store (`src/db/store.ts`, `record.ts`).** SQLite via `node:sqlite` (no dependency added) at `<out>/fsa.db`, WAL + busy-timeout so a reader (the server) and writers (runs) coexist. It is the **system of record for run tracking**, written live — not a rebuildable projection: projects, the run lifecycle, scope coverage (mapped vs audited, per-dig), findings and their status transitions (suspect→confirm→refute, on a `finding_status_event` timeline), and confirm decisions. It stores metadata + **paths** to the on-disk artifacts, not their content. `RunRecorder` (`src/db/record.ts`) is the failure-isolated bridge from the kernel's in-memory types to store rows — it never throws into a run. Findings map the kernel `confirmationStatus`, with a skeptic-disputed finding surfaced as `refuted`.
+**Tracking store (`src/db/store.ts`, `record.ts`).** SQLite via `node:sqlite` (no dependency added) at `<out>/fsa.db`, WAL + busy-timeout so readers (the server) and writers coexist. It is the **system of record for run tracking**, written live — not a rebuildable projection: projects, the run lifecycle, scope coverage (mapped vs audited vs deferred, per-dig), findings and their status transitions (suspect→confirm→refute, on a `finding_status_event` timeline), and confirm decisions — plus a `daemon` registry (bearer tokens) and a `job` queue that is the control plane's dispatch record. It stores metadata + **paths** to the on-disk artifacts, not their content. Findings map the kernel `confirmationStatus`, with a skeptic-disputed finding surfaced as `refuted`.
 
-**Run-manager (`src/server/run-manager.ts`).** Launches audits **in-process via the library** (`runAudit`/`runConfirm`) rather than spawning the CLI — the CLI is a thin wrapper over the same functions, so calling them directly yields the rich `AuditRunResult`/`ConfirmRunResult` and finer hooks: `specToConfig(spec)` is the in-process equivalent of `parseConfig` + `applyAuditPosture` (posture per verb, unbounded budgets by default, remap/quick/region/scope/mock); `options.signal` (an `AbortSignal`) makes "stop" cooperative (→ `session.abort()`, the run finalizes as `killed`); `options.onRun` reports the DB run id. The audit's heavy work (builds, tests) still runs in sandboxed subprocesses spawned by the `bash` tool. Because runs are in-process, a server restart ends them — startup reconciles any still-`running` row to `killed`.
+**Control plane vs. execution plane.** Execution is **decoupled**. The server (control plane) owns the DB and the job queue but never runs an audit. One or more `fsa daemon` processes (the execution plane, possibly on **other machines**) claim queued jobs and run `runAudit`/`runConfirm` locally — so the target **code and provider keys stay on the daemon**, never the server. The seam is `RunTracker`: `runAudit`/`runConfirm` accept `options.makeTracker`; the default `RunRecorder` (`src/db/record.ts`) writes the local SQLite store (the CLI path), while the daemon injects a `RemoteTracker` that **POSTs progress to the server** over HTTP instead of touching the DB. `specToConfig(spec)` (`src/server/run-manager.ts`) maps a launch spec to an `AuditorConfig` (the equivalent of `parseConfig` + `applyAuditPosture`: posture per verb, unbounded budgets by default, remap/quick/region/scope/mock). Stop is cooperative: `POST /api/runs/:id/stop` flags the job for cancel and pushes an SSE nudge; the daemon aborts (`options.signal` → `session.abort()`, finalize → `killed`). `fsa ui` auto-spawns a co-located daemon (it mints a token and runs `fsa daemon`) unless `--no-daemon`; a remote daemon authenticates with a token from `fsa db mint-token`. Because runs live on the daemon, they **survive a server restart** — the server does not blind-kill `running` rows.
 
-**REST API + self-describing catalog (`src/server/app.ts`).** A localhost-only `node:http` server (it executes audits and reads local code, so it never binds beyond `127.0.0.1`). Every workflow operation is a REST resource so an AI agent can drive the whole flow without the UI: **project** (CRUD), **run** (`POST /api/projects/:name/runs` to launch, `GET /api/runs/:id` incl. the rich library result, `POST /api/runs/:id/stop`), and read-only **scope** / **finding** (paginated + filterable) / **confirm-decision**. `GET /api` returns a catalog of every endpoint (method, path, params, body, summary) — an agent fetches it once to learn the surface. Routing is a data-driven table, so the catalog and the handlers cannot drift.
+**REST API + self-describing catalog (`src/server/app.ts`).** A `node:http` server that binds to `127.0.0.1` by default. Every workflow operation is a REST resource so an AI agent can drive the whole flow without the UI: **project** (CRUD), **run** (`POST /api/projects/:name/runs` **enqueues a job** and returns its `jobId`; `GET /api/runs/:id`; `POST /api/runs/:id/stop`), and read-only **scope** / **finding** (paginated + filterable) / **confirm-decision**. `GET /api` returns a catalog of every endpoint (method, path, params, body, summary) — an agent fetches it once to learn the surface. The execution-plane protocol — `/api/daemon/*` (register, SSE stream, claim, run-start, progress PATCH, activity, job-status), each **bearer-token-authenticated** — is **hidden from the catalog** (it is machine-to-machine, not agent-facing). Routing is a data-driven table, so the catalog and the handlers cannot drift.
 
-**Live streams.** `GET /api/stream` (SSE) pushes the project snapshot ~1/s (computed from aggregate queries, so it stays cheap with many findings). `GET /api/runs/:id/log` (SSE) streams a run's live activity: for a run launched in this server session it streams the model's **thinking/output tokens** directly from the in-process session (via an `onActivity` hook → an in-memory bus); for any other run it tails the persisted `events.jsonl` (block-level history).
+**Live streams.** `GET /api/stream` (SSE) pushes the project snapshot ~1/s (computed from aggregate queries, so it stays cheap with many findings). `GET /api/runs/:id/log` (SSE) streams a run's live **token-level** activity (thinking/output deltas + tool calls) from a per-run in-memory bus that the daemon feeds via batched activity POSTs — so the live stream works even when execution is on another machine.
 
 **UI (`src/server/public/index.html`).** A zero-dependency vanilla SPA styled to GitHub's Primer (light default + dark toggle). It is **one client of the API above** — it can be ignored entirely in favor of the API. Per-project dashboard: scope coverage, findings + status timeline, the bugs actually **confirmed** on the real target (front and center), an "Edit config" form, a live-activity panel (the model's thinking), and Start/Continue/Restart/Run/Stop/Delete — each a single API call.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { defaultConfig, normalizeProjectContext, normalizeRoleModels, type AuditorConfig } from "./config.js";
 import { runAudit } from "./agent/audit.js";
 import { runConfirm } from "./agent/confirm.js";
@@ -7,6 +9,7 @@ import { MockAuditLlmClient } from "./llm/mock.js";
 import { importRunToProjectHistory, projectHistoryManifestPath } from "./trace/history.js";
 import { MetadataStore } from "./db/store.js";
 import { startUiServer } from "./server/app.js";
+import { runDaemon } from "./server/daemon.js";
 
 async function main(argv: string[]): Promise<void> {
   const [cmd, ...rest] = argv;
@@ -26,13 +29,36 @@ async function main(argv: string[]): Promise<void> {
   }
 
   if (cmd === "ui") {
-    // Local web app: track/drive audits across projects. Keeps running (the server holds
-    // the event loop open) until interrupted. Binds to localhost only.
-    const port = readIntFlag(rest, "--port");
+    // Control-plane web app: track/drive audits across projects. Keeps running (the server
+    // holds the event loop open) until interrupted. Runs execute on a DAEMON, not here — so
+    // by default we also spawn a co-located local daemon (mint a token + `fsa daemon`). Pass
+    // --no-daemon to run the control plane alone and connect your own daemon(s) elsewhere.
+    const port = readIntFlag(rest, "--port") ?? 4500;
+    const host = readFlag(rest, "--host") ?? "127.0.0.1";
     const out = readFlag(rest, "--out") ?? "runs";
-    startUiServer({ out, ...(port !== undefined ? { port } : {}) });
+    const server = startUiServer({ out, port, host });
+    if (rest.includes("--no-daemon")) {
+      console.log("[fsa ui] --no-daemon: no executor started. Connect one with `fsa daemon --server <url> --token <token>`.");
+    } else {
+      const concurrency = readIntFlag(rest, "--concurrency");
+      server.on("listening", () => spawnLocalDaemon({ out, url: `http://${host}:${port}`, ...(concurrency !== undefined ? { concurrency } : {}) }));
+    }
     await new Promise(() => {}); // run until the process is interrupted
     return;
+  }
+
+  if (cmd === "daemon") {
+    // Execution plane: connect to a control-plane server, claim queued jobs, and run them
+    // LOCALLY (code + provider keys stay here). May run on a different machine than the
+    // server. Reports progress back over HTTP; never touches the server's DB directly.
+    const server = readFlag(rest, "--server");
+    const token = readFlag(rest, "--token");
+    if (!server || !token) throw new Error("fsa daemon needs --server <url> and --token <token> (mint one with `fsa ui`, or via the store)");
+    const out = readFlag(rest, "--out") ?? "runs";
+    const name = readFlag(rest, "--name");
+    const concurrency = readIntFlag(rest, "--concurrency");
+    await runDaemon({ server, token, out, ...(name ? { name } : {}), ...(concurrency !== undefined ? { concurrency } : {}) });
+    return; // runDaemon loops forever (until interrupted)
   }
 
   // The three sealed agentic verbs share one driver (runAudit); the verb selects the
@@ -225,6 +251,32 @@ function applyConfigOverrides(cfg: AuditorConfig, raw: Record<string, unknown>):
   if (typeof raw.dryRun === "boolean") cfg.dryRun = raw.dryRun;
 }
 
+// Spawn a co-located daemon for `fsa ui`: mint a fresh bearer token in the shared store,
+// then run `fsa daemon` as a child pointed at the just-started server. The child dies with
+// the parent. (A remote daemon is started the same way, by hand, on another machine.)
+function spawnLocalDaemon(opts: { out: string; url: string; concurrency?: number }): void {
+  const store = MetadataStore.openForOutput(opts.out);
+  const { token } = store.createDaemonToken(`local-${process.pid}`);
+  store.close();
+  const args = [fileURLToPath(import.meta.url), "daemon", "--server", opts.url, "--token", token, "--out", opts.out];
+  if (opts.concurrency !== undefined) args.push("--concurrency", String(opts.concurrency));
+  const child = spawn(process.execPath, args, { stdio: "inherit" });
+  child.on("error", (error) => console.error(`[fsa ui] could not start local daemon: ${error.message}`));
+  child.on("exit", (code) => console.log(`[fsa ui] local daemon exited (code ${code ?? "?"})`));
+  const kill = (): void => {
+    try {
+      child.kill();
+    } catch {
+      /* already gone */
+    }
+  };
+  process.on("exit", kill);
+  process.on("SIGINT", () => {
+    kill();
+    process.exit(0);
+  });
+}
+
 function hasFlag(args: string[], name: string): boolean {
   return args.includes(name);
 }
@@ -305,6 +357,25 @@ function runDbCommand(args: string[]): void {
       }
       return;
     }
+    if (subcommand === "daemons") {
+      const daemons = db.listDaemons();
+      if (daemons.length === 0) {
+        console.log("(no daemons registered — mint a token with `fsa db mint-token [name]`, then run `fsa daemon`)");
+        return;
+      }
+      for (const d of daemons) console.log(`• [${d.id}] ${d.name}  last_seen=${d.last_seen_at ?? "never"}`);
+      return;
+    }
+    if (subcommand === "mint-token") {
+      // Mint a bearer token for a (remote) daemon. Must run on the SERVER machine — the
+      // server owns this DB; the daemon authenticates with the printed token over HTTP.
+      const name = readFlag(args, "--name") ?? positional ?? "daemon";
+      const { id, token } = db.createDaemonToken(name);
+      console.log(`[daemon ${id}] ${name}`);
+      console.log(`token: ${token}`);
+      console.log(`run on the executor machine:\n  fsa daemon --server http://<this-server-host>:4500 --token ${token}`);
+      return;
+    }
     const projectId = resolveProjectId(db, target);
     if (subcommand === "runs") {
       for (const run of db.listRuns(projectId)) {
@@ -319,7 +390,7 @@ function runDbCommand(args: string[]): void {
       }
       return;
     }
-    throw new Error(`Unknown db command "${subcommand}". Use: fsa db projects | runs [--target <name>] | findings --target <name>`);
+    throw new Error(`Unknown db command "${subcommand}". Use: fsa db projects | runs [--target <name>] | findings --target <name> | daemons | mint-token [name]`);
   } finally {
     db.close();
   }
@@ -363,8 +434,16 @@ Usage:
   fsa audit   [<region> | --scope <id,...> | --verify <file>] --source ...   deep-audit a region, inventory scopes, or given claims
   fsa confirm <run-dir> --source <paths...>                                  open-world: reproduce a run's findings on the real target
   fsa history import-run --target <name> --run <dir>
-  fsa db      [projects | runs [<target>] | findings <target>]               read the SQLite tracking store (projects, runs, coverage, findings)
-  fsa ui      [--port <n>] [--out <dir>]                                      local web dashboard: track/drive audits across projects (localhost only)
+  fsa db      [projects | runs [<target>] | findings <target> | daemons | mint-token [name]]   read the tracking store; mint/list daemon tokens
+  fsa ui      [--port <n>] [--host <h>] [--out <dir>] [--no-daemon]           control-plane web dashboard + a co-located executor daemon (localhost)
+  fsa daemon  --server <url> --token <token> [--out <dir>] [--concurrency <n>]   execution plane: claim + run queued jobs (may be a different machine)
+
+Control plane vs execution plane:
+  fsa ui starts the CONTROL PLANE (the dashboard, REST API, SQLite store, and job queue) and,
+  unless --no-daemon, a co-located DAEMON to execute jobs. The daemon is what actually runs the
+  audit — so code and provider keys stay on the daemon's machine. Run "fsa daemon" on another
+  host (with a token minted by the server operator) to execute remotely; the server owns the DB
+  and the daemon only reports progress back over HTTP.
 
 Sealed vs open world:
   run / map / audit are NETWORK-SEALED — the model finds and proves bugs blind, with no

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -277,6 +277,7 @@ export class MetadataStore {
       this.db.prepare("DELETE FROM finding WHERE project_id = ?").run(id);
       this.db.prepare("DELETE FROM scope WHERE project_id = ?").run(id);
       this.db.prepare("DELETE FROM confirm_decision WHERE project_id = ?").run(id);
+      this.db.prepare("DELETE FROM job WHERE project = ?").run(String(project.name)); // jobs FK-reference runs
       this.db.prepare("DELETE FROM run WHERE project_id = ?").run(id);
       this.db.prepare("DELETE FROM project WHERE id = ?").run(id);
     });
@@ -381,6 +382,7 @@ export class MetadataStore {
       this.db.prepare("DELETE FROM finding_status_event WHERE finding_id IN (SELECT id FROM finding WHERE run_id = ?)").run(id);
       this.db.prepare("DELETE FROM finding WHERE run_id = ?").run(id);
       this.db.prepare("DELETE FROM confirm_decision WHERE run_id = ?").run(id);
+      this.db.prepare("UPDATE job SET run_id = NULL WHERE run_id = ?").run(id); // keep the job record, drop the dangling ref
       this.db.prepare("DELETE FROM run WHERE id = ?").run(id);
     });
     return true;
@@ -601,6 +603,11 @@ export class MetadataStore {
 
   listJobs(limit = 100): Array<Record<string, unknown>> {
     return this.db.prepare("SELECT * FROM job ORDER BY created_at DESC LIMIT ?").all(Math.max(1, Math.floor(limit))) as Array<Record<string, unknown>>;
+  }
+
+  /** Jobs still in flight (queued/dispatched/running) — for the dashboard's active counts. */
+  runningJobs(): Array<Record<string, unknown>> {
+    return this.db.prepare("SELECT * FROM job WHERE status IN ('queued','dispatched','running') ORDER BY created_at DESC").all() as Array<Record<string, unknown>>;
   }
 
   // --- internals ------------------------------------------------------------

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,16 +1,21 @@
-// Local web app + REST API for tracking/driving audits across projects. Every workflow
-// resource (project, run, scope, finding, confirm decision) is a REST resource, and every
-// operation the UI performs is an API call — so an AI agent can drive the whole workflow
-// without the UI by fetching GET /api (a self-describing catalog of all endpoints) and
-// calling them. The UI is just one client of this API. Zero-dependency: Node's built-in
-// http + a vanilla SPA. Binds to localhost only (it can spawn audit processes).
+// Control-plane server + REST API for tracking/driving audits across projects. Every
+// workflow resource (project, run, scope, finding, confirm decision) is a REST resource,
+// and every operation the UI performs is an API call — so an AI agent can drive the whole
+// workflow without the UI by fetching GET /api (a self-describing catalog of all endpoints)
+// and calling them. The UI is just one client of this API.
+//
+// Execution is DECOUPLED: this server owns the SQLite DB and a job queue but never runs an
+// audit itself. One or more `fsa daemon` processes (possibly on other machines) connect,
+// claim queued jobs, run runAudit/runConfirm locally (code + provider keys stay on the
+// daemon), and report progress back over HTTP. Server→daemon nudges (poll/cancel) ride an
+// SSE stream; daemon→server updates are POSTs. Zero-dependency: Node's built-in http + a
+// vanilla SPA. Bind to localhost unless a per-daemon bearer token is configured.
 
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { readFileSync, createReadStream, statSync } from "node:fs";
-import path from "node:path";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { MetadataStore, type RunKind, type ScopeStatus } from "../db/store.js";
-import { RunManager, type LaunchSpec, type ActivityBus } from "./run-manager.js";
+import { MetadataStore, type RunKind, type Coverage } from "../db/store.js";
+import { type LaunchSpec, ActivityBus } from "./run-manager.js";
 import { projectHistoryDir } from "../trace/history.js";
 import { loadScopeInventory, saveScopeInventory } from "../agent/scope-store.js";
 
@@ -29,13 +34,61 @@ export interface UiServerOptions {
   host?: string;
 }
 
+// The control plane: the live registry of connected daemons (for server→daemon nudges) and
+// a per-run activity bus (fed by daemon activity POSTs, read by the UI's SSE log stream).
+// It holds NO execution state — the DB job queue is the system of record for dispatch.
+class ControlPlane {
+  private readonly daemons = new Set<ServerResponse>();
+  private readonly buses = new Map<number, ActivityBus>();
+
+  addDaemon(res: ServerResponse): void {
+    this.daemons.add(res);
+  }
+  removeDaemon(res: ServerResponse): void {
+    this.daemons.delete(res);
+  }
+  daemonCount(): number {
+    return this.daemons.size;
+  }
+
+  /** Nudge every connected daemon to (re)claim queued jobs. */
+  nudge(): void {
+    this.broadcast({ type: "poll" });
+  }
+  /** Ask whichever daemon holds this job to abort it (others ignore an unknown jobId). */
+  cancel(jobId: number): void {
+    this.broadcast({ type: "cancel", jobId });
+  }
+  private broadcast(ev: unknown): void {
+    const frame = `data: ${JSON.stringify(ev)}\n\n`;
+    for (const res of this.daemons) {
+      try {
+        res.write(frame);
+      } catch {
+        this.daemons.delete(res);
+      }
+    }
+  }
+
+  /** The activity bus for a run (created on first use); daemon activity POSTs push into it,
+   * the UI's GET /api/runs/:id/log streams out of it. */
+  bus(runId: number): ActivityBus {
+    let bus = this.buses.get(runId);
+    if (!bus) {
+      bus = new ActivityBus();
+      this.buses.set(runId, bus);
+    }
+    return bus;
+  }
+}
+
 interface Ctx {
   req: IncomingMessage;
   res: ServerResponse;
   params: Record<string, string>;
   url: URL;
   store: MetadataStore;
-  manager: RunManager;
+  plane: ControlPlane;
   out: string;
 }
 
@@ -74,7 +127,7 @@ const ROUTES: Route[] = [
   route({
     method: "GET", path: "/api/projects",
     summary: "List all projects with a live snapshot (scope coverage, finding counts, confirmed-bug count, latest run, active runs).",
-    handler: (c) => sendJson(c.res, 200, { projects: projectSnapshots(c.store, c.manager) }),
+    handler: (c) => sendJson(c.res, 200, { projects: projectSnapshots(c.store) }),
   }),
   route({
     method: "POST", path: "/api/projects",
@@ -110,7 +163,7 @@ const ROUTES: Route[] = [
   }),
   route({
     method: "POST", path: "/api/projects/:name/runs",
-    summary: "Launch a run on the project (start/continue an audit, restart, map, audit a region/scope, or confirm). Uses the project's stored materials + config unless overridden. This is the single action behind the UI's Start/Continue/Restart/Run buttons.",
+    summary: "Queue a run on the project (start/continue an audit, restart, map, audit a region/scope, or confirm). The job is dispatched to a connected daemon, which executes it and reports back. Uses the project's stored materials + config unless overridden. This is the single action behind the UI's Start/Continue/Restart/Run buttons.",
     params: { name: "project name" },
     body: {
       verb: "'run' | 'map' | 'audit' | 'confirm' (default 'run'; run = map→dig, resumes)",
@@ -151,18 +204,16 @@ const ROUTES: Route[] = [
 
   route({
     method: "GET", path: "/api/runs/:id",
-    summary: "A single run (status, kind, coverage, finding count, run dir, timestamps). Includes the rich library `result` (AuditRunResult / ConfirmRunResult — full findings, summary, coverage) for a run launched in the current server session.",
+    summary: "A single run (status, kind, coverage, finding count, run dir, timestamps).",
     params: { id: "run id" },
     handler: (c) => {
       const run = c.store.getRun(Number(c.params.id));
-      if (!run) return sendJson(c.res, 404, { error: "no such run" });
-      const result = c.manager.resultFor(Number(c.params.id));
-      sendJson(c.res, 200, { run, ...(result ? { result } : {}) });
+      run ? sendJson(c.res, 200, { run }) : sendJson(c.res, 404, { error: "no such run" });
     },
   }),
   route({
     method: "POST", path: "/api/runs/:id/stop",
-    summary: "Stop a running run (aborts the in-process session). The run is reconciled to 'killed'.",
+    summary: "Stop a running run: flags its job for cancel and nudges the executing daemon to abort. The run is reconciled to 'killed'.",
     params: { id: "run id" },
     handler: runStop,
   }),
@@ -174,19 +225,28 @@ const ROUTES: Route[] = [
   }),
   route({
     method: "GET", path: "/api/runs/:id/log",
-    summary: "SSE stream of a run's live activity, tailed from its event log: the model's thinking + output blocks (audit_thinking / audit_text), tool calls (audit_step), and milestones. Streams existing entries then new ones as they happen.",
+    summary: "SSE stream of a run's live activity: the model's token-level thinking + output (audit_thinking / audit_text), tool calls (audit_step), and milestones, as reported by the executing daemon. Replays recent backlog then streams new events.",
     params: { id: "run id" },
-    handler: runLog,
+    handler: (c) => streamFromBus(c.res, c.plane.bus(Number(c.params.id))),
   }),
 
-  route({ method: "GET", path: "/api/active", summary: "Currently-running processes the run-manager is supervising.", handler: (c) => sendJson(c.res, 200, { active: c.manager.active() }) }),
-  route({ method: "GET", path: "/api/stream", summary: "Server-sent events: the project snapshot + active list, pushed ~1/s for live updates.", handler: (c) => streamSnapshots(c.res, c.store, c.manager) }),
+  route({ method: "GET", path: "/api/active", summary: "In-flight jobs (queued/dispatched/running) across all daemons.", handler: (c) => sendJson(c.res, 200, { active: activeRuns(c.store), daemons: c.store.listDaemons() }) }),
+  route({ method: "GET", path: "/api/stream", summary: "Server-sent events: the project snapshot + active list, pushed ~1/s for live updates.", handler: (c) => streamSnapshots(c.res, c.store) }),
+
+  // ---- execution plane: daemon ↔ server (hidden from the agent catalog) ----------------
+  route({ method: "POST", path: "/api/daemon/register", summary: "(daemon) Register/heartbeat. Bearer token required.", hidden: true, handler: daemonRegister }),
+  route({ method: "GET", path: "/api/daemon/stream", summary: "(daemon) SSE: poll/cancel nudges from the server.", hidden: true, handler: daemonStream }),
+  route({ method: "POST", path: "/api/daemon/claim", summary: "(daemon) Atomically claim the oldest queued job.", hidden: true, handler: daemonClaim }),
+  route({ method: "POST", path: "/api/daemon/runs", summary: "(daemon) Start a run row for a claimed job; links job→run.", hidden: true, handler: daemonRunStart }),
+  route({ method: "PATCH", path: "/api/daemon/runs/:id", summary: "(daemon) Report run progress: scopes / findings / confirm-decisions / finish.", hidden: true, handler: daemonRunUpdate }),
+  route({ method: "POST", path: "/api/daemon/runs/:id/activity", summary: "(daemon) Push a batch of token-level activity events for the live log.", hidden: true, handler: daemonRunActivity }),
+  route({ method: "POST", path: "/api/daemon/jobs/:id/status", summary: "(daemon) Report a job's terminal status (done/error/canceled).", hidden: true, handler: daemonJobStatus }),
 ];
 
 function catalog(): unknown {
   return {
     name: "full-stack-auditor",
-    description: "REST API for tracking and driving white-hat audits. Resources: project (CRUD), run (launch/stop/read), scope, finding, confirm-decision. Every UI operation is one of these calls.",
+    description: "REST API for tracking and driving white-hat audits. Resources: project (CRUD), run (launch/stop/read), scope, finding, confirm-decision. Runs execute on connected daemons; every UI operation is one of these calls.",
     resources: ["project", "run", "scope", "finding", "confirm-decision"],
     endpoints: ROUTES.filter((r) => !r.hidden).map((r) => ({
       method: r.method,
@@ -202,12 +262,12 @@ function catalog(): unknown {
 export function startUiServer(options: UiServerOptions = {}): ReturnType<typeof createServer> {
   const out = options.out ?? "runs";
   const port = options.port ?? 4500;
-  const host = options.host ?? "127.0.0.1"; // localhost only — this endpoint can spawn processes
+  const host = options.host ?? "127.0.0.1"; // localhost by default; expose only with daemon tokens set
   const store = MetadataStore.openForOutput(out);
-  // Runs execute in this process, so any row left `running` is orphaned by a prior restart.
-  const orphans = store.reconcileOrphanedRuns();
-  if (orphans > 0) console.log(`[fsa ui] reconciled ${orphans} interrupted run(s) from a previous session`);
-  const manager = new RunManager(store, out); // runs the library in-process (not the CLI)
+  const plane = new ControlPlane();
+  // NOTE: we do NOT reconcile `running` rows on startup — runs execute on daemons, which
+  // survive a server restart. Blind-killing them here would be wrong. (A future daemon
+  // heartbeat can reconcile rows whose daemon has gone stale.)
 
   const server = createServer((req, res) => {
     const url = new URL(req.url ?? "/", "http://localhost");
@@ -218,9 +278,14 @@ export function startUiServer(options: UiServerOptions = {}): ReturnType<typeof 
       if (!match) continue;
       const params: Record<string, string> = {};
       r.paramNames.forEach((name, i) => (params[name] = decodeURIComponent(match[i + 1] ?? "")));
-      Promise.resolve(r.handler({ req, res, params, url, store, manager, out })).catch((error) =>
-        sendJson(res, 500, { error: String(error instanceof Error ? error.message : error) }),
-      );
+      // .then(run) (not Promise.resolve(run())) so a SYNCHRONOUS throw in a handler becomes a
+      // rejection we can turn into a 500 — never an uncaught exception that kills the server.
+      Promise.resolve()
+        .then(() => r.handler({ req, res, params, url, store, plane, out }))
+        .catch((error) => {
+          if (!res.headersSent) sendJson(res, 500, { error: String(error instanceof Error ? error.message : error) });
+          else res.end();
+        });
       return;
     }
     sendJson(res, 404, { error: "not found", hint: "GET /api lists every endpoint" });
@@ -289,23 +354,30 @@ async function scopeSetStatus(c: Ctx): Promise<void> {
   }
   const scopeId = c.params.scopeId ?? "";
   // Update the persisted inventory the AUDIT reads (history-dir scopes.json), so the next
-  // dig honors the skip — then mirror it into the UI's SQLite projection.
+  // dig honors the skip — then mirror it into the UI's SQLite projection. (If the daemon
+  // executes from its own checkout, it re-reads the inventory there via resume/--remap; this
+  // server-side copy is the one a co-located daemon shares.)
   const inventoryDir = projectHistoryDir({ outputDir: c.out, targetName: String(project.name) });
   const inventory = await loadScopeInventory(inventoryDir);
   const scope = inventory.find((s) => s.id === scopeId);
-  if (!scope) return sendJson(c.res, 404, { error: `no scope "${scopeId}" in the inventory` });
-  scope.status = status;
-  await saveScopeInventory(inventoryDir, inventory);
+  if (scope) {
+    scope.status = status;
+    await saveScopeInventory(inventoryDir, inventory);
+  }
   c.store.setScopeStatus(Number(project.id), scopeId, status);
   sendJson(c.res, 200, { ok: true, scopeId, status });
 }
 
+// Queue a run for the project. The job lands in the DB queue; connected daemons are nudged
+// to claim it. Returns the job id (the run id appears once a daemon starts it).
 async function runLaunch(c: Ctx): Promise<void> {
   const project = c.store.getProject(c.params.name ?? "");
   if (!project) return sendJson(c.res, 404, { error: `no project named ${c.params.name}` });
   const body = (await readBody(c.req)) as Record<string, unknown>;
-  const result = c.manager.launch(launchSpec(project, body, c.out));
-  sendJson(c.res, 200, result);
+  const spec = launchSpec(project, body, c.out);
+  const jobId = c.store.enqueueJob(spec.target, spec);
+  c.plane.nudge();
+  sendJson(c.res, 200, { jobId, verb: spec.verb, queued: true, daemons: c.plane.daemonCount() });
 }
 
 function findingsList(c: Ctx): void {
@@ -331,78 +403,167 @@ function confirmDecisionsList(c: Ctx): void {
 function runStop(c: Ctx): void {
   const id = Number(c.params.id);
   if (!c.store.getRun(id)) return sendJson(c.res, 404, { error: "no such run" });
-  sendJson(c.res, 200, { stopped: c.manager.stop(id) });
-}
-
-function runLog(c: Ctx): void {
-  const id = Number(c.params.id);
-  const run = c.store.getRun(id);
-  if (!run) return sendJson(c.res, 404, { error: "no such run" });
-  // A run launched this session streams token-level activity from the in-memory bus; any
-  // other run (e.g. historical, or after a restart) tails its persisted event log.
-  const bus = c.manager.activityFor(id);
-  if (bus) {
-    streamFromBus(c.res, bus);
-    return;
+  const job = c.store.getJobByRun(id);
+  if (job) {
+    c.store.requestJobCancel(Number(job.id));
+    c.plane.cancel(Number(job.id)); // nudge the executing daemon to abort
   }
-  if (typeof run.run_dir === "string") {
-    streamRunLog(c.res, run.run_dir);
-    return;
-  }
-  sendJson(c.res, 404, { error: "run has no activity or event log" });
+  sendJson(c.res, 200, { stopped: Boolean(job) });
 }
 
 function streamFromBus(res: ServerResponse, bus: ActivityBus): void {
   res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
-  const unsubscribe = bus.subscribe((ev) => res.write(`data: ${JSON.stringify(ev)}\n\n`));
-  res.on("close", unsubscribe);
+  res.write(": open\n\n"); // flush headers immediately so the client's EventSource opens even before the first event
+  // `let` + no-op default: subscribe() replays backlog synchronously, so the callback can fire
+  // before the real unsubscribe is assigned — guard against the temporal-dead-zone reference.
+  let unsubscribe = (): void => {};
+  unsubscribe = bus.subscribe((ev) => {
+    try {
+      res.write(`data: ${JSON.stringify(ev)}\n\n`);
+    } catch {
+      unsubscribe();
+    }
+  });
+  res.on("close", () => unsubscribe());
 }
 
-// Tail a run's events.jsonl over SSE: send existing lines, then poll for appended bytes and
-// stream new ones. The run process (separate from this server) appends the model's thinking/
-// output blocks + tool calls there, so this is the live-activity channel for the UI.
-function streamRunLog(res: ServerResponse, runDir: string): void {
-  res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
-  const file = path.join(runDir, "events.jsonl");
-  let offset = 0;
-  let buf = "";
-  const pump = (): void => {
-    let size: number;
+// ---- daemon (execution-plane) handlers -----------------------------------------------
+
+// Authenticate a daemon by its bearer token. On failure, sends 401 and returns null.
+function daemonAuth(c: Ctx): Record<string, unknown> | null {
+  const header = c.req.headers["authorization"];
+  const token = typeof header === "string" && header.startsWith("Bearer ") ? header.slice(7) : "";
+  const daemon = token ? c.store.getDaemonByToken(token) : undefined;
+  if (!daemon) {
+    sendJson(c.res, 401, { error: "unauthorized: a valid daemon bearer token is required" });
+    return null;
+  }
+  return daemon;
+}
+
+async function daemonRegister(c: Ctx): Promise<void> {
+  const daemon = daemonAuth(c);
+  if (!daemon) return;
+  const body = (await readBody(c.req)) as { name?: string; capabilities?: unknown };
+  c.store.touchDaemon(Number(daemon.id), body.capabilities);
+  sendJson(c.res, 200, { ok: true, daemonId: Number(daemon.id), name: daemon.name });
+}
+
+function daemonStream(c: Ctx): void {
+  const daemon = daemonAuth(c);
+  if (!daemon) return;
+  c.store.touchDaemon(Number(daemon.id));
+  c.res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
+  c.plane.addDaemon(c.res);
+  c.res.write(`data: ${JSON.stringify({ type: "poll" })}\n\n`); // drain any backlog on connect
+  const keepalive = setInterval(() => {
     try {
-      size = statSync(file).size;
+      c.res.write(`: keepalive\n\n`);
     } catch {
-      return; // not created yet
+      /* closed */
     }
-    if (size < offset) {
-      offset = 0;
-      buf = "";
-    }
-    if (size <= offset) return;
-    const start = offset;
-    offset = size;
-    const stream = createReadStream(file, { start, end: size - 1, encoding: "utf8" });
-    let chunk = "";
-    stream.on("data", (d) => {
-      chunk += d;
-    });
-    stream.on("end", () => {
-      buf += chunk;
-      const lines = buf.split("\n");
-      buf = lines.pop() ?? "";
-      for (const line of lines) if (line.trim()) res.write(`data: ${line}\n\n`);
-    });
-    stream.on("error", () => {});
+  }, 25_000);
+  c.res.on("close", () => {
+    clearInterval(keepalive);
+    c.plane.removeDaemon(c.res);
+  });
+}
+
+function daemonClaim(c: Ctx): void {
+  const daemon = daemonAuth(c);
+  if (!daemon) return;
+  const job = c.store.claimJob(Number(daemon.id));
+  sendJson(c.res, 200, job ? { job } : {});
+}
+
+async function daemonRunStart(c: Ctx): Promise<void> {
+  const daemon = daemonAuth(c);
+  if (!daemon) return;
+  const body = (await readBody(c.req)) as { jobId?: number; project?: string; kind?: RunKind; runDir?: string; provider?: string; model?: string; thinking?: string; budgets?: unknown };
+  const name = (body.project ?? "").trim();
+  if (!name || !body.runDir) return sendJson(c.res, 400, { error: "project and runDir are required" });
+  const existing = c.store.getProject(name);
+  const projectId = existing ? Number(existing.id) : c.store.upsertProject({ name, config: body.budgets });
+  const runId = c.store.startRun({
+    projectId,
+    kind: body.kind ?? "run",
+    runDir: body.runDir,
+    provider: body.provider,
+    model: body.model,
+    thinking: body.thinking,
+    budgets: body.budgets,
+  });
+  if (typeof body.jobId === "number") c.store.setJobRun(body.jobId, runId); // link job → run (so stop can find it)
+  sendJson(c.res, 200, { runId });
+}
+
+async function daemonRunUpdate(c: Ctx): Promise<void> {
+  const daemon = daemonAuth(c);
+  if (!daemon) return;
+  const runId = Number(c.params.id);
+  const run = c.store.getRun(runId);
+  if (!run) return sendJson(c.res, 404, { error: "no such run" });
+  const projectId = Number(run.project_id);
+  const body = (await readBody(c.req)) as {
+    scopes?: Parameters<MetadataStore["upsertScopes"]>[1];
+    findings?: Parameters<MetadataStore["upsertFindings"]>[2];
+    reason?: string;
+    confirmDecisions?: Parameters<MetadataStore["upsertConfirmDecisions"]>[2];
+    decisionPath?: string;
+    finish?: { status: Parameters<MetadataStore["finishRun"]>[1]; coverage?: Coverage; findingsTotal?: number };
   };
-  pump();
-  const timer = setInterval(pump, 700);
-  res.on("close", () => clearInterval(timer));
+  if (body.scopes) {
+    c.store.upsertScopes(projectId, body.scopes);
+    c.store.updateRunCoverage(runId, c.store.scopeProgress(projectId));
+  }
+  if (body.findings) c.store.upsertFindings(projectId, runId, body.findings, body.reason);
+  if (body.confirmDecisions) c.store.upsertConfirmDecisions(projectId, runId, body.confirmDecisions, body.decisionPath);
+  if (body.finish) c.store.finishRun(runId, body.finish.status, body.finish.coverage, body.finish.findingsTotal);
+  sendJson(c.res, 200, { ok: true });
+}
+
+async function daemonRunActivity(c: Ctx): Promise<void> {
+  const daemon = daemonAuth(c);
+  if (!daemon) return;
+  const runId = Number(c.params.id);
+  const body = (await readBody(c.req)) as { events?: Array<{ kind: string; delta?: string; tool?: string; step?: number }> };
+  const bus = c.plane.bus(runId);
+  for (const ev of body.events ?? []) bus.push(ev);
+  sendJson(c.res, 200, { ok: true });
+}
+
+async function daemonJobStatus(c: Ctx): Promise<void> {
+  const daemon = daemonAuth(c);
+  if (!daemon) return;
+  const jobId = Number(c.params.id);
+  const body = (await readBody(c.req)) as { status?: string; error?: string };
+  const status = body.status ?? "done";
+  c.store.setJobStatus(jobId, status, body.error);
+  // If the daemon died/aborted before its run reached a terminal state, reconcile the run.
+  if (status === "error" || status === "canceled") {
+    const job = c.store.getJob(jobId);
+    const runId = job && typeof job.run_id === "number" ? job.run_id : undefined;
+    if (runId !== undefined) {
+      const run = c.store.getRun(runId);
+      if (run && run.status === "running") c.store.finishRun(runId, status === "canceled" ? "killed" : "error");
+    }
+  }
+  sendJson(c.res, 200, { ok: true });
 }
 
 // ---- shared -----------------------------------------------------------------
 
-function projectSnapshots(store: MetadataStore, manager: RunManager): Array<Record<string, unknown>> {
+// In-flight jobs across all daemons, shaped for the dashboard's "active" list.
+function activeRuns(store: MetadataStore): Array<Record<string, unknown>> {
+  return store.runningJobs().map((job) => {
+    const spec = safeParse(job.spec_json) as { verb?: string } | null;
+    return { jobId: job.id, runId: job.run_id ?? null, target: job.project, status: job.status, verb: spec?.verb ?? "run", startedAt: job.created_at };
+  });
+}
+
+function projectSnapshots(store: MetadataStore): Array<Record<string, unknown>> {
   const activeByTarget = new Map<string, number>();
-  for (const run of manager.active()) activeByTarget.set(run.target, (activeByTarget.get(run.target) ?? 0) + 1);
+  for (const job of store.runningJobs()) activeByTarget.set(String(job.project), (activeByTarget.get(String(job.project)) ?? 0) + 1);
   return store.listProjects().map((project) => {
     const id = Number(project.id);
     return {
@@ -419,14 +580,19 @@ function projectSnapshots(store: MetadataStore, manager: RunManager): Array<Reco
   });
 }
 
-function streamSnapshots(res: ServerResponse, store: MetadataStore, manager: RunManager): void {
+function streamSnapshots(res: ServerResponse, store: MetadataStore): void {
   res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
-  const tick = (): void => {
-    res.write(`data: ${JSON.stringify({ projects: projectSnapshots(store, manager), active: manager.active() })}\n\n`);
-  };
-  tick();
   const timer = setInterval(tick, 1200);
   res.on("close", () => clearInterval(timer));
+  tick();
+  // A throw here (closed socket, or a transient store read error) must not crash the server.
+  function tick(): void {
+    try {
+      res.write(`data: ${JSON.stringify({ projects: projectSnapshots(store), active: activeRuns(store) })}\n\n`);
+    } catch {
+      clearInterval(timer);
+    }
+  }
 }
 
 // Build a launch spec from the project's stored materials/config + the request body

--- a/src/server/daemon.ts
+++ b/src/server/daemon.ts
@@ -51,7 +51,7 @@ export async function runDaemon(opts: DaemonOptions): Promise<void> {
     let tracker: RemoteTracker | undefined;
     const sink = activitySink(() => tracker);
     const makeTracker = (cfg: AuditorConfig, runDir: string, kind: string): RunTracker => {
-      tracker = new RemoteTracker(base, headers, { project: cfg.targetName, kind, runDir, provider: cfg.provider, model: cfg.auditModel, thinking: cfg.thinkingLevel, budgets: configSnapshot(cfg) });
+      tracker = new RemoteTracker(base, headers, { jobId: job.id, project: cfg.targetName, kind, runDir, provider: cfg.provider, model: cfg.auditModel, thinking: cfg.thinkingLevel, budgets: configSnapshot(cfg) });
       return tracker;
     };
     try {
@@ -118,7 +118,7 @@ class RemoteTracker implements RunTracker {
   constructor(
     private readonly base: string,
     private readonly headers: Record<string, string>,
-    start: { project: string; kind: string; runDir: string; provider?: string; model?: string; thinking?: string; budgets: unknown },
+    start: { jobId: number; project: string; kind: string; runDir: string; provider?: string; model?: string; thinking?: string; budgets: unknown },
   ) {
     this.chain = this.req("POST", "/api/daemon/runs", start).then((r) => {
       this.runId = (r as { runId?: number } | null)?.runId;

--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -482,13 +482,21 @@ function projectFields(d) {
   return { cfg, sourcePaths: arr(d.project.source_paths), buildRoot: d.project.build_root || "", corpusPaths: arr(d.project.corpus_paths) };
 }
 
+// Queue a run on the selected project. Runs execute on a connected DAEMON; if none is
+// connected the job just sits queued — surface that so the user isn't left wondering.
+async function launchRun(body) {
+  if (!state.selected) return;
+  const res = await fetch("/api/projects/" + encodeURIComponent(state.selected) + "/runs", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) alert(data.error || "could not queue the run");
+  else if (data.queued && data.daemons === 0) alert("Run queued (job #" + data.jobId + "), but no executor daemon is connected — it will start once one connects.\n\nStart one with:\n  fsa daemon --server <this-server-url> --token <token>");
+  setTimeout(loadDetail, 400);
+}
+
 // Start/Continue = run (resume default); Restart = run + remap. The server launches using
 // the project's stored materials & config, so the UI just names the action.
 async function command(which) {
-  if (!state.selected) return;
-  const body = which === "restart" ? { verb: "run", remap: true } : { verb: "run" };
-  await fetch("/api/projects/" + encodeURIComponent(state.selected) + "/runs", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
-  setTimeout(loadDetail, 400);
+  await launchRun(which === "restart" ? { verb: "run", remap: true } : { verb: "run" });
 }
 
 // --- edit config dialog ---
@@ -550,8 +558,7 @@ $("#runForm").onsubmit = async (e) => {
   const body = { verb: f.get("verb"),
     region: f.get("region") || undefined, scope: f.get("scope") || undefined,
     inputRunDir: f.get("inputRunDir") || undefined, quick: f.get("quick") === "on", mockLlm: f.get("mockLlm") === "on" };
-  await fetch("/api/projects/" + encodeURIComponent(state.selected) + "/runs", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
-  setTimeout(loadDetail, 400);
+  await launchRun(body);
 };
 
 // --- live stream ---

--- a/src/server/run-manager.ts
+++ b/src/server/run-manager.ts
@@ -1,15 +1,11 @@
-// Run-manager: launches and supervises audits so a UI/agent can run them across projects
-// concurrently. It calls the LIBRARY in-process (runAudit / runConfirm) rather than shelling
-// out to the CLI — the CLI is just a thin wrapper over the same functions, so calling them
-// directly yields the rich result objects (AuditRunResult / ConfirmRunResult) and finer
-// hooks (an AbortSignal for stop, an onRun callback for the DB run id). The audit's heavy
-// work (builds, tests) still runs in sandboxed subprocesses spawned by the bash tool.
+// Run-spec utilities shared by the control plane (server) and the execution plane (daemon):
+// the translation of a UI/agent LaunchSpec into an AuditorConfig (what the daemon runs) and
+// into equivalent `fsa` CLI argv (for display), plus the per-run ActivityBus the server uses
+// to fan a daemon's token-level activity out to the UI's live log. Execution itself lives in
+// the daemon (src/server/daemon.ts); this module holds no run state.
 
-import { runAudit, type AuditRunResult } from "../agent/audit.js";
-import { runConfirm, type ConfirmRunResult } from "../agent/confirm.js";
 import { defaultConfig, type AuditorConfig } from "../config.js";
-import { MockAuditLlmClient } from "../llm/mock.js";
-import type { MetadataStore, RunKind, RunStatus } from "../db/store.js";
+import type { RunKind } from "../db/store.js";
 
 const DEFAULT_OUT = "runs";
 const THINKING = new Set(["minimal", "low", "medium", "high", "xhigh"]);
@@ -65,24 +61,6 @@ export interface LaunchSpec {
   out?: string | undefined;
 }
 
-export interface ActiveRun {
-  runId: number | undefined; // the DB run id (once runAudit has recorded it)
-  target: string;
-  verb: RunKind;
-  startedAt: string;
-}
-
-interface RunHandle {
-  spec: LaunchSpec;
-  abort: AbortController;
-  startedAt: string;
-  status: "running" | "done" | "error" | "killed";
-  runId?: number;
-  result?: AuditRunResult | ConfirmRunResult;
-  error?: string;
-  activity: ActivityBus;
-}
-
 // Translate a launch spec into an AuditorConfig — the in-process equivalent of the CLI's
 // parseConfig + applyAuditPosture. Budgets are UNBOUNDED unless the spec caps them.
 export function specToConfig(spec: LaunchSpec, out: string): AuditorConfig {
@@ -119,105 +97,6 @@ export function specToConfig(spec: LaunchSpec, out: string): AuditorConfig {
     cfg.auditDeep = true; // run = map -> dig, unless --quick (breadth)
   }
   return cfg;
-}
-
-export class RunManager {
-  private readonly runs = new Map<number, RunHandle>();
-  private nextLaunchId = 1;
-
-  constructor(
-    private readonly store: MetadataStore,
-    private readonly out: string = DEFAULT_OUT,
-  ) {}
-
-  /** Launch a run in-process. Returns a launch id; the DB run id appears once runAudit
-   * records it (poll GET /api/projects/:name or /api/runs). */
-  launch(spec: LaunchSpec): { launchId: number; verb: RunKind } {
-    const launchId = this.nextLaunchId++;
-    const abort = new AbortController();
-    const handle: RunHandle = { spec, abort, startedAt: new Date().toISOString(), status: "running", activity: new ActivityBus() };
-    this.runs.set(launchId, handle);
-    const onRun = (runId: number): void => {
-      handle.runId = runId;
-    };
-    const onActivity = (ev: Activity): void => handle.activity.push(ev);
-    // Promise.resolve().then(...) so a synchronous build error becomes a rejection, not a throw.
-    void Promise.resolve()
-      .then(() => this.execute(spec, abort.signal, onRun, onActivity))
-      .then(
-        (result) => {
-          handle.result = result;
-          handle.status = abort.signal.aborted ? "killed" : "done";
-        },
-        (error) => {
-          handle.status = abort.signal.aborted ? "killed" : "error";
-          handle.error = error instanceof Error ? error.message : String(error);
-          // A crash before runAudit's own finalize leaves the DB row "running"; reconcile it.
-          if (handle.runId !== undefined) this.reconcile(handle.runId, handle.status === "killed" ? "killed" : "error");
-        },
-      );
-    return { launchId, verb: spec.verb };
-  }
-
-  private execute(spec: LaunchSpec, signal: AbortSignal, onRun: (runId: number) => void, onActivity: (ev: Activity) => void): Promise<AuditRunResult | ConfirmRunResult> {
-    const cfg = specToConfig(spec, spec.out ?? this.out);
-    if (spec.verb === "confirm") {
-      if (!spec.inputRunDir) throw new Error("confirm requires inputRunDir (the finished run directory)");
-      return runConfirm(cfg, {
-        inputRunDir: spec.inputRunDir,
-        signal,
-        onRun,
-        onActivity,
-        ...(spec.maxSteps !== undefined ? { maxSteps: spec.maxSteps } : {}),
-        ...(spec.fresh ? { fresh: true } : {}),
-      });
-    }
-    return runAudit(cfg, {
-      kind: spec.verb,
-      signal,
-      onRun,
-      onActivity,
-      ...(spec.mockLlm ? { llm: new MockAuditLlmClient() } : {}),
-    });
-  }
-
-  /** The live activity bus for a run launched this session (token-level thinking/output +
-   * tool calls), or undefined for runs not in this session (use the persisted event log). */
-  activityFor(runId: number): ActivityBus | undefined {
-    for (const handle of this.runs.values()) if (handle.runId === runId) return handle.activity;
-    return undefined;
-  }
-
-  /** Request a cooperative stop of a running run (by its DB run id). */
-  stop(runId: number): boolean {
-    for (const handle of this.runs.values()) {
-      if (handle.runId === runId && handle.status === "running") {
-        handle.abort.abort();
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /** The rich library result for a run launched this session (AuditRunResult / ConfirmRunResult). */
-  resultFor(runId: number): AuditRunResult | ConfirmRunResult | undefined {
-    for (const handle of this.runs.values()) if (handle.runId === runId) return handle.result;
-    return undefined;
-  }
-
-  active(): ActiveRun[] {
-    return [...this.runs.values()]
-      .filter((handle) => handle.status === "running")
-      .map((handle) => ({ runId: handle.runId, target: handle.spec.target, verb: handle.spec.verb, startedAt: handle.startedAt }));
-  }
-
-  private reconcile(runId: number, status: RunStatus): void {
-    try {
-      this.store.finishRun(runId, status);
-    } catch {
-      // best-effort
-    }
-  }
 }
 
 // Translate a launch spec into `fsa` CLI argv — NOT used to run (the manager runs in-process),

--- a/tests/daemon-flow.test.mjs
+++ b/tests/daemon-flow.test.mjs
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { startUiServer } from "../dist/server/app.js";
+import { MetadataStore } from "../dist/db/store.js";
+
+// Execution is decoupled: the server owns the DB + a job queue and never runs an audit;
+// a daemon claims queued jobs, runs them elsewhere, and reports progress over HTTP. These
+// drive the server as BOTH the UI client (public API) and a simulated daemon (the hidden
+// /api/daemon/* protocol), pinning the whole handoff without spawning a real audit.
+
+async function withServerAndToken(fn) {
+  const out = await mkdtemp(path.join(os.tmpdir(), "fsa-daemon-"));
+  // Mint a daemon token directly in the store (the server has no token-minting endpoint;
+  // `fsa ui` mints one for its co-located daemon, an operator mints them for remote ones).
+  const minting = MetadataStore.openForOutput(out);
+  const { token } = minting.createDaemonToken("test-daemon");
+  minting.close();
+
+  const server = startUiServer({ port: 0, out, host: "127.0.0.1" });
+  await new Promise((resolve) => server.once("listening", resolve));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await fn({ base, token, out });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+const j = (r) => r.json();
+const ui = (base, method, p, body) => fetch(base + p, { method, ...(body ? { headers: { "content-type": "application/json" }, body: JSON.stringify(body) } : {}) });
+const asDaemon = (base, token, method, p, body) =>
+  fetch(base + p, { method, headers: { authorization: `Bearer ${token}`, ...(body ? { "content-type": "application/json" } : {}) }, ...(body ? { body: JSON.stringify(body) } : {}) });
+
+test("daemon: register requires a valid bearer token", async () => {
+  await withServerAndToken(async ({ base, token }) => {
+    assert.equal((await fetch(base + "/api/daemon/register", { method: "POST" })).status, 401); // no token
+    assert.equal((await asDaemon(base, "deadbeef", "POST", "/api/daemon/register")).status, 401); // wrong token
+    const ok = await asDaemon(base, token, "POST", "/api/daemon/register", { name: "d1", capabilities: {} });
+    assert.equal(ok.status, 200);
+    assert.equal((await j(ok)).ok, true);
+    // claim/run/activity/status all reject an unknown token too
+    assert.equal((await fetch(base + "/api/daemon/claim", { method: "POST" })).status, 401);
+  });
+});
+
+test("daemon: full job handoff — enqueue → claim → run start → ingest → finish", async () => {
+  await withServerAndToken(async ({ base, token }) => {
+    await asDaemon(base, token, "POST", "/api/daemon/register", { name: "d1" });
+
+    // UI creates a project and queues a run.
+    await ui(base, "POST", "/api/projects", { name: "acme", sourcePaths: ["./src"], config: { model: "m" } });
+    const launch = await j(await ui(base, "POST", "/api/projects/acme/runs", { verb: "run", mockLlm: true }));
+    assert.equal(launch.queued, true);
+    assert.equal(typeof launch.jobId, "number");
+
+    // Daemon claims the oldest queued job (FIFO), then opens a run row for it.
+    const claim = await j(await asDaemon(base, token, "POST", "/api/daemon/claim"));
+    assert.equal(claim.job.id, launch.jobId);
+    assert.equal(claim.job.project, "acme");
+    assert.equal(claim.job.spec.verb, "run");
+    assert.equal((await asDaemon(base, token, "POST", "/api/daemon/claim").then(j)).job, undefined); // queue drained
+
+    const start = await j(await asDaemon(base, token, "POST", "/api/daemon/runs", { jobId: launch.jobId, project: "acme", kind: "run", runDir: "/tmp/acme-run-1", budgets: { model: "m" } }));
+    assert.equal(typeof start.runId, "number");
+    const runId = start.runId;
+    // job ↔ run is linked (so a stop-by-run can find the job).
+    assert.equal((await j(await ui(base, "GET", `/api/runs/${runId}`))).run.status, "running");
+
+    // Daemon reports the scope inventory; the run's live coverage updates.
+    await asDaemon(base, token, "PATCH", `/api/daemon/runs/${runId}`, { scopes: [{ scopeId: "s1", title: "decode", status: "audited" }, { scopeId: "s2", title: "settle", status: "pending" }] });
+    const afterScopes = await j(await ui(base, "GET", "/api/projects/acme"));
+    assert.deepEqual(afterScopes.progress, { total: 2, audited: 1, pending: 1, deferred: 0 });
+
+    // Daemon reports findings (with a status reason for the timeline) and a confirm decision.
+    await asDaemon(base, token, "PATCH", `/api/daemon/runs/${runId}`, { findings: [{ findingKey: "f1", title: "unbound input", location: "src/x:10", status: "suspected" }], reason: "first sighting" });
+    await asDaemon(base, token, "PATCH", `/api/daemon/runs/${runId}`, { findings: [{ findingKey: "f1", title: "unbound input", location: "src/x:10", status: "confirmed-differential" }], reason: "differential passed" });
+    await asDaemon(base, token, "PATCH", `/api/daemon/runs/${runId}`, { confirmDecisions: [{ bug: "unbound input", reproduced: "yes", recommendation: "submit-candidate" }], decisionPath: "/tmp/acme-run-1/confirm_report.md" });
+
+    const findings = await j(await ui(base, "GET", "/api/projects/acme/findings"));
+    assert.equal(findings.findings.length, 1);
+    assert.equal(findings.findings[0].status, "confirmed-differential");
+    assert.deepEqual(findings.findings[0].timeline.map((e) => e.to_status), ["suspected", "confirmed-differential"]);
+    const detail = await j(await ui(base, "GET", "/api/projects/acme"));
+    assert.equal(detail.confirmedBugs, 1); // reproduced=yes surfaced as a confirmed bug
+
+    // Daemon finishes the run; status + final coverage/finding-count persist.
+    await asDaemon(base, token, "POST", `/api/daemon/jobs/${launch.jobId}/status`, { status: "done" });
+    await asDaemon(base, token, "PATCH", `/api/daemon/runs/${runId}`, { finish: { status: "done", coverage: { total: 2, audited: 2, pending: 0, deferred: 0 }, findingsTotal: 1 } });
+    const finished = await j(await ui(base, "GET", `/api/runs/${runId}`));
+    assert.equal(finished.run.status, "done");
+    assert.equal(finished.run.findings_total, 1);
+  });
+});
+
+test("daemon: activity POSTs surface on the run's live SSE log", async () => {
+  await withServerAndToken(async ({ base, token }) => {
+    await asDaemon(base, token, "POST", "/api/daemon/register", { name: "d1" });
+    await ui(base, "POST", "/api/projects", { name: "p" });
+    const { jobId } = await j(await ui(base, "POST", "/api/projects/p/runs", { verb: "run", mockLlm: true }));
+    await asDaemon(base, token, "POST", "/api/daemon/claim");
+    const { runId } = await j(await asDaemon(base, token, "POST", "/api/daemon/runs", { jobId, project: "p", kind: "run", runDir: "/tmp/p-1", budgets: {} }));
+
+    // Daemon pushes a batch of token-level activity (as the live audit would).
+    await asDaemon(base, token, "POST", `/api/daemon/runs/${runId}/activity`, { events: [{ kind: "thinking_delta", delta: "weighing the invariant" }, { kind: "step", tool: "bash", step: 1 }] });
+
+    // The public log stream replays the backlogged events (this is the daemon → bus → SSE pipe).
+    const ev = await readFirstActivity(base, runId, 2500);
+    assert.ok(ev, "expected an activity event on the SSE log");
+    assert.equal(ev.kind, "thinking_delta");
+    assert.equal(ev.delta, "weighing the invariant");
+  });
+});
+
+test("daemon: stopping a run flags its job for cancel and reconciles on the daemon's report", async () => {
+  await withServerAndToken(async ({ base, token, out }) => {
+    await asDaemon(base, token, "POST", "/api/daemon/register", { name: "d1" });
+    await ui(base, "POST", "/api/projects", { name: "p" });
+    const { jobId } = await j(await ui(base, "POST", "/api/projects/p/runs", { verb: "run", mockLlm: true }));
+    await asDaemon(base, token, "POST", "/api/daemon/claim");
+    const { runId } = await j(await asDaemon(base, token, "POST", "/api/daemon/runs", { jobId, project: "p", kind: "run", runDir: "/tmp/p-1", budgets: {} }));
+
+    // UI stops the run → the job is flagged for cancel (a connected daemon would get an SSE nudge).
+    const stop = await j(await ui(base, "POST", `/api/runs/${runId}/stop`));
+    assert.equal(stop.stopped, true);
+    const store = MetadataStore.openForOutput(out);
+    try {
+      assert.deepEqual(store.canceledJobIds(), [jobId]); // the daemon polls/streams this to abort
+    } finally {
+      store.close();
+    }
+
+    // Daemon reports the job canceled; the still-running run is reconciled to killed.
+    await asDaemon(base, token, "POST", `/api/daemon/jobs/${jobId}/status`, { status: "canceled" });
+    assert.equal((await j(await ui(base, "GET", `/api/runs/${runId}`))).run.status, "killed");
+  });
+});
+
+// Open the SSE log, return the first activity event (one with a `kind`), then abort. The
+// event is already in the bus backlog, so the first read returns it — no hang.
+async function readFirstActivity(base, runId, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${base}/api/runs/${runId}/log`, { signal: controller.signal });
+    const reader = res.body.getReader();
+    const dec = new TextDecoder();
+    let buf = "";
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+      let nl;
+      while ((nl = buf.indexOf("\n\n")) >= 0) {
+        const frame = buf.slice(0, nl);
+        buf = buf.slice(nl + 2);
+        const line = frame.split("\n").find((l) => l.startsWith("data:"));
+        if (!line) continue;
+        try {
+          const ev = JSON.parse(line.slice(5).trim());
+          if (ev && ev.kind) {
+            controller.abort();
+            return ev;
+          }
+        } catch {
+          // skip a non-JSON frame (e.g. the ": open" comment)
+        }
+      }
+    }
+  } catch {
+    // aborted at the timeout
+  } finally {
+    clearTimeout(timer);
+  }
+  return undefined;
+}


### PR DESCRIPTION
Decouple "where audits are tracked" from "where they run". The `fsa ui` server is now a pure CONTROL PLANE — it owns the SQLite store + a job queue and a self-describing REST API, but never runs an audit itself. Execution moves to one or more `fsa daemon` processes (the EXECUTION PLANE) that may live on other machines: a daemon claims queued jobs, runs runAudit/runConfirm locally (target code + provider keys stay on the daemon), and reports progress back over HTTP. The server owns the DB; the daemon never touches it.

- store: `runningJobs()`; deleteProject/deleteRun now clear FK-referencing `job` rows before deleting runs (fixes a FOREIGN KEY crash on delete).
- app.ts: replace the in-process RunManager with a ControlPlane (daemon SSE registry + per-run ActivityBus). Run launch = enqueueJob + nudge; stop = requestJobCancel + SSE cancel; the run log streams from a bus fed by daemon activity POSTs. New bearer-authenticated `/api/daemon/*` protocol (register, SSE stream, claim, run-start [links job↔run], progress PATCH, activity, job-status), hidden from the agent catalog. Harden the dispatcher so a synchronous handler throw can't crash the process; flush SSE headers on open. Drop the startup orphan-reconcile (remote runs survive a server restart).
- daemon.ts: include jobId in the RemoteTracker start payload (job↔run link).
- cli.ts: `fsa daemon --server --token`; `fsa ui` auto-spawns a co-located daemon unless `--no-daemon` (+ `--host`/`--concurrency`); `fsa db mint-token` / `fsa db daemons` to provision remote daemons.
- run-manager.ts: drop the now-dead RunManager class; keep specToConfig / buildArgs / ActivityBus / LaunchSpec.
- ui: warn when a run is queued with no daemon connected.
- tests: tests/daemon-flow.test.mjs pins the daemon protocol end-to-end (auth, claim, job↔run, ingest, activity pipe, stop→cancel reconcile).
- docs: ARCHITECTURE + README rewritten for the control/execution split.

Verified end-to-end against a live `fsa ui` + auto-spawned daemon (20 checks) and remote-token auth. 76/76 tests, types + public-surface clean.