### PR TITLE
perf: eliminate N+1 runningJobs() calls in SSE snapshot tick

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -874,11 +874,11 @@ function currentVisibleRuns(runs: Array<Record<string, unknown>>, boundary?: Rec
   });
 }
 
-function activePrepareRefreshStartedAt(store: MetadataStore, project: Record<string, unknown>, boundary?: Record<string, unknown>): string | undefined {
+function activePrepareRefreshStartedAt(store: MetadataStore, project: Record<string, unknown>, boundary?: Record<string, unknown>, jobs?: Array<Record<string, unknown>>): string | undefined {
   const projectName = stringValue(project.name);
   if (!projectName) return undefined;
   const boundaryStarted = stringValue(boundary?.started_at);
-  const job = store.runningJobs().find((entry) => {
+  const job = (jobs ?? store.runningJobs()).find((entry) => {
     if (stringValue(entry.project) !== projectName) return false;
     const spec = safeParse(entry.spec_json) as { verb?: unknown } | null;
     return spec?.verb === "prepare";
@@ -3073,13 +3073,14 @@ function summarizeDaemonCapabilities(capabilities: unknown): Record<string, unkn
 }
 
 function projectSnapshots(store: MetadataStore, options: ProjectListOptions = {}): Array<Record<string, unknown>> {
+  const runningJobs = store.runningJobs();
   const activeByTarget = new Map<string, number>();
-  for (const job of store.runningJobs()) activeByTarget.set(String(job.project), (activeByTarget.get(String(job.project)) ?? 0) + 1);
+  for (const job of runningJobs) activeByTarget.set(String(job.project), (activeByTarget.get(String(job.project)) ?? 0) + 1);
   return store.listProjects(options).map((project) => {
     const id = Number(project.id);
     const allRuns = store.listRuns(id);
     const materialBoundary = latestPrepareRun(allRuns);
-    const activePrepareRefresh = activePrepareRefreshStartedAt(store, project, materialBoundary);
+    const activePrepareRefresh = activePrepareRefreshStartedAt(store, project, materialBoundary, runningJobs);
     const currentRuns = currentVisibleRuns(allRuns, materialBoundary, activePrepareRefresh);
     const viewBoundary = materialViewBoundary(materialBoundary, activePrepareRefresh);
     const scopeBoundary = latestScopeInventoryBoundaryRun(currentRuns);


### PR DESCRIPTION
## Summary

- `projectSnapshots` called `store.runningJobs()` once per project inside the loop, on top of an existing call at the top of the function — causing N+1 redundant full-table SQLite scans per SSE tick (every 1200 ms per open browser tab).
- Pre-fetch `runningJobs` once at the top of `projectSnapshots` and pass it as an optional 4th parameter (`jobs?`) to `activePrepareRefreshStartedAt`.
- `activePrepareRefreshStartedAt` falls back to `store.runningJobs()` when `jobs` is not provided, keeping all 4 existing call sites unchanged and backward compatible.

**Result:** `store.runningJobs()` reduced from N+1 calls per tick to 1 call per tick. 5 lines changed in 1 file.

## Test plan

- [x] Start the server with multiple projects configured and open the dashboard in a browser
- [x] Verify snapshots still refresh correctly every ~1200 ms
- [x] Confirm running job status indicators still appear correctly per project
- [x] No regressions in existing call sites (project detail page, job status endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)