### PR TITLE
Expose sandbox readiness in daemon summaries

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -3873,6 +3873,7 @@ function summarizeDaemonCapabilities(capabilities: unknown): Record<string, unkn
   const providersRaw = capabilities && typeof capabilities === "object" && !Array.isArray(capabilities)
     ? (capabilities as { providers?: unknown }).providers
     : undefined;
+  const sandbox = summarizeDaemonSandbox(capabilities);
   const providers = Array.isArray(providersRaw)
     ? providersRaw.flatMap((entry) => {
         if (typeof entry === "string") return [{ provider: entry, configured: true, required: true }];
@@ -3891,7 +3892,23 @@ function summarizeDaemonCapabilities(capabilities: unknown): Record<string, unkn
     providers,
     providerCount: providers.length,
     configuredProviderCount: providers.filter((entry) => entry.configured).length,
+    ...(sandbox ? { sandbox } : {}),
   };
+}
+
+function summarizeDaemonSandbox(capabilities: unknown): Record<string, unknown> | undefined {
+  if (!capabilities || typeof capabilities !== "object" || Array.isArray(capabilities)) return undefined;
+  const sandbox = (capabilities as { sandbox?: unknown }).sandbox;
+  if (!sandbox || typeof sandbox !== "object" || Array.isArray(sandbox)) return undefined;
+  const read = sandbox as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  if (typeof read.ok === "boolean") out.ok = read.ok;
+  if (typeof read.backend === "string" && read.backend.trim()) out.backend = read.backend.trim();
+  if (typeof read.image === "string" && read.image.trim()) out.image = read.image.trim();
+  if (typeof read.allowHostFallback === "boolean") out.allowHostFallback = read.allowHostFallback;
+  if (typeof read.autoBuild === "boolean") out.autoBuild = read.autoBuild;
+  if (typeof read.message === "string" && read.message.trim()) out.message = read.message.trim();
+  return Object.keys(out).length ? out : undefined;
 }
 
 function normalizeProjectStatusFilter(value: string | null | undefined): ProjectStatusFilter | undefined {

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -3884,6 +3884,15 @@ test("api: daemon lists return provider-auth summaries by default", async () => 
             { provider: "openai-codex", configured: true, required: true, oauthLogin: true, expectedEnvVars: ["SHOULD_NOT_BE_DEFAULT"] },
             { provider: "anthropic", configured: false, required: true, oauthLogin: true, expectedEnvVars: ["ANTHROPIC_API_KEY"] },
           ],
+          sandbox: {
+            ok: true,
+            backend: "oci",
+            image: "flounder-sandbox:latest",
+            allowHostFallback: false,
+            autoBuild: true,
+            message: "Default sandbox image will be built automatically.",
+            expectedEnvVars: ["SHOULD_NOT_BE_DEFAULT"],
+          },
         },
       }),
     });
@@ -3891,6 +3900,14 @@ test("api: daemon lists return provider-auth summaries by default", async () => 
     const summary = await json(await fetch(base + "/api/daemons"));
     assert.equal(summary.daemons[0].capabilities.configuredProviderCount, 1);
     assert.deepEqual(summary.daemons[0].capabilities.providers[0], { provider: "openai-codex", configured: true, required: true, oauthLogin: true });
+    assert.deepEqual(summary.daemons[0].capabilities.sandbox, {
+      ok: true,
+      backend: "oci",
+      image: "flounder-sandbox:latest",
+      allowHostFallback: false,
+      autoBuild: true,
+      message: "Default sandbox image will be built automatically.",
+    });
     assert.equal(JSON.stringify(summary).includes("SHOULD_NOT_BE_DEFAULT"), false);
 
     const raw = await json(await fetch(base + "/api/daemons?include=capabilities"));


### PR DESCRIPTION
## Summary
- preserve daemon sandbox readiness in the default daemon capabilities summary
- keep the summary allowlisted so raw provider/env capability details are still hidden
- add API regression coverage so project setup can render Sandbox ready/missing instead of Sandbox not reported

## Tests
- npm test