### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flounders",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flounders",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flounders",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Autonomous white-hat security auditor for AI-driven code review, exploit construction, and execution-grounded verification.",
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Summary
- bump package version from 0.1.0 to 0.1.1
- keep package-lock root metadata in sync

## Verification
- npm run verify
- DB upgrade gate: opened a v0.1.0-shaped SQLite store with current code and confirmed schema_version=3 plus decision metadata/report backfills
