### PR TITLE
Fix pipeline continue coverage batches

### DIFF
--- a/src/agent/audit.ts
+++ b/src/agent/audit.ts
@@ -228,6 +228,19 @@ export async function runAudit(
       const phase = await runPhase(verifyCfg, { mode: "verify", verifySeed: buildVerifySeed(finding), maxSteps: cfg.auditDigSteps }, { ctx: verifyCtx, cwd: verifyWorkspace.absolute });
       aggregatedSteps.push(...phase.steps);
       ingestFindingsFromScratch(verifySession);
+      const claimLabel = String(finding.title ?? "").slice(0, 90);
+      const missingVerdict = verifySession.findings.length === 0;
+      if (missingVerdict) {
+        if (!phaseFailureReason) phaseFailureReason = "error";
+        await logger.event("audit_verify_no_verdict", {
+          index: idx + 1,
+          of: toVerify.length,
+          claim: claimLabel,
+          stoppedReason: phase.stoppedReason,
+          steps: phase.steps.length,
+          commandRuns: verifySession.commandRuns.length,
+        });
+      }
       // Carry the original suspected finding's identity onto THIS claim's verdict so it flips that
       // row (status + PoC) rather than inserting a duplicate. The link is positional — claim N is
       // seeded from input finding N — so it survives the verify session renaming the title. Only the
@@ -252,8 +265,9 @@ export async function runAudit(
       for (const [scratchPath, content] of verifySession.scratchFiles) session.scratchFiles.set(`${verifyLabel}/${scratchPath}`, content);
       for (const produced of verifySession.findings) aggregated.push(produced);
       recorder.findings(verifySession.findings, logger.runDir, `verify ${idx + 1}/${toVerify.length}`); // persist this verdict live (flips the original when originId is set)
-      recorder.runScopes(idx + 1, toVerify.length); // live progress for the UI
-      await logger.event("audit_verify_done", { index: idx + 1, of: toVerify.length, claim: String(finding.title ?? "").slice(0, 90), produced: verifySession.findings.length });
+      recorder.runScopes(missingVerdict ? idx : idx + 1, toVerify.length); // live progress for the UI; no verdict means this claim is not complete
+      await logger.event("audit_verify_done", { index: idx + 1, of: toVerify.length, claim: claimLabel, produced: verifySession.findings.length, stoppedReason: phase.stoppedReason });
+      if (missingVerdict && phase.stoppedReason === "error" && phase.steps.length === 0 && verifySession.commandRuns.length === 0) break;
     }
     aggregated.forEach((produced, i) => {
       produced.id = `f${i + 1}`;

--- a/src/agent/pi-session.ts
+++ b/src/agent/pi-session.ts
@@ -68,6 +68,13 @@ export function resolveFinalizePromptTimeoutMs(env: NodeJS.ProcessEnv = process.
   return Math.max(1, Math.floor(parsed));
 }
 
+export function verifyHasRequiredVerdict(session: ToolContext["session"]): boolean {
+  // In VERIFY mode an empty [] is not a valid clean-audit sentinel: the worker owes
+  // one verdict for the seeded claim, either confirmed by an executable PoC or
+  // refuted with concrete mitigating evidence.
+  return scratchHasFindings(session);
+}
+
 export async function promptWithWallClockAbort(
   session: { prompt: (message: string) => Promise<unknown>; abort: () => unknown },
   prompt: string,
@@ -194,6 +201,7 @@ export async function runAuditSession(input: {
   let finalizing = false;
   let finalizeTurns = 0;
   let finalizeAborted = false;
+  let verifyMissingVerdict = false;
   // Confirm-mode resume: checkpoint the model's decision sheet to the run dir each turn,
   // so an interrupted `flounder confirm` keeps the rows reproduced so far (raw; the end-of-run
   // write replaces them with the consolidated set).
@@ -339,6 +347,23 @@ export async function runAuditSession(input: {
       await input.logger.event("audit_map_finalize_done", { scopes: readScratchScopes(input.ctx.session).length });
       return;
     }
+    if (input.verify) {
+      if (verifyHasRequiredVerdict(input.ctx.session)) return;
+      finalizing = true;
+      await input.logger.event("audit_verify_finalize", { reason: "no verify verdict written before stop" });
+      try {
+        await runFinalizePrompt(VERIFY_FINALIZE_PROMPT, "audit_verify_finalize_timeout");
+      } catch {
+        // best-effort
+      }
+      const hasVerdict = verifyHasRequiredVerdict(input.ctx.session);
+      await input.logger.event("audit_verify_finalize_done", { hasVerdict, hasArtifact: scratchHasFindingsArtifact(input.ctx.session) });
+      if (!hasVerdict) {
+        verifyMissingVerdict = true;
+        await input.logger.event("audit_verify_no_verdict", { reason: "verify requires one confirmed or REFUTED finding for the seeded claim" });
+      }
+      return;
+    }
     if (scratchHasFindingsArtifact(input.ctx.session)) return;
     finalizing = true;
     await input.logger.event("audit_findings_finalize", { reason: "no findings written before stop" });
@@ -383,7 +408,7 @@ export async function runAuditSession(input: {
       // budgetAborted: fall through to the forced finalize below
     }
     await finalizeIfEmpty();
-    return { steps, stoppedReason: budgetAborted ? "step-budget" : "finished" };
+    return { steps, stoppedReason: verifyMissingVerdict ? "error" : budgetAborted ? "step-budget" : "finished" };
   } finally {
     unsubscribe();
     await shutdownSession(session);
@@ -666,6 +691,11 @@ ${MAP_GRANULARITY_RULES}`
 const MAP_FINALIZE_PROMPT = `Your exploration budget is spent. Do NOT read, grep, or run anything else. Based ONLY on what you have already examined, WRITE scopes.json now at the workspace root as your very next action — call the write tool once with a JSON array of objects {"id","obligation","region":"file:lines","lenses":[...],"exposure","difficulty","score","why"} covering every concrete scope you identified under the three general lenses: spec conditions, value/asset flow, and trusted-but-unbound inputs. Score each scope with an integer 0-100 ordering signal; use the full scale to distinguish similarly exposed scopes and do NOT compress into 0-10. If a scope covers multiple independent gates, proof boundaries, invariants, or attacker-controlled inputs, split it before writing. Partial but broad beats empty; do not collapse the inventory into a shortlist or a 30-scope dig batch. After writing, emit {"done": true}. Output only the write tool call.`;
 
 export const FINDINGS_FINALIZE_PROMPT = `Your budget is spent. Do NOT read, grep, or run anything else. Based ONLY on the analysis and command results you have already produced, WRITE findings.json now at the workspace root as your very next action — call the write tool once with ONLY actionable findings: UNMET obligations, concrete suspected bugs, and confirmed bugs that cite an already-passing purpose=confirm command_id. Do NOT include discharged/safe/no-issue obligations, ranked shortlist notes, or obligation ledgers. If you found no actionable bug, write [] exactly. Do NOT invent a confirmation and DO NOT mark anything confirmed by assertion. After writing, emit {"done": true}. Output only the write tool call.`;
+
+export const VERIFY_FINALIZE_PROMPT = `Your VERIFY budget is spent. Do NOT read, grep, or run anything else. Based ONLY on the analysis and command results you have already produced, write findings.json now with exactly ONE verdict for the seeded claim if the existing evidence supports it:
+- If an already-passing purpose=confirm command proves the bug, write one confirmed finding that cites that command_id and includes any fix_patch you already derived.
+- If the code trace or command results prove the claim is false or mitigated, write one severity "info" finding whose title starts "REFUTED:" and cite the exact mitigating evidence.
+If the existing evidence does NOT support either verdict, do NOT write [] and do NOT invent a verdict; emit {"done": true} so the driver marks VERIFY incomplete. After writing a supported verdict, emit {"done": true}.`;
 
 const PREPARE_FINALIZE_PROMPT = `Your budget is spent. Do NOT fetch or run anything else. WRITE prepare_manifest.json now at the workspace root as your very next action — call the write tool once with an object: {"clue","posture","match_deployed"(bool),"scope_declaration":"<where the in-scope set came from: the audited addresses and/or the project's own scope doc>","real_target":{"requires_confirmation":(bool),"mode":"deployed-contract|published-artifact|deployed-service|source-only|unknown","reason":"<why real-target confirmation is or is not required>","ground_truth":[{"kind":"chain|package|service|repo|other","network":"<e.g. ethereum-mainnet, n/a if source-only>","chain_id":<number|null>,"address":"<contract/address or empty if n/a>","role":"proxy|implementation|verifier|registry|asset|package|service|source","block":"<block/tag/version/latest/n/a>","source_match":"matched|unverified|n/a","evidence":"<source of this ground-truth record>","staged_component":"<component id/path>"}],"confirm_guidance":{"required":(bool),"allowed_network_actions":"none|read-only|read-and-local-fork","recommended_method":"<local source tests, package replay, local fork at block..., etc.>","not_required_reason":"<only when required=false>"}},"components":[{"role":"target|dependency|implementation|verifier|other","identity":"<address / package / path / etc.>","platform":"<chain / registry / host, or 'none'>","revision":"<block / version / commit / digest>","source":"<verified|published|repo@commit|unverified>","staged_path":"<workspace-relative path/glob of this component's code>","in_scope":(bool),"scope_basis":"deployed-match|project-scope-doc|first-party|dependency|off-deployment-boundary","match":"matched|unverified|n/a","match_evidence"}],"offscope":[{"kind":"circuit|spec|docs|prior-audit|other","resolved":(bool),"where","note"}],"gaps":[...],"answer_firewall":"clean|flagged: ...","notes"}. Record honestly: a deployed component you could not match is "unverified"; a non-deployed one is "n/a" with its source origin pinned; in_scope=true for the deployment-matched target / project-declared in-scope / first-party code, false for third-party deps and off-deployment trust boundaries (a FACT from deployment + the project's scope, not a guess about bugs). real_target is mandatory: if the later confirm must use a chain fork or published deployment, list the exact network/chain_id/address/role ground truth; if source-only is enough, set requires_confirmation=false and explain why. Every staged first-party source/package that the sealed audit should read must appear in components with a staged_path and revision/version/digest; staged docs/specs may appear in components or offscope, and missing docs/specs should be gaps/caveats rather than blockers. An empty components array is not acceptable after files were staged. Anything you could not find is a gap, not a guess. After writing, emit {"done": true}. Output only the write tool call.`;
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2102,7 +2102,7 @@ async function runLaunch(c: Ctx): Promise<void> {
   const currentResultRunIds = runIdSet(currentResultRuns(currentRuns, scopeBoundary));
   const scopeView = currentScopeView(c.store, projectId, currentRuns, undefined, scopeBoundary, !materialBoundary);
   const progress = scopeView.hasInventory ? scopeView.progress : emptyProgress();
-  const spec = launchSpec(project, body, c.out, profile, progress, phaseProfiles);
+  const spec = launchSpec(c.store, project, body, c.out, profile, progress, phaseProfiles);
   if (spec.verb === "run") {
     if (spec.sourcePaths.length > 0) {
       applyProjectSourceDefaults(spec, project);
@@ -3831,7 +3831,7 @@ function verifyWorklist(store: MetadataStore, projectId: number, currentResultRu
       if (!fromStart || row.confirm_status != null) return false;
       return status === "confirmed-executable" || status === "confirmed-differential";
     })
-    .map((row) => normalizeProjectVerifyFindings(findingDetailRow(row)));
+    .map((row) => normalizeProjectVerifyFindings(store, projectId, findingDetailRow(row)));
 }
 
 async function daemonJobStatus(c: Ctx): Promise<void> {
@@ -4193,7 +4193,7 @@ function phaseProviderProfiles(project: Record<string, unknown>, store: Metadata
   return out;
 }
 
-function launchSpec(project: Record<string, unknown>, body: Record<string, unknown>, out: string, profile?: ProviderProfile, progress?: Coverage, phaseProfiles: PhaseProfiles = {}): LaunchSpec {
+function launchSpec(store: MetadataStore, project: Record<string, unknown>, body: Record<string, unknown>, out: string, profile?: ProviderProfile, progress?: Coverage, phaseProfiles: PhaseProfiles = {}): LaunchSpec {
   const cfg = (safeParse(project.config_json) as Record<string, unknown>) ?? {};
   const overrides = (body.overrides as Record<string, unknown>) ?? {};
   const configOverrides = (overrides.config as Record<string, unknown>) ?? {};
@@ -4279,7 +4279,7 @@ function launchSpec(project: Record<string, unknown>, body: Record<string, unkno
     region: str(body.region),
     scope: str(body.scope),
     scopeNote: str(merged.scopeNote), // a project may store a default focus note in its config
-    ...(body.verifyFindings !== undefined ? { verifyFindings: normalizeProjectVerifyFindings(body.verifyFindings) } : {}),
+    ...(body.verifyFindings !== undefined ? { verifyFindings: normalizeProjectVerifyFindings(store, Number(project.id), body.verifyFindings) } : {}),
     inputRunDir: str(body.inputRunDir),
     clue: str(body.clue),
     posture: str(body.posture),
@@ -4289,12 +4289,16 @@ function launchSpec(project: Record<string, unknown>, body: Record<string, unkno
   };
 }
 
-function normalizeProjectVerifyFindings(input: unknown): unknown {
-  if (Array.isArray(input)) return input.map(normalizeProjectVerifyFindings);
+function normalizeProjectVerifyFindings(store: MetadataStore, projectId: number, input: unknown): unknown {
+  if (Array.isArray(input)) return input.map((item) => normalizeProjectVerifyFindings(store, projectId, item));
   if (!input || typeof input !== "object") return input;
   const row = input as Record<string, unknown>;
   if (typeof row.originId === "number" || typeof row.origin_id === "number") return input;
   if (typeof row.id !== "number" || !Number.isFinite(row.id)) return input;
+  const finding = store.getFinding(row.id);
+  if (finding && Number(finding.project_id) === projectId) {
+    return { ...findingDetailRow(finding), ...row, originId: row.id };
+  }
   return { ...row, originId: row.id };
 }
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -267,7 +267,7 @@ const ROUTES: Route[] = [
       region: "string? — audit: pinned region e.g. src/Foo.sol:120-180", scope: "string? — audit: scope id(s)", verifyFindings: "object|array? — audit: inline suspected finding(s) to confirm-or-refute by execution; project finding rows with id are linked back to that original row",
       allowMaterialDrift: "boolean? — expert override for verifyFindings when a newer Prepare run changed project materials after the selected findings were produced",
       regenerateReports: "boolean? — report: include findings that already have formal reports; selected findingIds are always regenerated",
-      scopeCoverageMode: "focused|standard|half|full|custom? — one-off coverage mode for this run; standard means audit until the project has 30 audited scopes",
+      scopeCoverageMode: "focused|standard|half|full|custom? — one-off coverage mode for this run; standard means audit until the project has 30 audited scopes, then pipeline Continue starts the next 30-scope batch after verify/confirm/report are settled",
       maxScopes: "number? — one-off scope cap for this run, or the custom target when scopeCoverageMode=custom", mapSteps: "number? — one-off map turn cap", digSteps: "number? — one-off per-scope dig turn cap",
       maxSteps: "number? — one-off global turn cap", digSamples: "number? — one-off samples per scope", digConcurrency: "number? — one-off parallel scopes",
       findingId: "number? — confirm/report: reproduce or report one selected finding",
@@ -2126,6 +2126,7 @@ async function runLaunch(c: Ctx): Promise<void> {
   }
   const prepared = applyPreparedWorkspaceIfNeeded(spec, runs);
   if (!prepared.ok) return sendJson(c.res, 400, { error: prepared.error });
+  promoteSettledPipelineCoverageBatch(spec, c.store, projectId, progress, currentResultRunIds, materialBoundary, runs);
   const materialDrift = verifyMaterialDrift(c.store, projectId, spec.verifyFindings, body.allowMaterialDrift === true);
   if (materialDrift) return sendJson(c.res, 409, materialDrift);
   if (coverageTargetReached(spec) && !(spec.verb === "run" && spec.pipeline)) {
@@ -2234,6 +2235,43 @@ function resetPipelineCoverageForUnknownInventory(spec: LaunchSpec): void {
     spec.coverageTarget = undefined;
     spec.maxScopes = undefined;
   }
+}
+
+function promoteSettledPipelineCoverageBatch(
+  spec: LaunchSpec,
+  store: MetadataStore,
+  projectId: number,
+  progress: Coverage,
+  currentResultRunIds: Set<number>,
+  materialBoundary: Record<string, unknown> | undefined,
+  runs: Array<Record<string, unknown>>,
+): void {
+  if (spec.verb !== "run" || !spec.pipeline) return;
+  if (spec.coverageMode !== "standard" || spec.coverageTarget !== 30 || spec.maxScopes !== 0) return;
+  if (progress.pending <= 0) return;
+  if (pipelinePostAuditWorkPending(store, projectId, currentResultRunIds, materialBoundary, runs)) return;
+  spec.maxScopes = Math.min(30, progress.pending);
+}
+
+function pipelinePostAuditWorkPending(
+  store: MetadataStore,
+  projectId: number,
+  currentResultRunIds: Set<number>,
+  materialBoundary: Record<string, unknown> | undefined,
+  runs: Array<Record<string, unknown>>,
+): boolean {
+  if (verifyWorklist(store, projectId, currentResultRunIds, materialBoundary).length > 0) return true;
+  const requiresRealTargetConfirmation = latestPrepareRequiresRealTargetConfirmation(runs);
+  if (requiresRealTargetConfirmation) {
+    const currentDecisions = currentConfirmDecisions(store.listConfirmDecisions(projectId).filter((row) => rowBelongsToCurrentMaterial(row, currentResultRunIds, materialBoundary)));
+    const submissionWorkKeys = new Set(currentDecisions.filter((row) => needsSubmissionReadinessWork(row)).flatMap(confirmDecisionMemberKeys));
+    const pending = store.pendingConfirmable(projectId)
+      .filter((row) => confirmableRunDir(row as unknown as Record<string, unknown>))
+      .filter((row) => rowBelongsToCurrentMaterial(row as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary));
+    if (pending.length > 0 || submissionWorkKeys.size > 0) return true;
+  }
+  const reports = reportWorklist(store, projectId, [], currentResultRunIds, materialBoundary, requiresRealTargetConfirmation);
+  return Array.isArray(reports.findings) && reports.findings.length > 0;
 }
 
 function selectedFindingIds(body: Record<string, unknown>): number[] {

--- a/src/server/ui/src/App.tsx
+++ b/src/server/ui/src/App.tsx
@@ -844,6 +844,34 @@ function pendingDecisionReports(decisions: ConfirmDecision[] | undefined): Confi
   return reportableDecisions(decisions).filter((decision) => !decision.has_report);
 }
 
+function pipelineRunActionDetail(detail: ProjectDetail, hasPipelineRun: boolean): string {
+  if (!hasPipelineRun) return "Run the automatic pipeline: Prepare when needed, then map/dig, confirm reproduced impact, and generate reports.";
+  const requiresConfirmation = needsRealTargetConfirmation(detail);
+  const verifyCount = rawPendingVerifyCount(detail.allFindings);
+  if (verifyCount > 0) return `Continue the current pipeline by verifying ${plural(verifyCount, "candidate")} before starting new scope coverage.`;
+  const confirmCount = pendingConfirmFindings(detail.allFindings, requiresConfirmation, detail.confirmDecisions).length;
+  if (confirmCount > 0) return `Continue the current pipeline by confirming ${plural(confirmCount, "finding")} before starting new scope coverage.`;
+  const reportCount = requiresConfirmation ? pendingDecisionReports(detail.confirmDecisions).length : pendingFormalReports(detail.allFindings, requiresConfirmation).length;
+  if (reportCount > 0) return `Continue the current pipeline by generating ${plural(reportCount, "report")} before starting new scope coverage.`;
+  const mode = coverageModeFromConfig(projectConfig(detail).cfg);
+  const audited = Math.max(0, detail.progress.audited ?? 0);
+  const pending = Math.max(0, detail.progress.pending ?? 0);
+  if (mode === "standard") {
+    if (pending === 0) return "Continue any remaining pipeline work; no pending mapped scopes remain.";
+    if (audited >= 30) return `Continue will start the next Standard batch of up to 30 scopes (${plural(pending, "pending scope")}).`;
+    return `Continue will audit up to ${plural(Math.min(30 - audited, pending), "scope")} to finish the first Standard batch (${audited}/30 audited).`;
+  }
+  if (mode === "focused") {
+    if (pending === 0) return "Continue any remaining pipeline work; no pending mapped scopes remain.";
+    if (audited >= 10) return `Continue will use the saved Focused coverage setting; choose Custom or Full for more scopes.`;
+    return `Continue will audit up to ${plural(Math.min(10 - audited, pending), "scope")} to finish Focused coverage (${audited}/10 audited).`;
+  }
+  if (mode === "half") return pending ? `Continue will audit about half of the ${plural(pending, "pending scope")}.` : "Continue any remaining pipeline work; no pending mapped scopes remain.";
+  if (mode === "full") return pending ? `Continue will audit all ${plural(pending, "pending scope")}.` : "Continue any remaining pipeline work; no pending mapped scopes remain.";
+  const cap = projectConfig(detail).cfg.maxScopes ?? 30;
+  return pending ? `Continue will audit up to ${plural(Math.min(cap, pending), "pending scope")} using Custom coverage.` : "Continue any remaining pipeline work; no pending mapped scopes remain.";
+}
+
 function reportDecisionFindings(detail: ProjectDetail, missingOnly: boolean): FindingRow[] {
   const decisions = missingOnly ? pendingDecisionReports(detail.confirmDecisions) : reportableDecisions(detail.confirmDecisions);
   const keys = new Set(decisions.flatMap(confirmDecisionMemberKeys));
@@ -1823,6 +1851,7 @@ export function App() {
   async function launch(action: LaunchAction, selectedFindings?: FindingRow[]) {
     if (!route.projectUuid) return;
     let verifyCandidates: FindingRow[] = [];
+    let runHint = "";
     if (detail?.project.uuid === route.projectUuid) {
       const currentDetail = currentMaterialDetail(detail);
       const running = currentMaterialRuns(detail.runs, detail.material).find((run) => run.status === "running");
@@ -1848,6 +1877,7 @@ export function App() {
         setModal(null);
         return;
       }
+      if (action === "run") runHint = pipelineRunActionDetail(currentDetail, currentDetail.runs.some((run) => run.kind === "run"));
       const requiresConfirmation = needsRealTargetConfirmation(currentDetail);
       if (action === "confirm" && pendingConfirmFindings(currentDetail.allFindings, requiresConfirmation, currentDetail.confirmDecisions).length === 0) {
         setToast({ tone: "warning", message: "There are no audit-confirmed findings waiting for real-target confirmation yet." });
@@ -1895,7 +1925,7 @@ export function App() {
         tone: waiting ? "warning" : "success",
         message: waiting
           ? `${label} queued, but no online daemon is connected. Start a daemon to claim the job.`
-          : `${label} queued for ${plural(result.daemons ?? 0, "daemon")}.`,
+          : `${label} queued for ${plural(result.daemons ?? 0, "daemon")}.${runHint && action === "run" ? ` ${runHint}` : ""}`,
       });
       await refreshBase();
     } catch (error) {
@@ -2611,6 +2641,7 @@ function ProjectDetailView(props: {
   const runningVerify = isVerifyRun(runningRun) ? runningRun : undefined;
   const runningVerifyProgress = verifyRunProgress(runningVerify);
   const hasPipelineRun = detail.runs.some((run) => run.kind === "run");
+  const pipelineActionDetail = pipelineRunActionDetail(currentDetail, hasPipelineRun);
   const runningInactive = runningRun ? runInactiveLabel(runningRun) : null;
   const [activityReadWatermarks, setActivityReadWatermarks] = useState<Record<string, string>>(() => readStoredStringMap(ACTIVITY_READ_WATERMARKS_KEY));
   const [setupReadWatermarks, setSetupReadWatermarks] = useState<Record<string, string>>(() => readStoredStringMap(SETUP_READ_WATERMARKS_KEY));
@@ -2833,7 +2864,7 @@ function ProjectDetailView(props: {
               variant="primary"
               icon="play"
               disabled={launchLocked}
-              title={runningRun ? "A run is already active for this project." : "Run the automatic pipeline: prepare if needed, map/dig, confirm, and report."}
+              title={runningRun ? "A run is already active for this project." : pipelineActionDetail}
               onClick={() => props.onLaunch("run")}
             >
               {runningRun ? "Running" : hasPipelineRun ? "Continue" : "Run"}
@@ -5496,6 +5527,7 @@ function RunModal({ detail, busy, onClose, onLaunch, onUpdateRunTarget, onError 
   const reportable = requiresConfirmation ? reportableDecisions(detail.confirmDecisions).length : reportableFindings(detail.allFindings, requiresConfirmation).length;
   const missingReports = requiresConfirmation ? pendingDecisionReports(detail.confirmDecisions).length : pendingFormalReports(detail.allFindings, requiresConfirmation).length;
   const hasPipelineRun = detail.runs.some((run) => run.kind === "run");
+  const pipelineActionDetail = pipelineRunActionDetail(detail, hasPipelineRun);
   const locked = busy || Boolean(running);
   const projectCoverageMode = coverageModeFromConfig(projectConfig(detail).cfg);
   const [runCoverageMode, setRunCoverageMode] = useState<CoverageMode>(projectCoverageMode);
@@ -5531,7 +5563,7 @@ function RunModal({ detail, busy, onClose, onLaunch, onUpdateRunTarget, onError 
     ? "Optionally re-run Prepare to close provenance, deployment-match, or real-target caveats. The current materials can still drive Map/Dig."
     : "Acquire official source/docs, pin provenance, and record material or real-target gaps before sealed auditing.";
   const options: Array<{ verb: LaunchAction; label: string; detail: string; disabled?: boolean }> = [
-    { verb: "run", label: hasPipelineRun ? "Continue" : "Run", detail: "Run the automatic pipeline: Prepare when needed, then map/dig, confirm reproduced impact, and generate reports.", disabled: locked },
+    { verb: "run", label: hasPipelineRun ? "Continue" : "Run", detail: pipelineActionDetail, disabled: locked },
     {
       verb: "prepare",
       label: prepareActionLabel,

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -382,7 +382,7 @@ test("api: full coverage continues prepared pending inventory without a scope ca
   });
 });
 
-test("api: standard coverage lets pipeline continue after 30 audited scopes but still allows explicit scopes", async () => {
+test("api: standard pipeline continue opens the next 30-scope batch after the first batch is settled", async () => {
   await withServer(async (base, out) => {
     const json = (r) => r.json();
     const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
@@ -396,7 +396,7 @@ test("api: standard coverage lets pipeline continue after 30 audited scopes but 
     try {
       store.upsertScopes(created.id, [
         ...Array.from({ length: 30 }, (_, i) => ({ scopeId: `audited-${i}`, title: `Audited ${i}`, status: "audited", score: 30 - i })),
-        ...Array.from({ length: 5 }, (_, i) => ({ scopeId: `pending-${i}`, title: `Pending ${i}`, status: "pending", score: 5 - i })),
+        ...Array.from({ length: 35 }, (_, i) => ({ scopeId: `pending-${i}`, title: `Pending ${i}`, status: "pending", score: 35 - i })),
       ]);
     } finally {
       store.close();
@@ -409,7 +409,7 @@ test("api: standard coverage lets pipeline continue after 30 audited scopes but 
     assert.equal(pipelineSpec.pipeline, true);
     assert.equal(pipelineSpec.coverageMode, "standard");
     assert.equal(pipelineSpec.coverageTarget, 30);
-    assert.equal(pipelineSpec.maxScopes, 0);
+    assert.equal(pipelineSpec.maxScopes, 30);
     assert.equal(pipelineSpec.sandboxConfirmNetwork, "enabled");
 
     const continued = await post(`/api/projects/${created.uuid}/runs`, { verb: "run" });
@@ -423,6 +423,50 @@ test("api: standard coverage lets pipeline continue after 30 audited scopes but 
     const spec = JSON.parse(job.spec_json);
     assert.equal(spec.scope, "pending-0");
     assert.equal(spec.maxScopes, 30);
+  });
+});
+
+test("api: standard pipeline continue finishes pending verify work before opening the next scope batch", async () => {
+  await withServer(async (base, out) => {
+    const json = (r) => r.json();
+    const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    const created = await json(await post("/api/projects", {
+      name: "standard-cumulative-pending-verify",
+      sourcePaths: ["./src"],
+      config: { scopeCoverageMode: "standard" },
+    }));
+
+    const store = MetadataStore.openForOutput(out);
+    try {
+      store.upsertScopes(created.id, [
+        ...Array.from({ length: 30 }, (_, i) => ({ scopeId: `audited-${i}`, title: `Audited ${i}`, status: "audited", score: 30 - i })),
+        ...Array.from({ length: 5 }, (_, i) => ({ scopeId: `pending-${i}`, title: `Pending ${i}`, status: "pending", score: 5 - i })),
+      ]);
+      const runId = store.startRun({ projectId: created.id, kind: "run", runDir: path.join(out, "standard-cumulative-pending-verify-run") });
+      store.upsertFindings(created.id, runId, [
+        {
+          findingKey: "ksuspected",
+          title: "Needs execution verification",
+          location: "src/A.sol:1",
+          severity: "high",
+          status: "suspected",
+          evidence: "candidate",
+        },
+      ]);
+      store.finishRun(runId, "done");
+    } finally {
+      store.close();
+    }
+
+    const pipeline = await json(await post(`/api/projects/${created.uuid}/runs`, { verb: "run", pipeline: true }));
+    assert.equal(pipeline.queued, true);
+    const pipelineJob = (await json(await fetch(base + "/api/jobs/" + pipeline.jobId))).job;
+    const pipelineSpec = JSON.parse(pipelineJob.spec_json);
+    assert.equal(pipelineSpec.pipeline, true);
+    assert.equal(pipelineSpec.coverageMode, "standard");
+    assert.equal(pipelineSpec.coverageTarget, 30);
+    assert.equal(pipelineSpec.maxScopes, 0);
+    assert.equal(pipelineSpec.sandboxConfirmNetwork, "enabled");
   });
 });
 

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -836,6 +836,17 @@ test("api: verify launch links project finding rows back to the original finding
     assert.equal(spec.verb, "audit");
     assert.equal(spec.verifyFindings[0].id, finding.id);
     assert.equal(spec.verifyFindings[0].originId, finding.id);
+
+    const launchedById = await json(await post(`/api/projects/${created.uuid}/runs`, {
+      verb: "audit",
+      verifyFindings: [{ id: finding.id }],
+    }));
+    const idJob = (await json(await fetch(base + "/api/jobs/" + launchedById.jobId))).job;
+    const idSpec = JSON.parse(idJob.spec_json);
+    assert.equal(idSpec.verifyFindings[0].id, finding.id);
+    assert.equal(idSpec.verifyFindings[0].originId, finding.id);
+    assert.equal(idSpec.verifyFindings[0].title, "Proof input is not bound");
+    assert.equal(idSpec.verifyFindings[0].location, "src/Rollup.sol:44");
   });
 });
 
@@ -882,6 +893,8 @@ test("api: verify launch rejects findings produced before a newer prepare run", 
     const job = (await json(await fetch(base + "/api/jobs/" + launched.jobId))).job;
     const spec = JSON.parse(job.spec_json);
     assert.equal(spec.verifyFindings[0].originId, findingId);
+    assert.equal(spec.verifyFindings[0].finding_key, "stale-suspected-bug");
+    assert.equal(spec.verifyFindings[0].title, "Stale proof input is not bound");
   });
 });
 

--- a/tests/pi-session-verify.test.mjs
+++ b/tests/pi-session-verify.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { verifyHasRequiredVerdict } from "../dist/agent/pi-session.js";
+import { newSession } from "../dist/agent/tools.js";
+
+test("pi VERIFY mode requires a non-empty verdict finding", () => {
+  const missing = newSession();
+  assert.equal(verifyHasRequiredVerdict(missing), false);
+
+  const empty = newSession();
+  empty.scratchFiles.set("findings.json", "[]");
+  assert.equal(verifyHasRequiredVerdict(empty), false);
+
+  const wrappedEmpty = newSession();
+  wrappedEmpty.scratchFiles.set("findings.json", JSON.stringify({ findings: [] }));
+  assert.equal(verifyHasRequiredVerdict(wrappedEmpty), false);
+
+  const verdict = newSession();
+  verdict.scratchFiles.set("findings.json", JSON.stringify([
+    {
+      title: "REFUTED: claim is mitigated",
+      severity: "info",
+      location: "src/example.ts:1",
+      description: "The cited value is bound by a nearby check.",
+    },
+  ]));
+  assert.equal(verifyHasRequiredVerdict(verdict), true);
+});


### PR DESCRIPTION
## Summary
- Treat empty verify runs as incomplete so Continue does not silently skip verification/report flow.
- Make pipeline Continue open the next up-to-30 Standard coverage batch only after verify/confirm/report work is settled.
- Preserve DB-backed finding details when launching verify from project finding IDs, so daemon verification receives enough evidence.
- Surface Continue intent in the project button, Run controls, and queued toast.

## Tests
- npm run check
- npm run build:server
- node --test tests/run-manager.test.mjs
- node --test tests/api.test.mjs