### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flounders",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flounders",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flounders",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Autonomous white-hat security auditor for AI-driven code review, exploit construction, and execution-grounded verification.",
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Summary
- bump the package version and lockfile from 0.1.1 to 0.1.2

## Verification
- npm run verify
- npm pack --dry-run
- database upgrade smoke against a copied existing flounder.db