### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flounders",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flounders",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flounders",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Autonomous white-hat security auditor for AI-driven code review, exploit construction, and execution-grounded verification.",
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Summary
- Bump flounders package metadata from 0.1.2 to 0.1.3
- Keep the release diff limited to package.json and package-lock.json

## Verification
- npm run verify
- npm pack --dry-run
- DB upgrade smoke: opened a copied runs/flounder.db with current MetadataStore and read projects=7