### PR TITLE
Clarify live activity for resumed confirm runs

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -3083,9 +3083,74 @@ function streamFromBus(res: ServerResponse, bus: ActivityBus, replay: Array<Reco
 
 function combinedRunActivity(run: Record<string, unknown>, bus: ActivityBus, limit: number): Array<Record<string, unknown>> {
   const events = [...persistedRunActivity(run, limit), ...compactLiveActivity(bus.snapshot(2000))];
-  return events
-    .sort((a, b) => String(a.ts ?? "").localeCompare(String(b.ts ?? "")))
-    .slice(-limit);
+  return dedupeRunActivity(events.sort((a, b) => String(a.ts ?? "").localeCompare(String(b.ts ?? "")))).slice(-limit);
+}
+
+function dedupeRunActivity(events: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  const seen = new Map<string, { index: number; ts: number }>();
+  for (const event of events) {
+    const key = activityDedupeKey(event);
+    if (!key) {
+      out.push(event);
+      continue;
+    }
+    const ts = activityTs(event);
+    const prior = seen.get(key.key);
+    if (prior && Math.abs(ts - prior.ts) <= key.windowMs) {
+      const existing = out[prior.index];
+      if (existing) {
+        out[prior.index] = richerActivityEvent(existing, event);
+        seen.set(key.key, { index: prior.index, ts });
+        continue;
+      }
+    }
+    seen.set(key.key, { index: out.length, ts });
+    out.push(event);
+  }
+  return out;
+}
+
+function activityDedupeKey(event: Record<string, unknown>): { key: string; windowMs: number } | undefined {
+  const kind = stringValue(event.kind);
+  if (!kind) return undefined;
+  if (kind === "audit_thinking" || kind === "audit_text") {
+    const body = normalizedActivityKey(activityBody(event));
+    return body ? { key: `${kind}:${body}`, windowMs: 30_000 } : undefined;
+  }
+  if (kind === "step") {
+    const step = numberValue(event.step);
+    const tool = stringValue(event.tool);
+    return step > 0 ? { key: `${kind}:${tool}:${step}`, windowMs: 10_000 } : undefined;
+  }
+  if (kind === "artifact") {
+    const name = stringValue(event.name);
+    const file = stringValue(event.path);
+    const id = name || file;
+    return id ? { key: `${kind}:${name}:${file}`, windowMs: 5_000 } : undefined;
+  }
+  return undefined;
+}
+
+function activityBody(event: Record<string, unknown>): string {
+  return stringValue(event.text) || stringValue(event.detail) || stringValue(event.result) || stringValue(event.delta);
+}
+
+function normalizedActivityKey(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function activityTs(event: Record<string, unknown>): number {
+  const ts = typeof event.ts === "string" ? Date.parse(event.ts) : NaN;
+  return Number.isFinite(ts) ? ts : 0;
+}
+
+function richerActivityEvent(a: Record<string, unknown>, b: Record<string, unknown>): Record<string, unknown> {
+  return activityRichness(b) > activityRichness(a) ? b : a;
+}
+
+function activityRichness(event: Record<string, unknown>): number {
+  return Object.keys(event).length * 10 + activityBody(event).length + (typeof event.text === "string" ? 50 : 0);
 }
 
 function compactLiveActivity(events: Activity[]): Array<Record<string, unknown>> {

--- a/src/server/ui/src/App.tsx
+++ b/src/server/ui/src/App.tsx
@@ -1040,6 +1040,11 @@ function payloadString(payload: Record<string, unknown>, key: string): string | 
   return typeof value === "string" && value ? value : undefined;
 }
 
+function payloadBoolean(payload: Record<string, unknown>, key: string): boolean | undefined {
+  const value = payload[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
 function writeSummary(event: ActivityRecord, verb: "Wrote" | "Edited"): { label: string; body: string } {
   const payload = eventPayload(event);
   const file = payloadString(payload, "path");
@@ -1060,6 +1065,29 @@ function eventSummary(event: ActivityRecord, fallbackBody: string): { label: str
     case "artifact": {
       const body = fallbackBody.replace(/^wrote\s+/i, "").trim();
       return { label: "Saved artifact", body: body || fallbackBody };
+    }
+    case "audit_confirm_freeze": {
+      const files = payloadNumber(payload, "files");
+      return { label: "Confirm inputs frozen", body: files !== undefined ? `${files} files fingerprinted before open-world confirmation.` : fallbackBody };
+    }
+    case "audit_confirm_resume": {
+      const settled = payloadNumber(payload, "settled");
+      return { label: "Resumed decisions", body: settled !== undefined ? `${settled} previously settled decisions carried forward.` : fallbackBody };
+    }
+    case "audit_confirm_start": {
+      const findings = payloadNumber(payload, "findings");
+      const maxSteps = payloadString(payload, "maxSteps");
+      return {
+        label: "Confirm started",
+        body: [
+          findings !== undefined ? `${findings} findings in context` : undefined,
+          maxSteps ? `${maxSteps} step budget` : undefined,
+        ].filter(Boolean).join(" · ") || fallbackBody,
+      };
+    }
+    case "audit_report_start": {
+      const findings = payloadNumber(payload, "findings");
+      return { label: "Report started", body: findings !== undefined ? `${findings} submit candidates selected for formal reports.` : fallbackBody };
     }
     case "audit_scope_progress": {
       const total = payloadNumber(payload, "total");
@@ -1106,6 +1134,46 @@ function eventSummary(event: ActivityRecord, fallbackBody: string): { label: str
         label: "Running command",
         body: [runId, purpose, command ? shortCommand(command) : undefined].filter(Boolean).join(" · ") || fallbackBody,
       };
+    }
+    case "audit_confirm_finalize":
+      return { label: "Finalizing decisions", body: "Requesting the required real-target decision sheet before finishing." };
+    case "audit_confirm_finalize_done":
+      return {
+        label: payloadBoolean(payload, "hasDecision") === false ? "Decision sheet missing" : "Decision sheet ready",
+        body: payloadBoolean(payload, "hasDecision") === false ? "The confirm run finished without a decision sheet." : "The confirm run produced its decision sheet.",
+      };
+    case "audit_confirm_equiv_skipped": {
+      const items = payloadNumber(payload, "items");
+      const maxItems = payloadNumber(payload, "maxItems");
+      return {
+        label: "Equivalence check skipped",
+        body: items !== undefined && maxItems !== undefined
+          ? `${items} decisions exceeded the automatic comparison limit of ${maxItems}.`
+          : fallbackBody,
+      };
+    }
+    case "audit_confirm_done": {
+      const rows = payloadNumber(payload, "rows");
+      const reproduced = payloadNumber(payload, "reproducedYes");
+      const submit = payloadNumber(payload, "submitCandidates");
+      return {
+        label: "Confirm finished",
+        body: [
+          rows !== undefined ? `${rows} decisions` : undefined,
+          reproduced !== undefined ? `${reproduced} reproduced` : undefined,
+          submit !== undefined ? `${submit} submit candidates` : undefined,
+        ].filter(Boolean).join(" · ") || fallbackBody,
+      };
+    }
+    case "audit_report_finalize":
+      return { label: "Finalizing reports", body: "Requesting any missing formal report files before finishing." };
+    case "audit_report_finalize_done": {
+      const reports = payloadNumber(payload, "reports");
+      return { label: "Reports ready", body: reports !== undefined ? `${reports} formal reports produced` : fallbackBody };
+    }
+    case "audit_report_done": {
+      const reports = payloadNumber(payload, "reports");
+      return { label: "Report finished", body: reports !== undefined ? `${reports} formal reports produced` : fallbackBody };
     }
     default:
       return undefined;
@@ -1250,6 +1318,28 @@ function appendFinalStreamLine(next: ActivityLine[], now: number, kind: Activity
   next[index] = { ...line, body: normalizeActivityBody(merged), time: now };
 }
 
+function activityLineDedupeBody(value: string): string {
+  return normalizeActivityBody(value).replace(/\s+/g, " ").trim();
+}
+
+function appendEventLine(next: ActivityLine[], line: ActivityLine): void {
+  const key = activityLineDedupeBody(line.body);
+  const recentIndex = [...next]
+    .reverse()
+    .findIndex((existing) =>
+      existing.kind === line.kind &&
+      existing.label === line.label &&
+      activityLineDedupeBody(existing.body) === key &&
+      Math.abs(line.time - existing.time) <= STREAM_MERGE_WINDOW_MS,
+    );
+  if (recentIndex >= 0) {
+    const index = next.length - 1 - recentIndex;
+    next[index] = { ...next[index], time: line.time, step: line.step ?? next[index].step, meta: line.meta ?? next[index].meta };
+    return;
+  }
+  next.push(line);
+}
+
 function activityEventLabel(kind: string): string {
   switch (kind) {
     case "audit_thinking":
@@ -1324,7 +1414,7 @@ function appendActivityLine(lines: ActivityLine[], event: ActivityRecord): Activ
       appendFinalStreamLine(next, now, "text", "Output", normalizedBody);
       return next.slice(-60);
     }
-    next.push({
+    appendEventLine(next, {
       id: now + next.length,
       kind: event.kind === "audit_thinking" ? "thinking" : "event",
       label: actionFailed ? "Action blocked" : action?.label ?? summary?.label ?? label,

--- a/tests/daemon-flow.test.mjs
+++ b/tests/daemon-flow.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtemp, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { startUiServer } from "../dist/server/app.js";
@@ -261,28 +261,41 @@ test("daemon: active job counts connected daemon identities, not stream connecti
 });
 
 test("daemon: JSON run log compacts token deltas for history views", async () => {
-  await withServerAndToken(async ({ base, token }) => {
+  await withServerAndToken(async ({ base, token, out }) => {
     await asDaemon(base, token, "POST", "/api/daemon/register", { name: "d1" });
     const created = await j(await ui(base, "POST", "/api/projects", { name: "p", sourcePaths: ["./src"] }));
     const { jobId } = await j(await ui(base, "POST", `/api/projects/${created.uuid}/runs`, { verb: "run", mockLlm: true }));
     await asDaemon(base, token, "POST", "/api/daemon/claim");
-    const { runId } = await j(await asDaemon(base, token, "POST", "/api/daemon/runs", { jobId, project: "p", kind: "run", runDir: "/tmp/p-1", budgets: {} }));
+    const runDir = path.join(out, "p-1");
+    await mkdir(runDir, { recursive: true });
+    const { runId } = await j(await asDaemon(base, token, "POST", "/api/daemon/runs", { jobId, project: "p", kind: "run", runDir, budgets: {} }));
+    await writeFile(path.join(runDir, "events.jsonl"), [
+      JSON.stringify({ ts: "2026-01-01T00:00:01.000Z", kind: "audit_thinking", text: "checking the invariant" }),
+      JSON.stringify({ ts: "2026-01-01T00:00:02.000Z", kind: "audit_text", text: "Confirmed candidate" }),
+      JSON.stringify({ ts: "2026-01-01T00:00:03.000Z", kind: "step", tool: "bash", step: 1 }),
+      JSON.stringify({ ts: "2026-01-01T00:00:04.000Z", kind: "artifact", name: "confirm_decision.json", path: "confirm_decision.json" }),
+      JSON.stringify({ ts: "2026-01-01T00:00:04.250Z", kind: "artifact", name: "confirm_decision.json", path: "confirm_decision.json" }),
+    ].join("\n") + "\n");
 
     await asDaemon(base, token, "POST", `/api/daemon/runs/${runId}/activity`, {
       events: [
-        { kind: "thinking_delta", delta: "checking " },
-        { kind: "thinking_delta", delta: "the invariant" },
-        { kind: "text_delta", delta: "Confirmed " },
-        { kind: "text_delta", delta: "candidate" },
-        { kind: "step", tool: "bash", step: 1 },
+        { ts: "2026-01-01T00:00:01.100Z", kind: "thinking_delta", delta: "checking " },
+        { ts: "2026-01-01T00:00:01.200Z", kind: "thinking_delta", delta: "the invariant" },
+        { ts: "2026-01-01T00:00:02.100Z", kind: "text_delta", delta: "Confirmed " },
+        { ts: "2026-01-01T00:00:02.200Z", kind: "text_delta", delta: "candidate" },
+        { ts: "2026-01-01T00:00:03.100Z", kind: "step", tool: "bash", step: 1 },
+        { ts: "2026-01-01T00:00:03.200Z", kind: "step", tool: "bash", step: 1 },
       ],
     });
 
     const body = await j(await ui(base, "GET", `/api/runs/${runId}/log?tail=50&format=json`));
     assert.equal(body.events.some((ev) => ev.kind === "thinking_delta" || ev.kind === "text_delta"), false);
+    assert.equal(body.events.filter((ev) => ev.kind === "audit_thinking").length, 1);
     assert.equal(body.events.find((ev) => ev.kind === "audit_thinking")?.detail, "checking the invariant");
+    assert.equal(body.events.filter((ev) => ev.kind === "audit_text").length, 1);
     assert.equal(body.events.find((ev) => ev.kind === "audit_text")?.detail, "Confirmed candidate");
-    assert.ok(body.events.find((ev) => ev.kind === "step"));
+    assert.equal(body.events.filter((ev) => ev.kind === "step").length, 1);
+    assert.equal(body.events.filter((ev) => ev.kind === "artifact" && ev.name === "confirm_decision.json").length, 1);
   });
 });
 


### PR DESCRIPTION
## Summary
- Deduplicate run live-activity snapshots when persisted events and live bus backlog represent the same thinking/text/step/artifact event.
- Add user-facing activity summaries for confirm resume/start/finalize/done and report start/done events.
- Extend daemon-flow coverage for persisted/live activity dedupe.

## Verification
- npm run build
- node --test tests/daemon-flow.test.mjs
- node --test tests/api.test.mjs
- npm run check:public