### PR TITLE
Gate reports on submission readiness

### DIFF
--- a/src/agent/confirm.ts
+++ b/src/agent/confirm.ts
@@ -8,6 +8,7 @@ import { writeLastRunPointer } from "../trace/last-run.js";
 import { RunLogger } from "../trace/logger.js";
 import type { Doc } from "../types.js";
 import { publicPath } from "../util/paths.js";
+import { enforceSubmissionReadiness } from "../util/submission-readiness.js";
 import { consolidateByFixEquivalence, type FixEquivEdge, type FixEquivItem } from "./consolidate.js";
 import { RunRecorder, type RunTrackerFactory } from "../db/record.js";
 import { findingContentKey } from "../util/finding-key.js";
@@ -567,13 +568,7 @@ type ConfirmDecisionLike = {
 };
 
 export function enforceBountySubmitReadiness<T extends ConfirmDecisionLike>(rows: T[], options: { impactInventory?: unknown } = {}): T[] {
-  return rows.map((row) => {
-    if (row.recommendation !== "submit-candidate") return row;
-    const blocker = bountySubmitBlocker(row, options.impactInventory);
-    if (!blocker) return row;
-    const humanGates = appendHumanGate(row.humanGates, `Framework blocked submit-candidate: ${blocker}`);
-    return { ...row, recommendation: "needs-human", humanGates } as T;
-  });
+  return enforceSubmissionReadiness(rows, { impactInventory: options.impactInventory, requireImpactInventory: true });
 }
 
 function bountySubmitBlocker(row: ConfirmDecisionLike, impactInventory: unknown): string | undefined {

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -14,6 +14,7 @@ import { createRequire } from "node:module";
 import { randomBytes, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { enforceSubmissionReadiness } from "../util/submission-readiness.js";
 
 // A static `import ... from "node:sqlite"` emits the builtin's ExperimentalWarning at link
 // time, before sqlite-quiet's body can install the filter. Loading it via require() during
@@ -767,7 +768,7 @@ export class MetadataStore {
       .prepare(
         `SELECT id, project_id, reproduced, recommendation, members_json, severity,
                 evidence_level, submission_confidence, repro_evidence, corroboration,
-                novelty, human_gates
+                novelty, human_gates, engagement_profile_json, adjudication_json
            FROM confirm_decision`,
       )
       .all() as Array<{
@@ -783,6 +784,8 @@ export class MetadataStore {
         corroboration: string | null;
         novelty: string | null;
         human_gates: string | null;
+        engagement_profile_json: string | null;
+        adjudication_json: string | null;
       }>;
     if (rows.length === 0) return;
 
@@ -803,7 +806,9 @@ export class MetadataStore {
 
     const update = this.db.prepare(
       `UPDATE confirm_decision
-          SET severity = ?,
+          SET recommendation = ?,
+              human_gates = ?,
+              severity = ?,
               evidence_level = ?,
               submission_confidence = ?
         WHERE id = ?`,
@@ -812,11 +817,14 @@ export class MetadataStore {
       const members = parseJsonArray(row.members_json).filter((member): member is string => typeof member === "string");
       const linked = linkedFindingMetadata(findingsByProject.get(row.project_id), members);
       const input = decisionEvidenceInput(row);
-      const evidenceLevel = decisionEvidenceLevel(input);
+      const enforced = enforceSubmissionReadiness([input], { requireImpactInventory: false })[0] ?? input;
+      const evidenceLevel = decisionEvidenceLevel(enforced);
       update.run(
+        enforced.recommendation ?? row.recommendation,
+        enforced.humanGates ?? row.human_gates,
         row.severity?.trim() || maxSeverity(linked.map((entry) => entry.severity)),
         evidenceLevel,
-        decisionSubmissionConfidence(input, evidenceLevel),
+        decisionSubmissionConfidence(enforced, evidenceLevel),
         row.id,
       );
     }
@@ -1678,6 +1686,7 @@ export class MetadataStore {
 
   upsertConfirmDecisions(projectId: number, runId: number, rows: ConfirmRow[], decisionPath?: string): void {
     this.transaction(() => {
+      const readyRows = enforceSubmissionReadiness(rows, { requireImpactInventory: false });
       // a confirm run's decision sheet is rewritten wholesale, so replace its rows
       this.db.prepare("DELETE FROM confirm_decision WHERE run_id = ?").run(runId);
       const stmt = this.db.prepare(
@@ -1700,7 +1709,7 @@ export class MetadataStore {
         if (row.severity) metadata.severity = row.severity;
         findingsByKey.set(row.finding_key.toLowerCase(), metadata);
       }
-      for (const r of rows) {
+      for (const r of readyRows) {
         const linked = linkedFindingMetadata(findingsByKey, r.members ?? []);
         const evidenceLevel = decisionEvidenceLevel(r);
         const submissionConfidence = decisionSubmissionConfidence(r, evidenceLevel);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -27,6 +27,7 @@ import { projectHistoryDir } from "../trace/history.js";
 import { loadScopeInventory, saveScopeInventory } from "../agent/scope-store.js";
 import { deriveScopeNote } from "../scope-note.js";
 import { confirmSelectorsForFinding } from "../util/confirm-selector.js";
+import { isResumeSettledDecision, isSubmissionReadyDecision, needsSubmissionReadinessWork } from "../util/submission-readiness.js";
 
 const UI_HTML_PATH = fileURLToPath(new URL("./public/index.html", import.meta.url));
 const UI_PUBLIC_DIR = path.dirname(UI_HTML_PATH);
@@ -1027,7 +1028,7 @@ function isSettledConfirmDecision(row: Record<string, unknown>): boolean {
 }
 
 function confirmSettledRows(rows: Array<Record<string, unknown>>): ConfirmSettledRow[] {
-  return rows.filter(isSettledConfirmDecision).map((row) => {
+  return rows.filter((row) => isResumeSettledDecision(row)).map((row) => {
     const reproduced = row.reproduced === "yes" || row.reproduced === "no" ? row.reproduced : "unknown";
     const recommendationRaw = stringValue(row.recommendation);
     const recommendation: ConfirmSettledRow["recommendation"] =
@@ -2336,7 +2337,8 @@ function decisionReportWorklist(
   }
   const selectedCovered = new Set<number>();
   const decisions = currentConfirmDecisions(store.listConfirmDecisions(projectId).filter((row) => rowBelongsToCurrentMaterial(row, currentIds, materialBoundary)))
-    .filter((decision) => decision.reproduced === "yes" && decision.recommendation !== "drop")
+    .filter((decision) => isSubmissionReadyDecision(decision, { requireImpactInventory: false }))
+    .filter((decision) => isRealTargetDecisionEvidence(stringValue(decision.evidence_level)))
     .filter((decision) => selected || includeExistingReports || !decisionHasFormalReport(decision))
     .filter((decision) => {
       if (!selected) return true;
@@ -2349,11 +2351,11 @@ function decisionReportWorklist(
     const missing = [...selected].filter((id) => !selectedCovered.has(id));
     if (missing.length > 0) {
       const unknown = missing.filter((id) => !findingsById.has(id));
-      const suffix = unknown.length > 0 ? " is not a current finding for this project" : " is not linked to a reproduced, non-dropped decision";
+      const suffix = unknown.length > 0 ? " is not a current finding for this project" : " is not linked to a submission-ready decision";
       return { error: `finding ${missing.join(", ")}${suffix}` };
     }
   }
-  if (decisions.length === 0) return { error: "no reproduced decisions are missing submission reports" };
+  if (decisions.length === 0) return { error: "no submission-ready decisions are missing formal reports" };
 
   return {
     findings: decisions.map((decision) => {
@@ -3676,17 +3678,18 @@ async function daemonPipelineWorklist(c: Ctx): Promise<void> {
     if (!requiresRealTargetConfirmation) {
       return sendJson(c.res, 200, { phase, requiresRealTargetConfirmation, inputRunDirs: [], confirmKeys: [] });
     }
+    const currentDecisions = currentConfirmDecisions(c.store.listConfirmDecisions(projectId).filter((row) => rowBelongsToCurrentMaterial(row, currentResultRunIds, materialBoundary)));
+    const submissionWorkKeys = new Set(currentDecisions.filter((row) => needsSubmissionReadinessWork(row)).flatMap(confirmDecisionMemberKeys));
     const pending = c.store.pendingConfirmable(projectId)
       .filter((row) => confirmableRunDir(row as unknown as Record<string, unknown>))
       .filter((row) => rowBelongsToCurrentMaterial(row as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary));
-    if (pending.length === 0) {
+    if (pending.length === 0 && submissionWorkKeys.size === 0) {
       return sendJson(c.res, 200, { phase, requiresRealTargetConfirmation, inputRunDirs: [], confirmKeys: [] });
     }
     const context = c.store.confirmableContext(projectId)
       .filter((row) => confirmableRunDir(row as unknown as Record<string, unknown>))
       .filter((row) => rowBelongsToCurrentMaterial(row as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary));
     const rows = context.length > 0 ? context : pending;
-    const currentDecisions = currentConfirmDecisions(c.store.listConfirmDecisions(projectId).filter((row) => rowBelongsToCurrentMaterial(row, currentResultRunIds, materialBoundary)));
     return sendJson(c.res, 200, {
       phase,
       requiresRealTargetConfirmation,
@@ -3969,12 +3972,14 @@ function projectSnapshots(store: MetadataStore, options: ProjectListOptions = {}
       ? []
       : currentConfirmDecisions(store.listConfirmDecisions(id).filter((row) => rowBelongsToCurrentMaterial(row, currentRunIds, materialBoundary)));
     const reproducedBugs = confirmDecisions.filter((row) => row.reproduced === "yes").length;
+    const submissionWorkKeys = new Set(confirmDecisions.filter((row) => needsSubmissionReadinessWork(row)).flatMap(confirmDecisionMemberKeys));
     const verifyPendingFindings = (counts.suspected ?? 0) + (counts["confirmed-source"] ?? 0);
     const requiresRealTargetConfirmation = latestPrepareRequiresRealTargetConfirmation(allRuns);
     const confirmPendingFindings = requiresRealTargetConfirmation
       ? findings.filter((finding) => {
           const status = String(finding.status ?? "");
-          return (status === "confirmed-executable" || status === "confirmed-differential") && !finding.confirm_status;
+          const key = stringValue(finding.finding_key).toLowerCase();
+          return (status === "confirmed-executable" || status === "confirmed-differential") && (!finding.confirm_status || (key && submissionWorkKeys.has(key)));
         }).length
       : 0;
     return {

--- a/src/server/ui/src/App.tsx
+++ b/src/server/ui/src/App.tsx
@@ -31,8 +31,10 @@ import {
   fmtDur,
   fmtTime,
   isVerifyRun,
+  isSubmissionReadyDecision,
   verifyRunProgress,
   verifyRunRechecksConfirmed,
+  needsSubmissionReadinessWork,
   pct,
   phaseState,
   PHASES,
@@ -802,11 +804,14 @@ function isExecutionConfirmedFinding(finding: FindingRow): boolean {
 
 function pendingConfirmFindings(rows: FindingRow[] | undefined, requiresConfirmation = true, decisions?: ConfirmDecision[]): FindingRow[] {
   if (!requiresConfirmation) return [];
-  const decidedFindingKeys = new Set((decisions ?? []).flatMap(confirmDecisionMemberKeys));
+  const readinessWorkKeys = new Set((decisions ?? []).filter(needsSubmissionReadinessWork).flatMap(confirmDecisionMemberKeys));
+  const decidedFindingKeys = new Set((decisions ?? []).filter((decision) => !needsSubmissionReadinessWork(decision)).flatMap(confirmDecisionMemberKeys));
   return activeFindings(rows).filter((finding) =>
     isExecutionConfirmedFinding(finding)
-    && !finding.confirm_status
-    && !(finding.finding_key && decidedFindingKeys.has(finding.finding_key.toLowerCase()))
+    && (
+      (!finding.confirm_status && !(finding.finding_key && decidedFindingKeys.has(finding.finding_key.toLowerCase())))
+      || Boolean(finding.finding_key && readinessWorkKeys.has(finding.finding_key.toLowerCase()))
+    )
   );
 }
 
@@ -832,7 +837,7 @@ function pendingFormalReports(rows: FindingRow[] | undefined, requiresConfirmati
 }
 
 function reportableDecisions(decisions: ConfirmDecision[] | undefined): ConfirmDecision[] {
-  return sortConfirmDecisionsForSubmission(decisions).filter((decision) => decision.reproduced === "yes" && decision.recommendation !== "drop");
+  return sortConfirmDecisionsForSubmission(decisions).filter(isSubmissionReadyDecision);
 }
 
 function pendingDecisionReports(decisions: ConfirmDecision[] | undefined): ConfirmDecision[] {

--- a/src/server/ui/src/domain.ts
+++ b/src/server/ui/src/domain.ts
@@ -85,6 +85,104 @@ function findingCoveredByDecision(finding: FindingRow, decidedFindingKeys: Set<s
   return Boolean(finding.finding_key && decidedFindingKeys.has(finding.finding_key.toLowerCase()));
 }
 
+function parseJsonObject(raw?: string | null): Record<string, unknown> | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function decisionObject(decision: ConfirmDecision, objectKey: "engagement_profile" | "adjudication", jsonKey: "engagement_profile_json" | "adjudication_json"): Record<string, unknown> | undefined {
+  const direct = decision[objectKey];
+  if (direct && typeof direct === "object" && !Array.isArray(direct)) return direct as Record<string, unknown>;
+  return parseJsonObject(decision[jsonKey]);
+}
+
+function normalizedWord(value: unknown): string {
+  return String(value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function stringField(obj: Record<string, unknown> | undefined, keys: string[]): string {
+  if (!obj) return "";
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+function gateStatus(adjudication: Record<string, unknown> | undefined, needles: string[], fallbackKeys: string[]): string {
+  const gates = Array.isArray(adjudication?.gates) ? adjudication.gates : [];
+  for (const gate of gates) {
+    if (!gate || typeof gate !== "object" || Array.isArray(gate)) continue;
+    const record = gate as Record<string, unknown>;
+    const id = normalizedWord(record.id ?? record.key ?? record.name ?? record.gate);
+    if (needles.some((needle) => id.includes(needle))) return String(record.status ?? record.result ?? record.state ?? "").trim();
+  }
+  return stringField(adjudication, fallbackKeys);
+}
+
+function isNegativeGateStatus(status: string): boolean {
+  const normalized = normalizedWord(status);
+  return [
+    "fail",
+    "failed",
+    "unknown",
+    "needs_human",
+    "blocked",
+    "missing",
+    "unsettled",
+    "unfunded",
+    "not_funded",
+    "not_live",
+    "no_live",
+    "no_funds",
+    "not_novel",
+    "already_disclosed",
+    "duplicate",
+    "disclosed",
+  ].some((token) => normalized === token || normalized.startsWith(`${token}_`));
+}
+
+function isPassingGateStatus(status: string): boolean {
+  const normalized = normalizedWord(status);
+  if (!normalized || isNegativeGateStatus(normalized)) return false;
+  return ["pass", "passed", "satisfied", "confirmed", "established", "eligible", "ok", "yes", "in_scope", "funded", "live_funded", "novel", "estimated", "collectible", "not_duplicate", "not_disclosed"].some((token) => normalized === token || normalized.startsWith(`${token}_`));
+}
+
+function decisionHasOpenSubmissionGate(decision: ConfirmDecision): boolean {
+  const text = (decision.human_gates ?? "").trim().toLowerCase();
+  if (text && !/^(?:none|n\/a|not applicable|no remaining gates?|no human gates?)\.?$/.test(text)) {
+    if (!/\b(?:no|none)\b.{0,32}\b(?:remaining|open|unsettled|human)\b.{0,24}\b(?:gate|gates|blocker|blockers)\b/.test(text)) {
+      if (/\b(?:scope|venue|eligib|bounty|reward|payout|collectible|live|funded|funds|deployment|production|current|human gate|needs?|requires?|not established|not confirmed|unknown|unclear|unverified|pending|review|cannot be settled|must)\b/.test(text)) return true;
+    }
+  }
+  const adjudication = decisionObject(decision, "adjudication", "adjudication_json");
+  const directStatuses = [
+    gateStatus(adjudication, ["scope", "venue", "eligib", "asset"], ["scope_status", "scopeStatus"]),
+    gateStatus(adjudication, ["live", "impact", "fund", "exposure", "deployment"], ["live_impact_status", "liveImpactStatus", "funds_status", "fundsStatus"]),
+    gateStatus(adjudication, ["known", "novel", "duplicate", "disclos"], ["known_issue_status", "knownIssueStatus", "novelty_status", "noveltyStatus"]),
+    gateStatus(adjudication, ["payout", "reward", "collectible", "bounty"], ["payout_status", "payoutStatus", "reward_status", "rewardStatus"]),
+  ].filter(Boolean);
+  return directStatuses.some((status) => !isPassingGateStatus(status));
+}
+
+function hasRealTargetEvidence(decision: ConfirmDecision): boolean {
+  const normalized = normalizedWord(decision.evidence_level);
+  return normalized === "real_target_reproduced" || normalized === "fork_reproduced" || normalized === "local_fork_reproduced";
+}
+
+export function isSubmissionReadyDecision(decision: ConfirmDecision): boolean {
+  return decision.reproduced === "yes" && decision.recommendation === "submit-candidate" && hasRealTargetEvidence(decision) && !decisionHasOpenSubmissionGate(decision);
+}
+
+export function needsSubmissionReadinessWork(decision: ConfirmDecision): boolean {
+  return decision.reproduced === "yes" && decision.recommendation !== "drop" && !isSubmissionReadyDecision(decision) && (decision.recommendation === "submit-candidate" || decisionHasOpenSubmissionGate(decision));
+}
+
 function confirmDecisionTail(decisions: ConfirmDecision[]): string {
   const pending = decisions.filter((decision) => !decision.reproduced || decision.reproduced === "pending").length;
   const needsHuman = decisions.filter((decision) => decision.recommendation === "needs-human").length;
@@ -195,7 +293,7 @@ function reportPackageStats(findings: FindingRow[], decisions: ConfirmDecision[]
       submissions: 0,
     };
   }
-  const reproduced = decisions.filter((decision) => decision.reproduced === "yes" && decision.recommendation !== "drop");
+  const reproduced = decisions.filter(isSubmissionReadyDecision);
   return {
     ready: reproduced.filter((decision) => decision.has_report).length,
     total: reproduced.length,
@@ -502,9 +600,11 @@ export function phaseState(detail: ProjectDetail, progress: Coverage): PhaseStat
   const conf = latest("confirm");
   const synthesis = stages(latestRunWithStage(runs, "synthesis")).synthesis;
   const requiresConfirmation = needsRealTargetConfirmation(detail);
-  const decidedFindingKeys = new Set(decisions.flatMap(confirmDecisionMemberKeys));
+  const readinessWorkKeys = new Set(decisions.filter(needsSubmissionReadinessWork).flatMap(confirmDecisionMemberKeys));
+  const decidedFindingKeys = new Set(decisions.filter((decision) => !needsSubmissionReadinessWork(decision)).flatMap(confirmDecisionMemberKeys));
   const pendingConfirmRaw = requiresConfirmation
-    ? findings.filter((finding) => isExecutionConfirmedFinding(finding) && !finding.confirm_status && !findingCoveredByDecision(finding, decidedFindingKeys)).length
+    ? findings.filter((finding) => isExecutionConfirmedFinding(finding)
+      && ((!finding.confirm_status && !findingCoveredByDecision(finding, decidedFindingKeys)) || findingCoveredByDecision(finding, readinessWorkKeys))).length
     : 0;
   const pendingVerify = findings.filter((finding) => finding.status === "suspected" || finding.status === "confirmed-source").length;
   const locallyVerified = findings.filter(isExecutionConfirmedFinding).length;
@@ -608,8 +708,8 @@ export function phaseState(detail: ProjectDetail, progress: Coverage): PhaseStat
           ? "pending"
         : !requiresConfirmation && locallyVerified > 0
           ? "done"
-          : decisions.length
-          ? (repro === decisions.length && pendingConfirm === 0 ? "done" : "partial")
+        : decisions.length
+          ? (repro === decisions.length && pendingConfirm === 0 && decisions.filter(needsSubmissionReadinessWork).length === 0 ? "done" : "partial")
           : pendingConfirm > 0
             ? "pending"
             : "none",
@@ -639,7 +739,7 @@ export function phaseState(detail: ProjectDetail, progress: Coverage): PhaseStat
           : reportPackages.total > 0
             ? `${reportPackages.total} waiting for formal report${reportPackages.submissions ? ` · ${reportPackages.submissions} ${reportPackages.submissions === 1 ? "submit candidate" : "submit candidates"}` : ""}`
             : decisions.length > 0
-              ? "No reproduced bug yet"
+              ? "No submission-ready bug yet"
               : "Not started",
       dur: runDur(reportLatest, reportRunning),
     },

--- a/src/util/submission-readiness.ts
+++ b/src/util/submission-readiness.ts
@@ -1,0 +1,326 @@
+export type SubmissionDecisionLike = {
+  bug?: string | undefined;
+  members?: string[] | undefined;
+  reproduced?: string | null | undefined;
+  recommendation?: string | null | undefined;
+  humanGates?: string | null | undefined;
+  engagementProfile?: unknown;
+  adjudication?: unknown;
+  evidenceLevel?: string | null | undefined;
+};
+
+export interface SubmissionReadinessOptions {
+  impactInventory?: unknown;
+  requireImpactInventory?: boolean;
+}
+
+export function enforceSubmissionReadiness<T extends object>(
+  rows: T[],
+  options: SubmissionReadinessOptions = {},
+): T[] {
+  return rows.map((row) => {
+    const decision = row as SubmissionDecisionLike;
+    if (decisionRecommendation(decision) !== "submit-candidate") return row;
+    const blocker = submissionReadinessBlocker(decision, options);
+    if (!blocker) return row;
+    const humanGates = appendHumanGate(decisionHumanGates(decision), `Framework blocked submit-candidate: ${blocker}`);
+    return { ...row, recommendation: "needs-human", humanGates } as T;
+  });
+}
+
+export function isSubmissionReadyDecision(row: object, options: SubmissionReadinessOptions = {}): boolean {
+  const decision = row as SubmissionDecisionLike;
+  return decisionReproduced(decision) === "yes"
+    && decisionRecommendation(decision) === "submit-candidate"
+    && !submissionReadinessBlocker(decision, { ...options, requireImpactInventory: options.requireImpactInventory ?? false });
+}
+
+export function needsSubmissionReadinessWork(row: object): boolean {
+  const decision = row as SubmissionDecisionLike;
+  if (decisionReproduced(decision) !== "yes") return false;
+  if (decisionRecommendation(decision) === "drop") return false;
+  if (isSubmissionReadyDecision(decision)) return false;
+  return decisionRecommendation(decision) === "submit-candidate"
+    || hasOpenSubmissionGate(decision)
+    || isBountyLikePolicy(decision);
+}
+
+export function isResumeSettledDecision(row: object): boolean {
+  const decision = row as SubmissionDecisionLike;
+  if (decisionReproduced(decision) === "no") return true;
+  if (decisionRecommendation(decision) === "drop") return true;
+  return isSubmissionReadyDecision(decision);
+}
+
+export function submissionReadinessBlocker(row: SubmissionDecisionLike, options: SubmissionReadinessOptions = {}): string | undefined {
+  if (decisionReproduced(row) !== "yes") return "the row is not reproduced on the real target";
+  if (!isBountyLikePolicy(row)) {
+    return hasOpenSubmissionGate(row) ? "submission gates remain unsettled in human_gates or adjudication" : undefined;
+  }
+  const adjudication = decisionAdjudication(row);
+  if (options.requireImpactInventory !== false && !impactInventoryCoversRow(row, options.impactInventory)) {
+    return "impact_inventory.json has no entry covering this reproduced bounty-like row";
+  }
+  for (const gate of ["scope", "live_impact", "known_issue", "payout"] as const) {
+    const status = bountyGateStatus(adjudication, gate);
+    if (!isPassingBountyGateStatus(status, gate)) return `${gate} gate is ${status ? JSON.stringify(status) : "missing"}`;
+  }
+  if (hasOpenSubmissionGate(row)) return "submission gates remain unsettled in human_gates or adjudication";
+  return undefined;
+}
+
+export function hasOpenSubmissionGate(row: SubmissionDecisionLike): boolean {
+  return hasStructuredBlockingGate(decisionAdjudication(row)) || hasUnsettledHumanGateText(decisionHumanGates(row));
+}
+
+export function isBountyLikePolicy(row: SubmissionDecisionLike): boolean {
+  const profile = asRecord(decisionEngagementProfile(row));
+  const adjudication = asRecord(decisionAdjudication(row));
+  const policyKind = normalizedWord(stringValue(profile?.policy_kind ?? profile?.policyKind ?? profile?.kind));
+  if (policyKind.includes("bug_bounty") || policyKind.includes("bounty") || policyKind.includes("contest")) return true;
+  const requiredRaw = profile?.required_gates ?? profile?.requiredGates;
+  const requiredGates = Array.isArray(requiredRaw) ? requiredRaw.map((entry) => normalizedWord(stringValue(entry))) : [];
+  const adjudicationHasPayout = Boolean(adjudication && ("payout_estimate" in adjudication || "payoutEstimate" in adjudication || "reward_estimate" in adjudication || "rewardEstimate" in adjudication));
+  if (policyKind === "custom" && (requiredGates.some(isRewardGate) || adjudicationHasPayout)) return true;
+  if (requiredGates.some(isRewardGate) && adjudicationHasPayout) return true;
+  return /\b(?:bounty|reward|payout|collectible)\b/.test(decisionHumanGates(row).toLowerCase());
+}
+
+function isRewardGate(gate: string): boolean {
+  return gate.includes("payout") || gate.includes("reward") || gate.includes("bounty") || gate.includes("collectible");
+}
+
+function decisionReproduced(row: SubmissionDecisionLike): string {
+  return stringField(row, ["reproduced"]).toLowerCase();
+}
+
+function decisionRecommendation(row: SubmissionDecisionLike): string {
+  return stringField(row, ["recommendation"]).toLowerCase();
+}
+
+function decisionHumanGates(row: SubmissionDecisionLike): string {
+  return stringField(row, ["humanGates", "human_gates"]);
+}
+
+function decisionEngagementProfile(row: SubmissionDecisionLike): unknown {
+  return structuredField(row, ["engagementProfile", "engagement_profile", "engagement_profile_json"]);
+}
+
+function decisionAdjudication(row: SubmissionDecisionLike): unknown {
+  return structuredField(row, ["adjudication", "adjudication_json"]);
+}
+
+function stringField(row: SubmissionDecisionLike, keys: string[]): string {
+  const record = row as Record<string, unknown>;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string") return value.trim();
+    if (value !== undefined && value !== null && typeof value !== "object") return String(value).trim();
+  }
+  return "";
+}
+
+function structuredField(row: SubmissionDecisionLike, keys: string[]): unknown {
+  const record = row as Record<string, unknown>;
+  for (const key of keys) {
+    const value = record[key];
+    if (value === undefined || value === null || value === "") continue;
+    if (typeof value === "string") return jsonParseOrNull(value) ?? value;
+    return value;
+  }
+  return undefined;
+}
+
+function hasUnsettledHumanGateText(value: string): boolean {
+  const text = value.trim().toLowerCase();
+  if (!text) return false;
+  if (/^(?:none|n\/a|not applicable|no remaining gates?|no human gates?)\.?$/.test(text)) return false;
+  if (/\b(?:no|none)\b.{0,32}\b(?:remaining|open|unsettled|human)\b.{0,24}\b(?:gate|gates|blocker|blockers)\b/.test(text)) return false;
+  return /\b(?:scope|venue|eligib|bounty|reward|payout|collectible|live|funded|funds|deployment|production|current|human gate|needs?|requires?|not established|not confirmed|unknown|unclear|unverified|pending|review|cannot be settled|must)\b/.test(text);
+}
+
+function hasStructuredBlockingGate(value: unknown): boolean {
+  const root = typeof value === "string" ? jsonParseOrNull(value) : value;
+  if (!root || typeof root !== "object" || Array.isArray(root)) return false;
+  const obj = root as Record<string, unknown>;
+  for (const key of ["scope_status", "scopeStatus", "live_impact_status", "liveImpactStatus", "known_issue_status", "knownIssueStatus", "payout_status", "payoutStatus", "reward_status", "rewardStatus"]) {
+    const status = stringValue(obj[key]);
+    if (status && !isPassingGenericStatus(status)) return true;
+  }
+  const payout = asRecord(obj.payout_estimate ?? obj.payoutEstimate ?? obj.reward_estimate ?? obj.rewardEstimate);
+  const payoutStatus = stringValue(payout?.status);
+  if (payoutStatus && !isPassingBountyGateStatus(payoutStatus, "payout")) return true;
+  const gateArrays = [obj.gates, obj.required_gates, obj.requiredGates].filter(Array.isArray) as unknown[][];
+  for (const gates of gateArrays) {
+    for (const gate of gates) {
+      if (!gate || typeof gate !== "object" || Array.isArray(gate)) continue;
+      const status = stringValue((gate as Record<string, unknown>).status);
+      if (!status) continue;
+      if (!isPassingGenericStatus(status)) return true;
+    }
+  }
+  return false;
+}
+
+function isPassingGenericStatus(status: string): boolean {
+  const normalized = normalizedWord(status);
+  return Boolean(normalized) && !isNegativeGateStatus(normalized) && matchesStatus(normalized, [
+    "pass",
+    "passed",
+    "yes",
+    "ok",
+    "satisfied",
+    "confirmed",
+    "established",
+    "not_required",
+    "not_applicable",
+    "in_scope",
+    "eligible",
+    "novel",
+    "estimated",
+  ]);
+}
+
+function bountyGateStatus(adjudication: unknown, gate: "scope" | "live_impact" | "known_issue" | "payout"): string | undefined {
+  const record = asRecord(adjudication);
+  if (!record) return undefined;
+  const direct = directGateStatus(record, gate);
+  if (direct) return direct;
+  const gates = Array.isArray(record.gates) ? record.gates.map(asRecord).filter((entry): entry is Record<string, unknown> => Boolean(entry)) : [];
+  const needles = gateNeedles(gate);
+  for (const entry of gates) {
+    const id = normalizedWord(stringValue(entry.id ?? entry.key ?? entry.name ?? entry.gate));
+    if (needles.some((needle) => id.includes(needle))) {
+      const status = stringValue(entry.status ?? entry.result ?? entry.state);
+      if (status) return status;
+    }
+  }
+  return undefined;
+}
+
+function directGateStatus(record: Record<string, unknown>, gate: "scope" | "live_impact" | "known_issue" | "payout"): string | undefined {
+  const keys: Record<typeof gate, string[]> = {
+    scope: ["scope_status", "scopeStatus", "asset_status", "assetStatus", "eligibility_status", "eligibilityStatus"],
+    live_impact: ["live_impact_status", "liveImpactStatus", "funds_status", "fundsStatus", "exposure_status", "exposureStatus"],
+    known_issue: ["known_issue_status", "knownIssueStatus", "novelty_status", "noveltyStatus", "duplicate_status", "duplicateStatus"],
+    payout: ["payout_status", "payoutStatus", "reward_status", "rewardStatus"],
+  };
+  for (const key of keys[gate]) {
+    const status = stringValue(record[key]);
+    if (status) return status;
+  }
+  if (gate === "payout") {
+    const payout = asRecord(record.payout_estimate ?? record.payoutEstimate ?? record.reward_estimate ?? record.rewardEstimate);
+    const status = stringValue(payout?.status);
+    if (status) return status;
+  }
+  return undefined;
+}
+
+function gateNeedles(gate: "scope" | "live_impact" | "known_issue" | "payout"): string[] {
+  switch (gate) {
+    case "scope": return ["scope", "venue", "eligib", "asset"];
+    case "live_impact": return ["live", "impact", "fund", "exposure", "deployment"];
+    case "known_issue": return ["known", "novel", "duplicate", "disclos"];
+    case "payout": return ["payout", "reward", "collectible", "bounty"];
+  }
+}
+
+function isPassingBountyGateStatus(status: string | undefined, gate: "scope" | "live_impact" | "known_issue" | "payout"): boolean {
+  const normalized = normalizedWord(status);
+  if (!normalized) return false;
+  if (isNegativeGateStatus(normalized)) return false;
+  if (matchesStatus(normalized, ["pass", "passed", "satisfied", "confirmed", "established", "eligible", "ok", "yes"])) return true;
+  if (gate === "scope" && matchesStatus(normalized, ["in_scope", "eligible"])) return true;
+  if (gate === "live_impact" && matchesStatus(normalized, ["funded", "live", "live_funded", "affected_live_deployment"])) return true;
+  if (gate === "known_issue" && matchesStatus(normalized, ["novel", "not_duplicate", "not_disclosed", "no_known_issue", "not_known"])) return true;
+  if (gate === "payout" && matchesStatus(normalized, ["estimated", "collectible"])) return true;
+  return false;
+}
+
+function isNegativeGateStatus(normalized: string): boolean {
+  return matchesStatus(normalized, [
+    "fail",
+    "failed",
+    "unknown",
+    "needs_human",
+    "blocked",
+    "missing",
+    "unsettled",
+    "not_applicable",
+    "unfunded",
+    "not_funded",
+    "not_live",
+    "no_live",
+    "no_funds",
+    "not_novel",
+    "not_estimated",
+    "already_disclosed",
+    "duplicate",
+    "disclosed",
+  ]);
+}
+
+function matchesStatus(normalized: string, tokens: string[]): boolean {
+  return tokens.some((token) => normalized === token || normalized.startsWith(`${token}_`));
+}
+
+function impactInventoryCoversRow(row: SubmissionDecisionLike, impactInventory: unknown): boolean {
+  const inventory = asRecord(impactInventory);
+  const inventoryItems = inventory?.items;
+  const itemsRaw = Array.isArray(inventoryItems)
+    ? inventoryItems
+    : Array.isArray(impactInventory)
+      ? impactInventory
+      : [];
+  if (itemsRaw.length === 0) return false;
+  const rowMembers = new Set(decisionMembers(row).map((member) => normalizedWord(member)).filter(Boolean));
+  const record = row as Record<string, unknown>;
+  const rowBug = normalizedWord(stringValue(row.bug ?? record.title));
+  for (const raw of itemsRaw) {
+    const item = asRecord(raw);
+    if (!item) continue;
+    const bug = normalizedWord(stringValue(item.bug ?? item.title));
+    if (bug && rowBug && bug === rowBug) return true;
+    const members = Array.isArray(item.members) ? item.members.map((member) => normalizedWord(stringValue(member))).filter(Boolean) : [];
+    if (members.some((member) => rowMembers.has(member))) return true;
+  }
+  return false;
+}
+
+function decisionMembers(row: SubmissionDecisionLike): string[] {
+  if (Array.isArray(row.members)) return row.members.filter((member): member is string => typeof member === "string");
+  const raw = (row as Record<string, unknown>).members_json;
+  if (typeof raw === "string") {
+    const parsed = jsonParseOrNull(raw);
+    if (Array.isArray(parsed)) return parsed.filter((member): member is string => typeof member === "string");
+  }
+  return [];
+}
+
+function appendHumanGate(existing: string | undefined, note: string): string {
+  const trimmed = existing?.trim();
+  if (!trimmed) return note;
+  if (trimmed.includes(note)) return trimmed;
+  return `${trimmed} ${note}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : value === undefined || value === null ? "" : String(value).trim();
+}
+
+function normalizedWord(value: unknown): string {
+  return stringValue(value).toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function jsonParseOrNull(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -551,9 +551,27 @@ test("api: daemon pipeline worklist exposes verify candidates before confirm", a
           confidence: 0.93,
         },
       ], "differential");
+      store.upsertFindings(created.id, runId, [
+        {
+          findingKey: "kgateblocked",
+          title: "Gate-blocked reproduced proof",
+          location: "src/Vault.sol:92",
+          severity: "critical",
+          status: "confirmed-executable",
+          confidence: 0.9,
+        },
+      ], "differential");
       const confirmRun = store.startRun({ projectId: created.id, kind: "confirm", runDir: path.join(out, "pipeline-confirm-run") });
       store.upsertConfirmDecisions(created.id, confirmRun, [
         { bug: "prior reproduced withdrawal proof", reproduced: "yes", recommendation: "submit-candidate", members: ["kalreadyreproduced"] },
+        {
+          bug: "gate-blocked reproduced proof",
+          reproduced: "yes",
+          recommendation: "needs-human",
+          members: ["kgateblocked"],
+          reproEvidence: "purpose=confirm command cmd-gate reproduced the real target effect",
+          humanGates: "Live funded exposure and payout tier are pending review.",
+        },
       ]);
       store.finishRun(confirmRun, "done");
       store.upsertFindings(created.id, runId, [
@@ -598,6 +616,7 @@ test("api: daemon pipeline worklist exposes verify candidates before confirm", a
     }));
     assert.ok(confirm.confirmKeys.includes("confirmed-bug"));
     assert.ok(confirm.confirmKeys.includes("kalreadyreproduced"), "confirm worklist carries prior decided findings as consolidation context");
+    assert.ok(confirm.confirmKeys.includes("kgateblocked"), "confirm worklist carries reproduced decisions whose submission gates are still open");
     assert.deepEqual(confirm.confirmSettledRows.map((row) => row.bug), ["prior reproduced withdrawal proof"]);
     assert.ok(confirm.confirmKeys.some((key) => /^origin:\d+:confirmed-bug$/.test(key)), "worklist carries origin selector for verify-artifact recovery");
 
@@ -1385,6 +1404,13 @@ test("api: report launch queues only reproduced real-target findings that were n
           severity: "medium",
           status: "confirmed-executable",
         },
+        {
+          findingKey: "kneeds",
+          title: "Gate-blocked bug",
+          location: "src/Target.sol:67",
+          severity: "high",
+          status: "confirmed-executable",
+        },
       ]);
       const confirmRun = store.startRun({ projectId: created.id, kind: "confirm", runDir: path.join(out, "report-launch-confirm") });
       store.upsertConfirmDecisions(created.id, confirmRun, [
@@ -1395,6 +1421,15 @@ test("api: report launch queues only reproduced real-target findings that were n
           members: ["kready"],
           reproEvidence: "purpose=confirm command cmd1 reproduced the real target effect",
           reproCommandId: "cmd1",
+        },
+        {
+          bug: "Gate-blocked bug",
+          reproduced: "yes",
+          recommendation: "needs-human",
+          members: ["kneeds"],
+          reproEvidence: "purpose=confirm command cmd-needs reproduced the real target effect",
+          reproCommandId: "cmd-needs",
+          humanGates: "Live funded impact and payout tier are still pending review.",
         },
         {
           bug: "Dropped bug",
@@ -1426,11 +1461,13 @@ test("api: report launch queues only reproduced real-target findings that were n
     const ready = detail.allFindings.find((finding) => finding.finding_key === "kready");
     const dropped = detail.allFindings.find((finding) => finding.finding_key === "kdrop");
     const existing = detail.allFindings.find((finding) => finding.finding_key === "kexisting");
+    const needs = detail.allFindings.find((finding) => finding.finding_key === "kneeds");
     const readyDecision = detail.confirmDecisions.find((decision) => decision.bug === "Ready bug");
     const existingDecision = detail.confirmDecisions.find((decision) => decision.bug === "Existing report bug");
     assert.ok(ready);
     assert.ok(dropped);
     assert.ok(existing);
+    assert.ok(needs);
     assert.ok(readyDecision);
     assert.ok(existingDecision);
     assert.equal(existing.has_report, false);
@@ -1481,7 +1518,10 @@ test("api: report launch queues only reproduced real-target findings that were n
 
     const rejected = await post(`/api/projects/${created.uuid}/runs`, { verb: "report", findingIds: [dropped.id] });
     assert.equal(rejected.status, 400);
-    assert.match((await rejected.json()).error, /not reproduced on the real target|dropped/);
+    assert.match((await rejected.json()).error, /not reproduced on the real target|dropped|submission-ready/);
+    const gateBlocked = await post(`/api/projects/${created.uuid}/runs`, { verb: "report", findingIds: [needs.id] });
+    assert.equal(gateBlocked.status, 400);
+    assert.match((await gateBlocked.json()).error, /submission-ready/);
   });
 });
 

--- a/tests/db-store.test.mjs
+++ b/tests/db-store.test.mjs
@@ -469,7 +469,9 @@ test("store: confirm decisions persist decision reports without overwriting link
   assert.equal(decision.repro_evidence, "purpose=confirm command cmd_1 reproduced the real target effect");
   assert.equal(decision.repro_command_id, "cmd_1");
   assert.equal(decision.novelty, "novel");
-  assert.equal(decision.human_gates, "venue scope still needs human review");
+  assert.match(decision.human_gates, /venue scope still needs human review/);
+  assert.match(decision.human_gates, /Framework blocked submit-candidate/);
+  assert.equal(decision.recommendation, "needs-human");
   assert.equal(JSON.parse(decision.engagement_profile_json).policy_kind, "bug_bounty");
   assert.equal(JSON.parse(decision.adjudication_json).gates[1].status, "unknown");
   assert.equal(decision.severity, "high");
@@ -513,6 +515,8 @@ test("store: structured adjudication gates keep bounty confidence conservative",
   ]);
 
   const [decision] = db.listConfirmDecisions(projectId);
+  assert.equal(decision.recommendation, "needs-human");
+  assert.match(decision.human_gates, /Framework blocked submit-candidate/);
   assert.equal(decision.evidence_level, "local-fork-reproduced");
   assert.equal(decision.submission_confidence, "medium");
   db.close();

--- a/tests/ui-source-state.test.mjs
+++ b/tests/ui-source-state.test.mjs
@@ -55,7 +55,7 @@ test("ui: phase cards count report packages by reproduced decision, not linked f
       { id: 3, finding_key: "kgamma", status: "confirmed-differential", confirm_status: null, has_report: false },
     ],
     confirmDecisions: [
-      { bug: "same root cause", reproduced: "yes", recommendation: "submit-candidate", members_json: JSON.stringify(["kalpha", "kbeta"]) },
+      { bug: "same root cause", reproduced: "yes", recommendation: "submit-candidate", evidence_level: "fork-reproduced", members_json: JSON.stringify(["kalpha", "kbeta"]) },
     ],
   };
   const phases = phaseState(detail, { total: 0, audited: 0, deferred: 0, pending: 0 });
@@ -80,7 +80,7 @@ test("ui: phase cards do not double-count findings already covered by decisions"
       { id: 2, finding_key: "ktwo", status: "confirmed-differential", confirm_status: null, has_report: false },
     ],
     confirmDecisions: [
-      { bug: "submit root cause", reproduced: "yes", recommendation: "submit-candidate", members_json: JSON.stringify(["kone"]) },
+      { bug: "submit root cause", reproduced: "yes", recommendation: "submit-candidate", evidence_level: "fork-reproduced", members_json: JSON.stringify(["kone"]) },
       { bug: "setup blocker", reproduced: "could-not-set-up", recommendation: "needs-human", members_json: JSON.stringify(["ktwo"]) },
     ],
   };


### PR DESCRIPTION
## Summary
- add a shared submission-readiness gate for confirm decisions
- keep gate-blocked reproduced decisions in confirm/continue instead of treating them as settled
- only generate formal reports for submission-ready, real-target reproduced decisions
- update UI phase/report counts and regression coverage for gate-blocked decisions

## Tests
- npm test