### PR TITLE
Harden audit safety and submission evidence gates

### DIFF
--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -431,19 +431,160 @@ function maxSeverity(values: Array<string | undefined>): string | null {
   return best;
 }
 
-function decisionEvidenceLevel(reproduced?: string): string {
-  if (reproduced === "yes") return "real-target-reproduced";
-  if (reproduced === "no") return "not-reproduced";
-  if (reproduced === "could-not-set-up") return "could-not-set-up";
-  return "unknown";
+const EVIDENCE_LEVEL_RANK: Record<string, number> = {
+  unknown: 0,
+  "could-not-set-up": 1,
+  "not-reproduced": 1,
+  reasoned: 2,
+  "source-supported": 3,
+  "source-only-local-confirmed": 4,
+  "locally-reproduced": 4,
+  "execution-reproduced": 4,
+  "local-fork-reproduced": 5,
+  "fork-reproduced": 5,
+  "real-target-reproduced": 6,
+};
+
+const CONFIDENCE_RANK: Record<string, number> = {
+  unknown: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+};
+
+function decisionEvidenceText(row: Pick<ConfirmRow, "reproEvidence" | "humanGates" | "corroboration" | "novelty">): string {
+  return [row.reproEvidence, row.humanGates, row.corroboration, row.novelty].filter(Boolean).join("\n").toLowerCase();
 }
 
-function decisionSubmissionConfidence(reproduced?: string, recommendation?: string): string {
-  if (reproduced === "yes" && recommendation === "submit-candidate") return "high";
-  if (reproduced === "yes" && recommendation === "needs-human") return "medium";
-  if (reproduced === "yes") return "medium";
-  if (reproduced === "no" || recommendation === "drop") return "low";
-  return "unknown";
+function hasSourceOnlyReproductionCrutch(row: Pick<ConfirmRow, "reproEvidence" | "humanGates" | "corroboration" | "novelty">): boolean {
+  const text = decisionEvidenceText(row);
+  if (!text) return false;
+  return [
+    /\bsource[- ]level\b/,
+    /\bmock(?:ed|s)?\b/,
+    /\bconstrained mock/,
+    /\blocal execution\b/,
+    /\bpublished source\b/,
+    /\bverified deployed source locally\b/,
+    /\bimported (?:the )?(?:verified |published )?.*source\b/,
+    /\bforge (?:test|tests|poc|harness)\b/,
+    /\blocal (?:forge |foundry |hardhat )?harness\b/,
+    /\bharness\b.*\bnot a live\b/,
+    /\bnot a live\b/,
+    /\brather than a live\b/,
+    /\bno live\b/,
+    /\bwithout (?:a )?live\b/,
+    /\bdid not (?:complete|use|fork)\b/,
+    /\blive fork (?:was )?not completed\b/,
+    /\bexact (?:live |production |deployment )?(?:state|liveness).*not (?:confirmed|established)\b/,
+    /\bproduction (?:impact|exposure|severity|configuration).*depends\b/,
+    /\bdeployment liveness is not established\b/,
+  ].some((pattern) => pattern.test(text));
+}
+
+function hasLocalForkReproduction(row: Pick<ConfirmRow, "reproEvidence" | "humanGates" | "corroboration" | "novelty">): boolean {
+  const text = decisionEvidenceText(row);
+  return /\b(?:local |mainnet |polygon |ethereum |arbitrum |optimism |base |bsc |avalanche )?fork(?:ed)?\b/.test(text)
+    || /\bforked (?:live|mainnet|polygon|ethereum|arbitrum|optimism|base|bsc|avalanche)\b/.test(text);
+}
+
+function hasRealTargetReproduction(row: Pick<ConfirmRow, "reproEvidence" | "humanGates" | "corroboration" | "novelty">): boolean {
+  const text = decisionEvidenceText(row);
+  return /\breal[- ]target\b/.test(text)
+    || /\breal target effect\b/.test(text)
+    || /\bactual deployed (?:artifact|contract|code|state)\b/.test(text)
+    || /\bcurrent deployment\b/.test(text);
+}
+
+function inferredDecisionEvidenceLevel(row: Pick<ConfirmRow, "reproduced" | "reproEvidence" | "humanGates" | "corroboration" | "novelty">): string {
+  if (row.reproduced === "no") return "not-reproduced";
+  if (row.reproduced === "could-not-set-up") return "could-not-set-up";
+  if (row.reproduced !== "yes") return "unknown";
+  if (hasSourceOnlyReproductionCrutch(row)) return "source-only-local-confirmed";
+  if (hasLocalForkReproduction(row)) return "local-fork-reproduced";
+  if (hasRealTargetReproduction(row)) return "real-target-reproduced";
+  return "real-target-reproduced";
+}
+
+function shouldDowngradeEvidence(stored: string, inferred: string): boolean {
+  const storedRank = EVIDENCE_LEVEL_RANK[stored] ?? 0;
+  const inferredRank = EVIDENCE_LEVEL_RANK[inferred] ?? 0;
+  return inferred === "source-only-local-confirmed" && storedRank > inferredRank;
+}
+
+function decisionEvidenceLevel(row: Pick<ConfirmRow, "reproduced" | "evidenceLevel" | "reproEvidence" | "humanGates" | "corroboration" | "novelty">): string {
+  const inferred = inferredDecisionEvidenceLevel(row);
+  const explicit = row.evidenceLevel?.trim();
+  if (explicit && !shouldDowngradeEvidence(explicit, inferred)) return explicit;
+  return inferred;
+}
+
+function isRealTargetEvidenceLevel(value?: string): boolean {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  return normalized === "real-target-reproduced" || normalized === "fork-reproduced" || normalized === "local-fork-reproduced";
+}
+
+function hasUnsettledSubmissionGate(row: Pick<ConfirmRow, "humanGates">): boolean {
+  const text = String(row.humanGates ?? "").toLowerCase();
+  return /\b(?:scope|venue|eligib|bounty|live|deployment|production|current|human gate|needs?|not established|not confirmed|review)\b/.test(text);
+}
+
+function inferredDecisionSubmissionConfidence(
+  row: Pick<ConfirmRow, "reproduced" | "recommendation" | "humanGates">,
+  evidenceLevel: string,
+): string {
+  if (row.reproduced === "no" || row.recommendation === "drop") return "low";
+  if (row.reproduced === "could-not-set-up") return "low";
+  if (row.reproduced !== "yes") return "unknown";
+  const realTarget = isRealTargetEvidenceLevel(evidenceLevel);
+  if (row.recommendation === "submit-candidate") {
+    if (!realTarget) return "low";
+    return hasUnsettledSubmissionGate(row) ? "medium" : "high";
+  }
+  if (row.recommendation === "needs-human") return realTarget ? "medium" : "low";
+  return realTarget ? "medium" : "low";
+}
+
+function decisionSubmissionConfidence(
+  row: Pick<ConfirmRow, "reproduced" | "recommendation" | "submissionConfidence" | "humanGates">,
+  evidenceLevel: string,
+): string {
+  const inferred = inferredDecisionSubmissionConfidence(row, evidenceLevel);
+  const explicit = row.submissionConfidence?.trim();
+  if (!explicit) return inferred;
+  const explicitRank = CONFIDENCE_RANK[explicit] ?? 0;
+  const inferredRank = CONFIDENCE_RANK[inferred] ?? 0;
+  if (explicitRank > inferredRank && (!isRealTargetEvidenceLevel(evidenceLevel) || hasUnsettledSubmissionGate(row))) return inferred;
+  return explicit;
+}
+
+function decisionConfirmOutcome(row: Pick<ConfirmRow, "reproduced">, evidenceLevel: string): "reproduced" | "not-reproduced" | null {
+  if (row.reproduced === "yes" && isRealTargetEvidenceLevel(evidenceLevel)) return "reproduced";
+  if (row.reproduced === "no") return "not-reproduced";
+  return null;
+}
+
+function decisionEvidenceInput(row: {
+  reproduced?: string | null;
+  recommendation?: string | null;
+  evidence_level?: string | null;
+  submission_confidence?: string | null;
+  repro_evidence?: string | null;
+  human_gates?: string | null;
+  corroboration?: string | null;
+  novelty?: string | null;
+}): ConfirmRow {
+  return {
+    bug: "",
+    reproduced: row.reproduced ?? undefined,
+    recommendation: row.recommendation ?? undefined,
+    evidenceLevel: row.evidence_level ?? undefined,
+    submissionConfidence: row.submission_confidence ?? undefined,
+    reproEvidence: row.repro_evidence ?? undefined,
+    humanGates: row.human_gates ?? undefined,
+    corroboration: row.corroboration ?? undefined,
+    novelty: row.novelty ?? undefined,
+  };
 }
 
 export class MetadataStore {
@@ -544,14 +685,30 @@ export class MetadataStore {
 
   private reconcileConfirmStatuses(): void {
     const rows = this.db
-      .prepare("SELECT project_id, reproduced, members_json FROM confirm_decision WHERE reproduced IN ('yes','no') AND members_json IS NOT NULL")
-      .all() as Array<{ project_id: number; reproduced: string; members_json: string }>;
+      .prepare(
+        `SELECT project_id, reproduced, members_json, evidence_level, repro_evidence, human_gates,
+                corroboration, novelty
+           FROM confirm_decision
+          WHERE reproduced IN ('yes','no') AND members_json IS NOT NULL`,
+      )
+      .all() as Array<{
+        project_id: number;
+        reproduced: string | null;
+        members_json: string;
+        evidence_level: string | null;
+        repro_evidence: string | null;
+        human_gates: string | null;
+        corroboration: string | null;
+        novelty: string | null;
+      }>;
     if (rows.length === 0) return;
     const update = this.db.prepare("UPDATE finding SET confirm_status = ? WHERE project_id = ? AND finding_key = ? AND confirm_status IS NULL");
     for (const row of rows) {
       const members = jsonParseOrNull(row.members_json);
       if (!Array.isArray(members)) continue;
-      const outcome = row.reproduced === "yes" ? "reproduced" : "not-reproduced";
+      const evidenceLevel = decisionEvidenceLevel(decisionEvidenceInput(row));
+      const outcome = decisionConfirmOutcome({ reproduced: row.reproduced ?? undefined }, evidenceLevel);
+      if (!outcome) continue;
       for (const member of members) {
         if (typeof member !== "string") continue;
         for (const key of confirmMemberKeys(member)) update.run(outcome, row.project_id, key);
@@ -571,7 +728,8 @@ export class MetadataStore {
     const rows = this.db
       .prepare(
         `SELECT id, project_id, reproduced, recommendation, members_json, severity,
-                evidence_level, submission_confidence
+                evidence_level, submission_confidence, repro_evidence, corroboration,
+                novelty, human_gates
            FROM confirm_decision`,
       )
       .all() as Array<{
@@ -583,6 +741,10 @@ export class MetadataStore {
         severity: string | null;
         evidence_level: string | null;
         submission_confidence: string | null;
+        repro_evidence: string | null;
+        corroboration: string | null;
+        novelty: string | null;
+        human_gates: string | null;
       }>;
     if (rows.length === 0) return;
 
@@ -603,18 +765,20 @@ export class MetadataStore {
 
     const update = this.db.prepare(
       `UPDATE confirm_decision
-          SET severity = COALESCE(NULLIF(severity, ''), ?),
-              evidence_level = COALESCE(NULLIF(evidence_level, ''), ?),
-              submission_confidence = COALESCE(NULLIF(submission_confidence, ''), ?)
+          SET severity = ?,
+              evidence_level = ?,
+              submission_confidence = ?
         WHERE id = ?`,
     );
     for (const row of rows) {
       const members = parseJsonArray(row.members_json).filter((member): member is string => typeof member === "string");
       const linked = linkedFindingMetadata(findingsByProject.get(row.project_id), members);
+      const input = decisionEvidenceInput(row);
+      const evidenceLevel = decisionEvidenceLevel(input);
       update.run(
-        row.severity?.trim() ? null : maxSeverity(linked.map((entry) => entry.severity)),
-        row.evidence_level?.trim() ? null : decisionEvidenceLevel(row.reproduced ?? undefined),
-        row.submission_confidence?.trim() ? null : decisionSubmissionConfidence(row.reproduced ?? undefined, row.recommendation ?? undefined),
+        row.severity?.trim() || maxSeverity(linked.map((entry) => entry.severity)),
+        evidenceLevel,
+        decisionSubmissionConfidence(input, evidenceLevel),
         row.id,
       );
     }
@@ -1499,6 +1663,8 @@ export class MetadataStore {
       }
       for (const r of rows) {
         const linked = linkedFindingMetadata(findingsByKey, r.members ?? []);
+        const evidenceLevel = decisionEvidenceLevel(r);
+        const submissionConfidence = decisionSubmissionConfidence(r, evidenceLevel);
         stmt.run(
           projectId,
           runId,
@@ -1507,8 +1673,8 @@ export class MetadataStore {
           r.recommendation ?? null,
           jsonOrNull(r.members),
           r.severity ?? maxSeverity(linked.map((entry) => entry.severity)),
-          r.evidenceLevel ?? decisionEvidenceLevel(r.reproduced),
-          r.submissionConfidence ?? decisionSubmissionConfidence(r.reproduced, r.recommendation),
+          evidenceLevel,
+          submissionConfidence,
           r.distinctFix ?? null,
           r.reproEvidence ?? null,
           r.corroboration ?? null,
@@ -1520,7 +1686,7 @@ export class MetadataStore {
           r.decisionPath ?? decisionPath ?? null,
           ts,
         );
-        const outcome = r.reproduced === "yes" ? "reproduced" : r.reproduced === "no" ? "not-reproduced" : null;
+        const outcome = decisionConfirmOutcome(r, evidenceLevel);
         for (const member of r.members ?? []) {
           for (const key of confirmMemberKeys(member)) {
             if (outcome) setConfirm.run(outcome, projectId, key);

--- a/src/security/policy.ts
+++ b/src/security/policy.ts
@@ -151,6 +151,8 @@ export function analyzeConfirmBashCommandSafety(command: StructuredReproductionC
   }
   const workspaceDecision = analyzeWorkspacePathSafety(args);
   if (workspaceDecision.blocked) return workspaceDecision;
+  const destructiveDecision = analyzeDestructiveFilesystemCommandSafety(program, args);
+  if (destructiveDecision.blocked) return destructiveDecision;
   const rendered = [program, ...args].join(" ");
   const broadcast = findMatch(rendered, CONFIRM_BROADCAST_PATTERNS);
   if (broadcast && targetsNonLocalNetwork(args)) {
@@ -202,6 +204,8 @@ function analyzeStructuredCommandBaseSafety(command: StructuredReproductionComma
       reason: "Blocked by flounder guardrail: reproduction command arguments must be simple argv entries.",
     };
   }
+  const destructiveDecision = analyzeDestructiveFilesystemCommandSafety(program, args);
+  if (destructiveDecision.blocked) return destructiveDecision;
 
   return { blocked: false };
 }
@@ -217,6 +221,30 @@ function analyzeWorkspacePathSafety(args: string[]): CommandSafetyDecision {
       };
     }
   }
+  return { blocked: false };
+}
+
+function analyzeDestructiveFilesystemCommandSafety(program: string, args: string[]): CommandSafetyDecision {
+  const name = program.toLowerCase();
+  const lower = args.map((arg) => arg.toLowerCase());
+  const block = (matchedAction: string): CommandSafetyDecision => ({
+    blocked: true,
+    reason: "Blocked by flounder guardrail: destructive filesystem commands are not allowed in agent bash.",
+    matchedAction,
+  });
+
+  if (["rm", "rmdir", "unlink", "shred"].includes(name)) return block(name);
+  if (name === "find" && lower.some((arg) => ["-delete", "-exec", "-execdir", "-ok", "-okdir"].includes(arg))) {
+    return block("find");
+  }
+  if (name === "sed" && lower.some((arg) => arg === "-i" || arg.startsWith("-i.") || arg === "--in-place" || arg.startsWith("--in-place="))) {
+    return block("sed");
+  }
+  if (name === "git") {
+    if (lower.includes("clean")) return block("git clean");
+    if (lower.includes("reset") && lower.includes("--hard")) return block("git reset --hard");
+  }
+
   return { blocked: false };
 }
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1460,7 +1460,7 @@ function readPrepareSummary(run: Record<string, unknown>): Record<string, unknow
 
   const posture = stringValue(manifest?.posture);
   const answerFirewall = describeAnswerFirewall(manifest?.answer_firewall, posture);
-  if (answerFirewall !== "clean" && answerFirewall !== "not reported" && !answerFirewall.startsWith("clean ")) {
+  if (!isNonBlockingAnswerFirewall(answerFirewall)) {
     issues.push(`answer firewall is ${answerFirewall}`);
   }
   const realTarget = summarizePrepareRealTarget(manifest?.real_target ?? manifest?.realTarget);
@@ -1546,13 +1546,16 @@ function prepareSummaryQuality(input: {
 
 function isBlockingPrepareIssue(issue: string): boolean {
   const raw = issue.toLowerCase();
+  if (raw.includes("answer firewall is")) {
+    const firewall = issue.replace(/^.*?\banswer firewall is\b/i, "").trim();
+    return !isNonBlockingAnswerFirewall(firewall);
+  }
   return raw.includes("prepare_manifest.json has not been written")
     || raw.includes("prepare_manifest.json could not be parsed")
     || raw.includes("prepare_manifest.json is not a json object")
     || raw.includes("manifest lists no components")
     || raw.includes("prepared workspace is empty")
-    || raw.includes("prepare run ended with status")
-    || raw.includes("answer firewall is");
+    || raw.includes("prepare run ended with status");
 }
 
 function summarizePrepareComponent(component: Record<string, unknown>): Record<string, unknown> {
@@ -1855,13 +1858,33 @@ function describeAnswerFirewall(value: unknown, posture = ""): string {
   return "not reported";
 }
 
+function isNonBlockingAnswerFirewall(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed || trimmed === "not reported") return true;
+  return isCleanFirewallNote(trimmed);
+}
+
 function isCleanFirewallNote(text: string): boolean {
   const lower = text.toLowerCase();
+  if (lower === "clean" || lower.startsWith("clean ")) return true;
+  if (hasUnnegatedAnswerFirewallInclusion(lower)) return false;
   if (lower.includes("blind")) return true;
-  if (lower.includes("included")) return false;
-  if ((lower.includes("not fetched") || lower.includes("not staged") || lower.includes("skipped") || lower.includes("excluded")) && !lower.includes("included")) return true;
-  if ((lower.includes("no material") || lower.includes("no vulnerability") || lower.includes("not copied") || lower.includes("removed")) && !lower.includes("included")) return true;
-  return lower === "clean" || lower.startsWith("clean ");
+  if (/(^|[.;:]\s*)(no|not|never|without)\b[^.;:]*(material|vulnerability|exploit|poc|proof|incident|post-mortem|bug writeup|opened|staged|fetched|copied|included)/.test(lower)) return true;
+  if (lower.includes("not fetched") || lower.includes("not staged") || lower.includes("not copied")) return true;
+  if (lower.includes("skipped") || lower.includes("excluded") || lower.includes("removed")) return true;
+  return false;
+}
+
+function hasUnnegatedAnswerFirewallInclusion(lower: string): boolean {
+  return lower
+    .split(/[.;]\s*/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .some((part) => {
+      if (!part.includes("included")) return false;
+      return !/\b(no|not|never|without)\b[^.;:]*\bincluded\b/.test(part)
+        && !/\bincluded\b[^.;:]*\b(no|not|never|without)\b/.test(part);
+    });
 }
 
 function summarizePrepareGaps(value: unknown): string[] {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1837,6 +1837,10 @@ function describeAnswerFirewall(value: unknown, posture = ""): string {
   if (typeof value === "string" && value.trim()) {
     const text = value.trim();
     if (text.toLowerCase() === "clean") return "clean";
+    const notes = splitAnswerFirewallNotes(text);
+    if (notes.length > 1 && notes.every(isCleanFirewallNote)) {
+      return `clean · ${notes.length} guardrail note${notes.length === 1 ? "" : "s"}`;
+    }
     return isCleanFirewallNote(text) ? `clean · ${text}` : text;
   }
   if (Array.isArray(value)) {
@@ -1856,6 +1860,10 @@ function describeAnswerFirewall(value: unknown, posture = ""): string {
   }
   if (posture.trim().toLowerCase() === "blind") return "clean · blind posture";
   return "not reported";
+}
+
+function splitAnswerFirewallNotes(text: string): string[] {
+  return text.split(";").map((part) => part.trim()).filter(Boolean);
 }
 
 function isNonBlockingAnswerFirewall(text: string): boolean {
@@ -2337,11 +2345,11 @@ function decisionReportWorklist(
     const missing = [...selected].filter((id) => !selectedCovered.has(id));
     if (missing.length > 0) {
       const unknown = missing.filter((id) => !findingsById.has(id));
-      const suffix = unknown.length > 0 ? " is not a current finding for this project" : " is not linked to a reproduced, non-dropped real-target decision";
+      const suffix = unknown.length > 0 ? " is not a current finding for this project" : " is not linked to a reproduced, non-dropped decision";
       return { error: `finding ${missing.join(", ")}${suffix}` };
     }
   }
-  if (decisions.length === 0) return { error: "no reproduced real-target decisions are missing submission reports" };
+  if (decisions.length === 0) return { error: "no reproduced decisions are missing submission reports" };
 
   return {
     findings: decisions.map((decision) => {
@@ -2349,14 +2357,15 @@ function decisionReportWorklist(
       const primary = linkedFindings[0];
       const decisionId = Number(decision.id);
       const severity = stringValue(decision.severity) || maxSeverityFromRows(linkedFindings) || undefined;
+      const evidenceLevel = stringValue(decision.evidence_level) || "unknown";
       return {
         unit: "decision",
         decisionId,
         findingId: primary ? Number(primary.id) : undefined,
         findingKey: `decision-${decisionId}`,
         reportKey: `decision-${decisionId}`,
-        evidenceMode: "real-target-reproduced",
-        evidenceLevel: stringValue(decision.evidence_level) || "real-target-reproduced",
+        evidenceMode: isRealTargetDecisionEvidence(evidenceLevel) ? "real-target-reproduced" : "source-only-local-confirmed",
+        evidenceLevel,
         submissionConfidence: stringValue(decision.submission_confidence) || undefined,
         title: stringValue(decision.bug),
         location: primary ? stringValue(primary.location) || undefined : undefined,
@@ -2387,6 +2396,11 @@ function decisionLinkedFindingRows(decision: Record<string, unknown>, findingsBy
     out.push(row);
   }
   return out;
+}
+
+function isRealTargetDecisionEvidence(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return normalized === "real-target-reproduced" || normalized === "fork-reproduced" || normalized === "local-fork-reproduced";
 }
 
 function maxSeverityFromRows(rows: Array<Record<string, unknown>>): string | undefined {
@@ -2799,9 +2813,10 @@ function renderDecisionReportMarkdown(decision: Record<string, unknown>, linkedF
     "",
   ];
 
+  const confirmationNoun = isRealTargetDecisionEvidence(evidenceLevel) ? "real-target confirmation run" : "confirmation run";
   const summary = descriptions[0]
     || (evidence ? evidence.split(/\n\s*\n/)[0] : "")
-    || `A real-target confirmation run evaluated "${title}" and recorded reproduction status "${reproduced}" with recommendation "${recommendation}".`;
+    || `A ${confirmationNoun} evaluated "${title}" and recorded reproduction status "${reproduced}" with recommendation "${recommendation}".`;
   pushReportSection(lines, "Summary", summary);
   pushReportBullets(lines, "Evidence Basis", [
     `Reproduction status: ${reproduced}`,

--- a/src/server/ui/src/App.tsx
+++ b/src/server/ui/src/App.tsx
@@ -3005,10 +3005,33 @@ function compactText(value: string, max = 120): string {
 }
 
 function isCleanFirewallIssue(value: string): boolean {
-  const text = value.toLowerCase();
-  return text.includes("no material whose purpose")
-    && text.includes("vulnerability")
-    && text.includes("no vulnerability mechanism");
+  const text = value
+    .replace(/^.*?\banswer firewall is\b/i, "")
+    .trim()
+    .toLowerCase();
+  if (!text) return false;
+  if (text === "clean" || text.startsWith("clean ")) return true;
+  if (hasUnnegatedFirewallInclusion(text)) return false;
+  if (text.includes("blind")) return true;
+  if (/(^|[.;:]\s*)(no|not|never|without)\b[^.;:]*(material|vulnerability|exploit|poc|proof|incident|post-mortem|bug writeup|opened|staged|fetched|copied|included)/.test(text)) return true;
+  return text.includes("not fetched")
+    || text.includes("not staged")
+    || text.includes("not copied")
+    || text.includes("skipped")
+    || text.includes("excluded")
+    || text.includes("removed");
+}
+
+function hasUnnegatedFirewallInclusion(text: string): boolean {
+  return text
+    .split(/[.;]\s*/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .some((part) => {
+      if (!part.includes("included")) return false;
+      return !/\b(no|not|never|without)\b[^.;:]*\bincluded\b/.test(part)
+        && !/\bincluded\b[^.;:]*\b(no|not|never|without)\b/.test(part);
+    });
 }
 
 function prepareIssueBuckets(summary: PrepareSummary): { blockingIssues: string[]; caveats: string[] } {

--- a/src/server/ui/src/domain.ts
+++ b/src/server/ui/src/domain.ts
@@ -138,6 +138,7 @@ const DECISION_EVIDENCE_RANK: Record<string, number> = {
   "local-fork-reproduced": 4,
   "execution-reproduced": 3,
   "locally-reproduced": 3,
+  "source-only-local-confirmed": 3,
   "source-supported": 2,
   "reasoned": 1,
 };
@@ -149,9 +150,11 @@ function rankToken(value?: string | null): string {
 function confirmDecisionPriority(decision: ConfirmDecision): number {
   const recommendation = rankToken(decision.recommendation);
   const reproduced = rankToken(decision.reproduced);
+  const evidenceLevel = rankToken(decision.evidence_level);
+  const realTargetEvidence = evidenceLevel === "real-target-reproduced" || evidenceLevel === "fork-reproduced" || evidenceLevel === "local-fork-reproduced";
   const group = recommendation === "drop"
     ? 0
-    : reproduced === "yes" && recommendation === "submit-candidate"
+    : reproduced === "yes" && recommendation === "submit-candidate" && realTargetEvidence
       ? 5
       : reproduced === "yes"
         ? 4

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -2321,6 +2321,71 @@ test("api: clean prepare firewall notes and optional material gaps do not block 
   });
 });
 
+test("api: clean answer-firewall exclusion notes with negated included wording do not block audits", async () => {
+  await withServer(async (base, out) => {
+    const json = (r) => r.json();
+    const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+
+    const created = await json(await post("/api/projects", { name: "reserve-style-clean-firewall" }));
+    const runDir = path.join(out, "reserve-style-clean-firewall-prepare");
+    const workspace = path.join(runDir, "prepare", "workspace");
+    await mkdir(path.join(workspace, "sources", "reserve"), { recursive: true });
+    await writeFile(path.join(workspace, "sources", "reserve", "README.md"), "official staged source\n");
+    await writeFile(
+      path.join(workspace, "prepare_manifest.json"),
+      JSON.stringify({
+        status: "partial",
+        posture: "blind",
+        scope_declaration: "Public bounty target source and official materials only.",
+        answer_firewall: [
+          "Blind posture honored: no third-party exploit PoCs or target-specific bug writeups were opened or staged.",
+          "A generic Immunefi writeups-list search result appeared but was not fetched.",
+          "No vulnerability hypotheses, exploit mechanisms, or security conclusions are included.",
+        ],
+        real_target: {
+          requires_confirmation: false,
+          mode: "source-only",
+          reason: "Fixture keeps real-target confirmation out of scope.",
+          ground_truth: [],
+          confirm_guidance: {
+            required: false,
+            allowed_network_actions: "none",
+            recommended_method: "Run local source-level checks against staged source.",
+            not_required_reason: "No deployed target is in scope for this fixture.",
+          },
+        },
+        components: [
+          {
+            identity: "reserve/source",
+            platform: "github",
+            revision: "abc123",
+            source: "https://example.invalid/reserve.git",
+            staged_path: "sources/reserve",
+            in_scope: true,
+            match: "n/a",
+          },
+        ],
+      }),
+    );
+
+    const store = MetadataStore.openForOutput(out);
+    try {
+      const runId = store.startRun({ projectId: created.id, kind: "prepare", runDir, provider: "openai-codex", model: "gpt-5.5" });
+      store.finishRun(runId, "done");
+    } finally {
+      store.close();
+    }
+
+    const detail = await json(await fetch(base + `/api/projects/${created.uuid}`));
+    assert.equal(detail.prepareSummary.quality, "limited");
+    assert.equal(detail.prepareSummary.auditReady, true);
+    assert.equal(detail.prepareSummary.blocked, false);
+    assert.deepEqual(detail.prepareSummary.blockingIssues, []);
+    assert.deepEqual(detail.prepareSummary.issues, []);
+    assert.equal(detail.prepareSummary.answerFirewall, "clean · 3 guardrail notes");
+  });
+});
+
 test("api: blind prepare manifests get a clean answer-firewall fallback", async () => {
   await withServer(async (base, out) => {
     const json = (r) => r.json();

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -2386,6 +2386,70 @@ test("api: clean answer-firewall exclusion notes with negated included wording d
   });
 });
 
+test("api: semicolon-joined clean answer-firewall notes do not block audits", async () => {
+  await withServer(async (base, out) => {
+    const json = (r) => r.json();
+    const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+
+    const created = await json(await post("/api/projects", { name: "reserve-style-clean-firewall-string" }));
+    const runDir = path.join(out, "reserve-style-clean-firewall-string-prepare");
+    const workspace = path.join(runDir, "prepare", "workspace");
+    await mkdir(path.join(workspace, "sources", "reserve"), { recursive: true });
+    await writeFile(path.join(workspace, "sources", "reserve", "README.md"), "official staged source\n");
+    await writeFile(
+      path.join(workspace, "prepare_manifest.json"),
+      JSON.stringify({
+        status: "partial",
+        posture: "blind",
+        scope_declaration: "Public bounty target source and official materials only.",
+        answer_firewall:
+          "Blind posture honored: no third-party exploit PoCs or target-specific bug writeups were opened or staged.; " +
+          "A generic Immunefi writeups-list search result appeared but was not fetched.; " +
+          "No vulnerability hypotheses, exploit mechanisms, or security conclusions are included.",
+        real_target: {
+          requires_confirmation: false,
+          mode: "source-only",
+          reason: "Fixture keeps real-target confirmation out of scope.",
+          ground_truth: [],
+          confirm_guidance: {
+            required: false,
+            allowed_network_actions: "none",
+            recommended_method: "Run local source-level checks against staged source.",
+            not_required_reason: "No deployed target is in scope for this fixture.",
+          },
+        },
+        components: [
+          {
+            identity: "reserve/source",
+            platform: "github",
+            revision: "abc123",
+            source: "https://example.invalid/reserve.git",
+            staged_path: "sources/reserve",
+            in_scope: true,
+            match: "n/a",
+          },
+        ],
+      }),
+    );
+
+    const store = MetadataStore.openForOutput(out);
+    try {
+      const runId = store.startRun({ projectId: created.id, kind: "prepare", runDir, provider: "openai-codex", model: "gpt-5.5" });
+      store.finishRun(runId, "done");
+    } finally {
+      store.close();
+    }
+
+    const detail = await json(await fetch(base + `/api/projects/${created.uuid}`));
+    assert.equal(detail.prepareSummary.quality, "limited");
+    assert.equal(detail.prepareSummary.auditReady, true);
+    assert.equal(detail.prepareSummary.blocked, false);
+    assert.deepEqual(detail.prepareSummary.blockingIssues, []);
+    assert.deepEqual(detail.prepareSummary.issues, []);
+    assert.equal(detail.prepareSummary.answerFirewall, "clean · 3 guardrail notes");
+  });
+});
+
 test("api: blind prepare manifests get a clean answer-firewall fallback", async () => {
   await withServer(async (base, out) => {
     const json = (r) => r.json();

--- a/tests/db-store.test.mjs
+++ b/tests/db-store.test.mjs
@@ -460,7 +460,39 @@ test("store: confirm decisions persist decision reports without overwriting link
   assert.equal(decision.human_gates, "venue scope still needs human review");
   assert.equal(decision.severity, "high");
   assert.equal(decision.evidence_level, "real-target-reproduced");
-  assert.equal(decision.submission_confidence, "high");
+  assert.equal(decision.submission_confidence, "medium");
   assert.match(decision.report_markdown, /^# Missing verifier binding/);
+  db.close();
+});
+
+test("store: source-level confirm evidence is not promoted to real-target submission confidence", async () => {
+  const db = await tempDb();
+  const projectId = db.upsertProject({ name: "p" });
+  const auditRun = db.startRun({ projectId, kind: "run", runDir: "/runs/p-audit-1" });
+  db.upsertFindings(projectId, auditRun, [
+    {
+      findingKey: "ksourceonly",
+      title: "Mock-backed source reproduction",
+      severity: "high",
+      status: "confirmed-executable",
+    },
+  ]);
+  const confirmRun = db.startRun({ projectId, kind: "confirm", runDir: "/runs/p-confirm-1" });
+  db.upsertConfirmDecisions(projectId, confirmRun, [
+    {
+      bug: "Mock-backed source reproduction",
+      reproduced: "yes",
+      recommendation: "submit-candidate",
+      members: ["ksourceonly"],
+      reproEvidence: "Forge harness used published source and constrained mocks; this was source-level execution, not a live fork.",
+      humanGates: "Needs current deployment review and bounty eligibility confirmation.",
+    },
+  ]);
+
+  const [decision] = db.listConfirmDecisions(projectId);
+  assert.equal(decision.evidence_level, "source-only-local-confirmed");
+  assert.equal(decision.submission_confidence, "low");
+  const [finding] = db.listFindings(projectId);
+  assert.equal(finding.confirm_status, null);
   db.close();
 });

--- a/tests/security-policy.test.mjs
+++ b/tests/security-policy.test.mjs
@@ -53,6 +53,22 @@ test("arbitrary non-build, non-test, non-inspection commands stay blocked", () =
   assert.equal(analyzeAgentBashCommandSafety(cmd("python3", "-c", "print('unchecked script')")).blocked, true);
 });
 
+test("destructive filesystem commands stay blocked even in network-enabled confirm mode", () => {
+  for (const c of [
+    cmd("rm", "-rf", "sources/reserve-protocol-protocol/sources"),
+    cmd("rmdir", "sources/tmp"),
+    cmd("find", "sources", "-delete"),
+    cmd("find", "sources", "-exec", "rm", "-rf", "{}", ";"),
+    cmd("sed", "-i", "s/a/b/g", "contracts/Target.sol"),
+    cmd("git", "-C", "sources/repo", "clean", "-fdx"),
+    cmd("git", "-C", "sources/repo", "reset", "--hard"),
+  ]) {
+    const decision = analyzeConfirmBashCommandSafety(c);
+    assert.equal(decision.blocked, true, `${c.program} ${c.args.join(" ")} must be blocked`);
+    assert.match(decision.reason, /destructive filesystem/i);
+  }
+});
+
 test("agent bash allows readonly tool discovery, version, and local JSON inspection", () => {
   for (const c of [
     cmd("which", "nargo"),

--- a/tests/ui-source-state.test.mjs
+++ b/tests/ui-source-state.test.mjs
@@ -96,10 +96,12 @@ test("ui: real-target decisions rank by submit readiness, severity, and confiden
     { id: 3, bug: "critical submit", reproduced: "yes", recommendation: "submit-candidate", severity: "critical", submission_confidence: "medium", evidence_level: "fork-reproduced" },
     { id: 4, bug: "high non-submit reproduced", reproduced: "yes", recommendation: "needs-human", severity: "high", submission_confidence: "high", evidence_level: "fork-reproduced" },
     { id: 5, bug: "critical drop", reproduced: "yes", recommendation: "drop", severity: "critical", submission_confidence: "high", evidence_level: "fork-reproduced" },
+    { id: 6, bug: "source-only submit", reproduced: "yes", recommendation: "submit-candidate", severity: "critical", submission_confidence: "low", evidence_level: "source-only-local-confirmed" },
   ]).map((decision) => decision.bug);
   assert.deepEqual(ordered, [
     "critical submit",
     "medium submit",
+    "source-only submit",
     "high non-submit reproduced",
     "critical human gate",
     "critical drop",


### PR DESCRIPTION
## Summary
- block destructive filesystem commands in agent bash, including confirm-mode command checks
- keep clean answer-firewall notes from blocking prepared audits, including semicolon-joined guardrail strings
- distinguish source-only/local-harness confirmation from real-target or fork reproduction when deriving submission readiness and reports

## Tests
- npm test -- tests/api.test.mjs tests/db-store.test.mjs tests/ui-source-state.test.mjs tests/security-policy.test.mjs
