### PR TITLE
Resume interrupted coverage batches on Continue

### DIFF
--- a/docker/flounder-sandbox.Dockerfile
+++ b/docker/flounder-sandbox.Dockerfile
@@ -4,13 +4,20 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gnupg \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
     bash \
     build-essential \
-    ca-certificates \
     cmake \
     cargo \
     coreutils \
-    curl \
     findutils \
     gawk \
     git \
@@ -19,7 +26,6 @@ RUN apt-get update \
     jq \
     libgmp-dev \
     nodejs \
-    npm \
     ninja-build \
     pkg-config \
     python3 \
@@ -29,6 +35,8 @@ RUN apt-get update \
     ripgrep \
     rustc \
     sed \
+  && node --version \
+  && npm --version \
   && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g yarn@1.22.22 pnpm@9.15.9 \

--- a/src/agent/prepare.ts
+++ b/src/agent/prepare.ts
@@ -59,25 +59,27 @@ export interface ToolVersionCheck {
   reason?: string;
 }
 
-export async function prepareWorkspaceToolchain(input: { workspace: SandboxWorkspace; cfg: AuditorConfig; logger: RunLogger; cacheDir?: string }): Promise<PrepareReport> {
+export async function prepareWorkspaceToolchain(input: { workspace: SandboxWorkspace; cfg: AuditorConfig; logger: RunLogger; cacheDir?: string; focusCommand?: ReproductionCommand }): Promise<PrepareReport> {
+  const allPlans = await detectToolchains(input.workspace.absolute);
+  const plans = focusPlans(allPlans, input.focusCommand);
   const pinnedToolVersions = await detectPinnedToolVersions(input.workspace.absolute);
+  const relevantPins = relevantPinnedToolVersions(pinnedToolVersions, plans);
   if (pinnedToolVersions.length > 0) {
     await input.logger.event("audit_prepare_tool_versions", { pins: pinnedToolVersions });
   }
-  const toolVersionChecks = await checkPinnedToolVersions(input, pinnedToolVersions);
+  const toolVersionChecks = await checkPinnedToolVersions(input, relevantPins);
   if (toolVersionChecks.length > 0) {
     await input.logger.event("audit_prepare_tool_version_checks", { checks: toolVersionChecks });
   }
-  const plans = await detectToolchains(input.workspace.absolute);
   const failedChecks = toolVersionChecks.filter((check) => !check.ok);
   if (failedChecks.length > 0) {
     await input.logger.event("audit_prepare_tool_version_mismatch", { checks: failedChecks });
-    await input.logger.artifact("audit_prepare.json", { detected: plans.map((plan) => plan.toolchain), pinnedToolVersions, toolVersionChecks, results: [] });
-    return { ran: false, detected: plans.map((plan) => plan.toolchain), pinnedToolVersions, toolVersionChecks, results: [] };
+    await input.logger.artifact("audit_prepare.json", { detected: plans.map((plan) => plan.toolchain), pinnedToolVersions: relevantPins, toolVersionChecks, results: [] });
+    return { ran: false, detected: plans.map((plan) => plan.toolchain), pinnedToolVersions: relevantPins, toolVersionChecks, results: [] };
   }
   if (plans.length === 0) {
     await input.logger.event("audit_prepare_skipped", { reason: "no supported toolchain manifest detected" });
-    return { ran: false, detected: [], pinnedToolVersions, toolVersionChecks, results: [] };
+    return { ran: false, detected: [], pinnedToolVersions: relevantPins, toolVersionChecks, results: [] };
   }
 
   await input.logger.event("audit_prepare_start", { toolchains: plans.map((plan) => plan.toolchain), timeoutMs: input.cfg.auditPrepareTimeoutMs });
@@ -117,8 +119,8 @@ export async function prepareWorkspaceToolchain(input: { workspace: SandboxWorks
     }
   }
 
-  await input.logger.artifact("audit_prepare.json", { detected: plans.map((plan) => plan.toolchain), pinnedToolVersions, toolVersionChecks, results });
-  return { ran: true, detected: plans.map((plan) => plan.toolchain), pinnedToolVersions, toolVersionChecks, results };
+  await input.logger.artifact("audit_prepare.json", { detected: plans.map((plan) => plan.toolchain), pinnedToolVersions: relevantPins, toolVersionChecks, results });
+  return { ran: true, detected: plans.map((plan) => plan.toolchain), pinnedToolVersions: relevantPins, toolVersionChecks, results };
 }
 
 export function prepareToolVersionBlockingIssue(report: PrepareReport): string | undefined {
@@ -202,6 +204,72 @@ interface ToolchainPlan {
   toolchain: Toolchain;
   cwd?: string;
   commands: string[][];
+}
+
+function focusPlans(plans: ToolchainPlan[], command?: ReproductionCommand): ToolchainPlan[] {
+  if (!command) return plans;
+  const commandToolchain = commandToolchainName(command.program);
+  const cwd = normalizePlanDir(command.cwd ?? "");
+  let focused = commandToolchain
+    ? plans.filter((plan) => plan.toolchain === commandToolchain && planCoversCommandCwd(plan.cwd, cwd))
+    : plans.filter((plan) => cwd && sameOrNestedPlan(plan.cwd, cwd));
+  if (focused.length === 0 && commandToolchain) {
+    focused = plans.filter((plan) => plan.toolchain === commandToolchain);
+  }
+  if (focused.length === 0) return plans;
+  const focusDirs = focused.map((plan) => normalizePlanDir(plan.cwd ?? ""));
+  const dependencyPlans = plans.filter((plan) =>
+    ["npm", "pnpm", "yarn"].includes(plan.toolchain)
+    && focusDirs.some((dir) => sameOrNestedPlan(plan.cwd, dir) || sameOrNestedPlan(dir, plan.cwd ?? "")),
+  );
+  focused = [...dependencyPlans, ...focused];
+  return uniquePlans(focused);
+}
+
+function commandToolchainName(program: string): Toolchain | undefined {
+  const name = path.basename(program);
+  if (name === "npm" || name === "pnpm" || name === "yarn" || name === "cargo" || name === "go" || name === "forge" || name === "scarb" || name === "blueprint") return name;
+  return undefined;
+}
+
+function planCoversCommandCwd(planCwd: string | undefined, commandCwd: string): boolean {
+  const planDir = normalizePlanDir(planCwd ?? "");
+  const commandDir = normalizePlanDir(commandCwd);
+  return planDir === commandDir || commandDir.startsWith(`${planDir}/`);
+}
+
+function relevantPinnedToolVersions(pins: PinnedToolVersion[], plans: ToolchainPlan[]): PinnedToolVersion[] {
+  return pins.filter((pin) => plans.some((plan) => pinAppliesToPlan(pin, plan)));
+}
+
+function pinAppliesToPlan(pin: PinnedToolVersion, plan: ToolchainPlan): boolean {
+  if (pin.tool === "scarb" || pin.tool === "starknet-foundry" || pin.tool === "universal-sierra-compiler") {
+    return plan.toolchain === "scarb" && sameOrNestedPlan(pin.dir, plan.cwd ?? "");
+  }
+  return sameOrNestedPlan(pin.dir, plan.cwd ?? "");
+}
+
+function sameOrNestedPlan(a: string | undefined, b: string | undefined): boolean {
+  const left = normalizePlanDir(a ?? "");
+  const right = normalizePlanDir(b ?? "");
+  return left === right || left === "." || right === "." || left.startsWith(`${right}/`) || right.startsWith(`${left}/`);
+}
+
+function normalizePlanDir(value: string): string {
+  const normalized = value.replaceAll("\\", "/").replace(/^\.\/+/, "").replace(/\/+$/, "");
+  return normalized || ".";
+}
+
+function uniquePlans(plans: ToolchainPlan[]): ToolchainPlan[] {
+  const seen = new Set<string>();
+  const out: ToolchainPlan[] = [];
+  for (const plan of plans) {
+    const key = `${plan.toolchain}:${plan.cwd ?? "."}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(plan);
+  }
+  return out;
 }
 
 async function detectToolchains(workspaceAbsolute: string): Promise<ToolchainPlan[]> {

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -574,7 +574,7 @@ function commandFileArgs(command: ReproductionCommand, session: AgentSession): s
       continue;
     }
     if (arg.startsWith("-")) continue;
-    addCommandFileArg(out, arg, [], session);
+    addCommandFileArg(out, arg, roots, session);
   }
   return [...new Set(out)];
 }

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -346,7 +346,7 @@ const bashTool: AgentTool = {
     // the toolchain on first use rather than eagerly for every (possibly
     // read-only or unauthenticated) run.
     if (isAgentConfirmCommand(normalized.command) || isAgentBuildCommand(normalized.command)) {
-      const prepareBlock = await ensurePrepared(ctx, workspace);
+      const prepareBlock = await ensurePrepared(ctx, workspace, normalized.command);
       if (prepareBlock) return { observation: `blocked: ${prepareBlock} Write resource_requests.json with kind "sandbox-image" or rebuild/select the correct target-specific image before retrying.` };
     }
     ctx.session.counters.command += 1;
@@ -837,12 +837,12 @@ function dirname(normalizedPath: string): string {
   return idx === -1 ? "" : normalizedPath.slice(0, idx);
 }
 
-async function ensurePrepared(ctx: ToolContext, workspace: SandboxWorkspace): Promise<string | undefined> {
+async function ensurePrepared(ctx: ToolContext, workspace: SandboxWorkspace, focusCommand?: ReproductionCommand): Promise<string | undefined> {
   if (!ctx.cfg.auditPrepare) return undefined;
   if (ctx.session.prepareBlock) return ctx.session.prepareBlock;
   if (ctx.session.prepared) return undefined;
   ctx.session.prepared = true; // set before awaiting so a second test command does not re-trigger
-  const report = await prepareWorkspaceToolchain({ workspace, cfg: ctx.cfg, logger: ctx.logger, ...(ctx.session.buildCacheDir ? { cacheDir: ctx.session.buildCacheDir } : {}) });
+  const report = await prepareWorkspaceToolchain({ workspace, cfg: ctx.cfg, logger: ctx.logger, ...(ctx.session.buildCacheDir ? { cacheDir: ctx.session.buildCacheDir } : {}), ...(focusCommand ? { focusCommand } : {}) });
   const issue = prepareToolVersionBlockingIssue(report);
   if (issue) ctx.session.prepareBlock = issue;
   return issue;

--- a/src/cli-project.ts
+++ b/src/cli-project.ts
@@ -6,10 +6,12 @@ export function buildProjectContinueBody(args: readonly string[]): Record<string
   if (args.includes("--remap")) body.remap = true;
   if (args.includes("--quick")) body.quick = true;
   if (args.includes("--mock-llm")) body.mockLlm = true;
+  if (args.includes("--continue-coverage")) body.continueCoverage = true;
   const scopeCoverageMode = readFlag(args, "--scope-coverage-mode") ?? readFlag(args, "--coverage");
   if (scopeCoverageMode !== undefined) {
     if (!COVERAGE_MODES.has(scopeCoverageMode)) throw new Error("--coverage needs focused|standard|half|full|custom");
     body.scopeCoverageMode = scopeCoverageMode;
+    body.continueCoverage = true;
   }
   for (const [flag, key] of [
     ["--max-scopes", "maxScopes"],
@@ -20,7 +22,10 @@ export function buildProjectContinueBody(args: readonly string[]): Record<string
     ["--dig-concurrency", "digConcurrency"],
   ] as const) {
     const value = readIntFlag(args, flag);
-    if (value !== undefined) body[key] = value;
+    if (value !== undefined) {
+      body[key] = value;
+      if (flag === "--max-scopes") body.continueCoverage = true;
+    }
   }
   return body;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1012,7 +1012,7 @@ Usage:
   flounder verify  <file> --source <paths...>                                     alias for audit --verify: confirm/refute suspected findings locally
   flounder confirm <run-dir> --source <paths...>                                  open-world: reproduce a run's findings on the real target
   flounder report  --project <uuid|name> [--finding <id>...] [--all]              generate missing reports or regenerate selected/all formal reports
-  flounder continue --project <uuid|name>                                         continue the stored project pipeline (same as the UI Continue button)
+  flounder continue --project <uuid|name>                                         finish the stored project pipeline round (same as the UI Continue button)
   flounder history import-run --target <name> --run <dir>
   flounder server project list                                                   list tracked projects
   flounder server run list [--project <name>]                                    list run history globally or for one project
@@ -1121,6 +1121,7 @@ flounder continue:
   --project <uuid|name>   tracked UI/API project. Names are resolved client-side when unique.
   --verify-from-start     re-run Verify from the beginning instead of only pending candidates.
   --remap                 re-enumerate scopes from scratch before digging.
+  --continue-coverage     explicitly open another mapped scope batch after the current round is settled.
   --coverage <mode>       focused|standard|half|full|custom one-off coverage mode.
   --max-scopes <n>        one-off scope cap, or custom target when --coverage custom.
 `);
@@ -1153,14 +1154,19 @@ Usage:
 
 This is the CLI equivalent of the UI Continue button. It queues project work with
 verb:"run", so the control plane decides the next phase from stored project state:
-prepare if needed, map/dig pending scopes, verify pending claims, confirm pending
-real-target findings, and generate missing reports.
+prepare if needed, finish the current map/dig batch, verify pending claims,
+confirm pending real-target findings, and generate missing reports.
+
+After a round has produced its reports, plain continue stops. Pass
+--continue-coverage, --coverage, or --max-scopes only when you intentionally want
+to open another mapped scope batch.
 
 Options:
   --project <uuid|name>     tracked UI/API project; names are allowed when unique
   --verify-from-start       re-run Verify from the beginning instead of only pending candidates
   --remap                   re-enumerate scopes from scratch before digging
   --quick                   single breadth pass instead of map -> dig
+  --continue-coverage       explicitly open another mapped scope batch after this round is settled
   --coverage <mode>         focused|standard|half|full|custom one-off coverage mode
   --max-scopes <n>          one-off scope cap, or custom target when --coverage custom
   --map-steps <n>           one-off map turn cap

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -268,6 +268,7 @@ const ROUTES: Route[] = [
       region: "string? — audit: pinned region e.g. src/Foo.sol:120-180", scope: "string? — audit: scope id(s)", verifyFindings: "object|array? — audit: inline suspected finding(s) to confirm-or-refute by execution; project finding rows with id are linked back to that original row",
       allowMaterialDrift: "boolean? — expert override for verifyFindings when a newer Prepare run changed project materials after the selected findings were produced",
       regenerateReports: "boolean? — report: include findings that already have formal reports; selected findingIds are always regenerated",
+      continueCoverage: "boolean? — explicit opt-in to open the next mapped scope batch after the current pipeline round is fully settled",
       scopeCoverageMode: "focused|standard|half|full|custom? — one-off coverage mode for this run; standard means audit until the project has 30 audited scopes; pass continueCoverage:true to explicitly start another scope batch after verify/confirm/report are settled",
       maxScopes: "number? — one-off scope cap for this run, or the custom target when scopeCoverageMode=custom", mapSteps: "number? — one-off map turn cap", digSteps: "number? — one-off per-scope dig turn cap",
       maxSteps: "number? — one-off global turn cap", digSamples: "number? — one-off samples per scope", digConcurrency: "number? — one-off parallel scopes",

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -268,7 +268,7 @@ const ROUTES: Route[] = [
       region: "string? — audit: pinned region e.g. src/Foo.sol:120-180", scope: "string? — audit: scope id(s)", verifyFindings: "object|array? — audit: inline suspected finding(s) to confirm-or-refute by execution; project finding rows with id are linked back to that original row",
       allowMaterialDrift: "boolean? — expert override for verifyFindings when a newer Prepare run changed project materials after the selected findings were produced",
       regenerateReports: "boolean? — report: include findings that already have formal reports; selected findingIds are always regenerated",
-      scopeCoverageMode: "focused|standard|half|full|custom? — one-off coverage mode for this run; standard means audit until the project has 30 audited scopes, then pipeline Continue starts the next 30-scope batch after verify/confirm/report are settled",
+      scopeCoverageMode: "focused|standard|half|full|custom? — one-off coverage mode for this run; standard means audit until the project has 30 audited scopes; pass continueCoverage:true to explicitly start another scope batch after verify/confirm/report are settled",
       maxScopes: "number? — one-off scope cap for this run, or the custom target when scopeCoverageMode=custom", mapSteps: "number? — one-off map turn cap", digSteps: "number? — one-off per-scope dig turn cap",
       maxSteps: "number? — one-off global turn cap", digSamples: "number? — one-off samples per scope", digConcurrency: "number? — one-off parallel scopes",
       findingId: "number? — confirm/report: reproduce or report one selected finding",
@@ -439,7 +439,7 @@ const ROUTES: Route[] = [
       provider: "string?", model: "string?", thinking: "string?",
       scopeCoverageMode: "focused|standard|half|full|custom? — standard/focused are cumulative project targets, not per-run additions", maxScopes: "number?", mapSteps: "number?", digSteps: "number?", maxSteps: "number?", digSamples: "number?", digConcurrency: "number?",
       sandboxBackend: "'auto'|'oci'|'apple-container'|'host'?", sandboxImage: "string?", sandboxAllowHostFallback: "boolean?", sandboxPrepareNetwork: "'none'|'enabled'?", sandboxConfirmNetwork: "'none'|'enabled'?",
-      remap: "boolean?", quick: "boolean?", mockLlm: "boolean?", pipeline: "boolean? — run clue pipeline: prepare if needed -> map/dig -> synthesize -> verify -> confirm -> report", verifyFromStart: "boolean? — pipeline: re-run Verify from the beginning instead of only pending candidates", region: "string?", scope: "string?", scopeNote: "string? — map/audit: 'authorized scope note' that focuses map on the in-scope target (the pipeline auto-derives it from prepare's manifest)", verifyFindings: "object|array? — audit: inline suspected finding(s) to confirm-or-refute by execution",
+      remap: "boolean?", quick: "boolean?", mockLlm: "boolean?", pipeline: "boolean? — run clue pipeline: prepare if needed -> map/dig -> synthesize -> verify -> confirm -> report", continueCoverage: "boolean? — explicit opt-in to open the next mapped scope batch after the current pipeline round is fully settled", verifyFromStart: "boolean? — pipeline: re-run Verify from the beginning instead of only pending candidates", region: "string?", scope: "string?", scopeNote: "string? — map/audit: 'authorized scope note' that focuses map on the in-scope target (the pipeline auto-derives it from prepare's manifest)", verifyFindings: "object|array? — audit: inline suspected finding(s) to confirm-or-refute by execution",
       inputRunDir: "string? — confirm", fresh: "boolean? — confirm",
       clue: "string? — prepare", posture: "string? — prepare", matchDeployed: "boolean? — prepare", endpoint: "string? — prepare",
     },
@@ -2174,6 +2174,16 @@ async function runLaunch(c: Ctx): Promise<void> {
   promoteSettledPipelineCoverageBatch(spec, c.store, projectId, progress, currentResultRunIds, materialBoundary, runs);
   const materialDrift = verifyMaterialDrift(c.store, projectId, spec.verifyFindings, body.allowMaterialDrift === true);
   if (materialDrift) return sendJson(c.res, 409, materialDrift);
+  if (spec.verb === "run" && spec.pipeline && pipelineRoundComplete(spec, progress, c.store, projectId, currentResultRunIds, materialBoundary, runs)) {
+    return sendJson(c.res, 409, {
+      error: "Current pipeline round is complete. Pass continueCoverage:true, choose a coverage mode, or use Dig pending scopes to start another scope batch.",
+      roundComplete: true,
+      continueCoverageRequired: true,
+      coverageMode: spec.coverageMode,
+      coverageTarget: spec.coverageTarget,
+      progress,
+    });
+  }
   if (coverageTargetReached(spec) && !(spec.verb === "run" && spec.pipeline)) {
     const target = spec.coverageTarget;
     const denominator = target ? Math.min(target, progress.total || target) : progress.total;
@@ -2316,9 +2326,26 @@ function promoteSettledPipelineCoverageBatch(
 ): void {
   if (spec.verb !== "run" || !spec.pipeline) return;
   if (spec.coverageMode !== "standard" || spec.coverageTarget !== 30 || spec.maxScopes !== 0) return;
+  if (!spec.continueCoverage) return;
   if (progress.pending <= 0) return;
   if (pipelinePostAuditWorkPending(store, projectId, currentResultRunIds, materialBoundary, runs)) return;
   spec.maxScopes = Math.min(30, progress.pending);
+}
+
+function pipelineRoundComplete(
+  spec: LaunchSpec,
+  _progress: Coverage,
+  store: MetadataStore,
+  projectId: number,
+  currentResultRunIds: Set<number>,
+  materialBoundary: Record<string, unknown> | undefined,
+  runs: Array<Record<string, unknown>>,
+): boolean {
+  if (spec.continueCoverage) return false;
+  if (spec.maxScopes !== 0) return false;
+  if (!coverageTargetReached(spec)) return false;
+  if (pipelinePostAuditWorkPending(store, projectId, currentResultRunIds, materialBoundary, runs)) return false;
+  return true;
 }
 
 function pipelinePostAuditWorkPending(
@@ -2741,6 +2768,7 @@ function normalizeLaunchSpec(body: Record<string, unknown>, target: string, verb
     quick: bool(body.quick),
     mockLlm: bool(body.mockLlm),
     pipeline: bool(body.pipeline),
+    continueCoverage: bool(body.continueCoverage),
     verifyFromStart: bool(body.verifyFromStart),
     region: str(body.region),
     scope: str(body.scope),
@@ -4294,6 +4322,11 @@ function launchSpec(store: MetadataStore, project: Record<string, unknown>, body
   const bodyOverrides = runBodyConfigOverrides(body);
   const merged = { ...cfg, ...configOverrides, ...bodyOverrides };
   const explicitRunMaxScopes = configOverrides.maxScopes !== undefined || bodyOverrides.maxScopes !== undefined;
+  const explicitCoverageContinuation =
+    body.continueCoverage === true
+    || configOverrides.scopeCoverageMode !== undefined
+    || bodyOverrides.scopeCoverageMode !== undefined
+    || explicitRunMaxScopes;
   const num = (v: unknown): number | undefined => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
   const str = (v: unknown): string | undefined => (typeof v === "string" && v ? v : undefined);
   const backend = (v: unknown): SandboxBackend | undefined => isSandboxBackend(v) ? v : undefined;
@@ -4369,6 +4402,7 @@ function launchSpec(store: MetadataStore, project: Record<string, unknown>, body
     quick: Boolean(body.quick),
     mockLlm: Boolean(body.mockLlm),
     pipeline,
+    continueCoverage: explicitCoverageContinuation,
     verifyFromStart: Boolean(body.verifyFromStart),
     region: str(body.region),
     scope: str(body.scope),

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2209,9 +2209,8 @@ async function runLaunch(c: Ctx): Promise<void> {
       spec.confirmKeys = rows.flatMap((row) => confirmSelectorsForFinding(row as unknown as { id?: unknown; finding_key?: unknown }));
       spec.confirmFindings = confirmFindingSeeds(c.store, Number(project.id), rows);
     } else {
-      const pending = c.store.pendingConfirmable(Number(project.id))
-        .filter((p) => confirmableRunDir(p as unknown as Record<string, unknown>))
-        .filter((p) => rowBelongsToCurrentMaterial(p as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary));
+      const currentDecisions = currentConfirmDecisions(c.store.listConfirmDecisions(Number(project.id)).filter((row) => rowBelongsToCurrentMaterial(row, currentResultRunIds, materialBoundary)));
+      const pending = confirmWorkRows(c.store, Number(project.id), currentResultRunIds, materialBoundary, currentDecisions);
       if (pending.length === 0) return sendJson(c.res, 400, { error: "nothing to confirm — every audit-confirmed finding already has a real-target decision (use --fresh to redo)" });
       const context = c.store.confirmableContext(Number(project.id))
         .filter((p) => confirmableRunDir(p as unknown as Record<string, unknown>))
@@ -2221,7 +2220,6 @@ async function runLaunch(c: Ctx): Promise<void> {
       spec.inputRunDir = spec.inputRunDirs[0];
       spec.confirmKeys = rows.flatMap((p) => confirmSelectorsForFinding(p as unknown as { id?: unknown; finding_key?: unknown }));
       spec.confirmFindings = confirmFindingSeeds(c.store, Number(project.id), rows);
-      const currentDecisions = currentConfirmDecisions(c.store.listConfirmDecisions(Number(project.id)).filter((row) => rowBelongsToCurrentMaterial(row, currentResultRunIds, materialBoundary)));
       spec.confirmSettledRows = confirmSettledRows(currentDecisions);
     }
   }
@@ -2334,15 +2332,46 @@ function pipelinePostAuditWorkPending(
   const requiresRealTargetConfirmation = latestPrepareRequiresRealTargetConfirmation(runs);
   if (requiresRealTargetConfirmation) {
     const currentDecisions = currentConfirmDecisions(store.listConfirmDecisions(projectId).filter((row) => rowBelongsToCurrentMaterial(row, currentResultRunIds, materialBoundary)));
-    const decisionKeys = confirmDecisionKeySet(currentDecisions);
-    const pending = store.pendingConfirmable(projectId)
-      .filter((row) => confirmableRunDir(row as unknown as Record<string, unknown>))
-      .filter((row) => rowBelongsToCurrentMaterial(row as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary))
-      .filter((row) => !findingRowCoveredByDecision(row as unknown as Record<string, unknown>, decisionKeys));
+    const pending = confirmWorkRows(store, projectId, currentResultRunIds, materialBoundary, currentDecisions);
     if (pending.length > 0) return true;
   }
   const reports = reportWorklist(store, projectId, [], currentResultRunIds, materialBoundary, requiresRealTargetConfirmation);
   return Array.isArray(reports.findings) && reports.findings.length > 0;
+}
+
+function confirmWorkRows(
+  store: MetadataStore,
+  projectId: number,
+  currentResultRunIds: Set<number>,
+  materialBoundary: Record<string, unknown> | undefined,
+  currentDecisions: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+  const settledKeys = confirmDecisionKeySet(currentDecisions.filter((row) => !needsSubmissionReadinessWork(row)));
+  const pending = store.pendingConfirmable(projectId)
+    .filter((row) => confirmableRunDir(row as unknown as Record<string, unknown>))
+    .filter((row) => rowBelongsToCurrentMaterial(row as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary))
+    .filter((row) => !findingRowCoveredByDecision(row as unknown as Record<string, unknown>, settledKeys));
+  const readinessKeys = new Set(currentDecisions.filter((row) => needsSubmissionReadinessWork(row)).flatMap(confirmDecisionMemberKeys));
+  const readiness = readinessKeys.size === 0 ? [] : store.confirmableContext(projectId)
+    .filter((row) => confirmableRunDir(row as unknown as Record<string, unknown>))
+    .filter((row) => rowBelongsToCurrentMaterial(row as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary))
+    .filter((row) => {
+      const key = stringValue((row as Record<string, unknown>).finding_key).toLowerCase();
+      return Boolean(key && readinessKeys.has(key));
+    });
+  return uniqueRowsByFindingKey([...pending, ...readiness]);
+}
+
+function uniqueRowsByFindingKey(rows: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  const seen = new Set<string>();
+  const out: Array<Record<string, unknown>> = [];
+  for (const row of rows) {
+    const key = stringValue(row.finding_key).toLowerCase() || String(row.id ?? "");
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(row);
+  }
+  return out;
 }
 
 function selectedFindingIds(body: Record<string, unknown>): number[] {
@@ -3861,11 +3890,7 @@ async function daemonPipelineWorklist(c: Ctx): Promise<void> {
       return sendJson(c.res, 200, { phase, requiresRealTargetConfirmation, inputRunDirs: [], confirmKeys: [] });
     }
     const currentDecisions = currentConfirmDecisions(c.store.listConfirmDecisions(projectId).filter((row) => rowBelongsToCurrentMaterial(row, currentResultRunIds, materialBoundary)));
-    const decisionKeys = confirmDecisionKeySet(currentDecisions);
-    const pending = c.store.pendingConfirmable(projectId)
-      .filter((row) => confirmableRunDir(row as unknown as Record<string, unknown>))
-      .filter((row) => rowBelongsToCurrentMaterial(row as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary))
-      .filter((row) => !findingRowCoveredByDecision(row as unknown as Record<string, unknown>, decisionKeys));
+    const pending = confirmWorkRows(c.store, projectId, currentResultRunIds, materialBoundary, currentDecisions);
     if (pending.length === 0) {
       return sendJson(c.res, 200, { phase, requiresRealTargetConfirmation, inputRunDirs: [], confirmKeys: [] });
     }

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -13,7 +13,7 @@
 // unless a per-daemon bearer token is configured.
 
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { closeSync, existsSync, fstatSync, openSync, readFileSync, readSync, readdirSync, statSync } from "node:fs";
 import { timingSafeEqual } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -36,6 +36,7 @@ const PROJECT_STREAM_LIMIT = 100;
 const DAEMON_JOB_HEARTBEAT_TTL_MS = 45_000;
 const DAEMON_OFFLINE_RECONCILE_GRACE_MS = DAEMON_JOB_HEARTBEAT_TTL_MS * 2;
 const PROJECT_STATUS_FILTERS = ["running", "needs-work", "done", "failed", "not-started"] as const;
+const PERSISTED_ACTIVITY_TAIL_BYTES = 16 * 1024 * 1024;
 type ProjectStatusFilter = (typeof PROJECT_STATUS_FILTERS)[number];
 type ProjectStatusCounts = Record<"all" | ProjectStatusFilter, number>;
 
@@ -642,7 +643,7 @@ function hasSuccessfulTerminalEvent(run: Record<string, unknown>): boolean {
   const eventsPath = path.join(path.resolve(runDir), "events.jsonl");
   if (!existsSync(eventsPath)) return false;
   try {
-    const lines = readFileSync(eventsPath, "utf8").trim().split("\n").filter(Boolean).slice(-500);
+    const lines = readTailLines(eventsPath, 500);
     for (let i = lines.length - 1; i >= 0; i -= 1) {
       const line = lines[i];
       if (!line) continue;
@@ -663,6 +664,40 @@ function hasSuccessfulTerminalEvent(run: Record<string, unknown>): boolean {
     return false;
   }
   return false;
+}
+
+function readTailLines(file: string, limit: number, maxBytes = PERSISTED_ACTIVITY_TAIL_BYTES): string[] {
+  const safeLimit = Math.max(0, Math.floor(limit));
+  const safeMaxBytes = Math.max(0, Math.floor(maxBytes));
+  if (safeLimit <= 0 || safeMaxBytes <= 0) return [];
+  const fd = openSync(file, "r");
+  try {
+    const size = fstatSync(fd).size;
+    if (size <= 0) return [];
+    const chunkSize = 64 * 1024;
+    const chunks: Buffer[] = [];
+    let position = size;
+    let bytesReadTotal = 0;
+    let newlineCount = 0;
+    while (position > 0 && newlineCount <= safeLimit && bytesReadTotal < safeMaxBytes) {
+      const readLength = Math.min(chunkSize, position, safeMaxBytes - bytesReadTotal);
+      if (readLength <= 0) break;
+      position -= readLength;
+      const buffer = Buffer.allocUnsafe(readLength);
+      const bytesRead = readSync(fd, buffer, 0, readLength, position);
+      if (bytesRead <= 0) break;
+      const chunk = bytesRead === readLength ? buffer : buffer.subarray(0, bytesRead);
+      chunks.unshift(chunk);
+      bytesReadTotal += bytesRead;
+      for (const byte of chunk) {
+        if (byte === 10) newlineCount += 1;
+      }
+    }
+    if (chunks.length === 0) return [];
+    return Buffer.concat(chunks, bytesReadTotal).toString("utf8").split(/\n+/).filter(Boolean).slice(-safeLimit);
+  } finally {
+    closeSync(fd);
+  }
 }
 
 function isLoopbackHost(host: string): boolean {
@@ -3585,11 +3620,11 @@ function persistedRunActivity(run: Record<string, unknown>, limit: number): Arra
   if (path.dirname(file) !== runDir) return [];
   let lines: string[];
   try {
-    lines = readFileSync(file, "utf8").trim().split(/\n+/).filter(Boolean);
+    lines = readTailLines(file, limit);
   } catch {
     return [];
   }
-  return lines.slice(-limit).flatMap((line) => {
+  return lines.flatMap((line) => {
     try {
       const rec = JSON.parse(line) as Record<string, unknown>;
       return [persistedEventToActivity(rec)];

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1112,6 +1112,15 @@ function confirmDecisionMemberKeys(row: Record<string, unknown>): string[] {
   return [...keys];
 }
 
+function confirmDecisionKeySet(rows: Array<Record<string, unknown>>): Set<string> {
+  return new Set(rows.flatMap(confirmDecisionMemberKeys));
+}
+
+function findingRowCoveredByDecision(row: Record<string, unknown>, decisionKeys: Set<string>): boolean {
+  const key = stringValue(row.finding_key).toLowerCase();
+  return Boolean(key && decisionKeys.has(key));
+}
+
 function linkedFindingsForDecision(store: MetadataStore, projectId: number, decision: Record<string, unknown>): Array<Record<string, unknown>> {
   const keys = new Set(confirmDecisionMemberKeys(decision));
   if (keys.size === 0) return [];
@@ -2325,11 +2334,12 @@ function pipelinePostAuditWorkPending(
   const requiresRealTargetConfirmation = latestPrepareRequiresRealTargetConfirmation(runs);
   if (requiresRealTargetConfirmation) {
     const currentDecisions = currentConfirmDecisions(store.listConfirmDecisions(projectId).filter((row) => rowBelongsToCurrentMaterial(row, currentResultRunIds, materialBoundary)));
-    const submissionWorkKeys = new Set(currentDecisions.filter((row) => needsSubmissionReadinessWork(row)).flatMap(confirmDecisionMemberKeys));
+    const decisionKeys = confirmDecisionKeySet(currentDecisions);
     const pending = store.pendingConfirmable(projectId)
       .filter((row) => confirmableRunDir(row as unknown as Record<string, unknown>))
-      .filter((row) => rowBelongsToCurrentMaterial(row as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary));
-    if (pending.length > 0 || submissionWorkKeys.size > 0) return true;
+      .filter((row) => rowBelongsToCurrentMaterial(row as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary))
+      .filter((row) => !findingRowCoveredByDecision(row as unknown as Record<string, unknown>, decisionKeys));
+    if (pending.length > 0) return true;
   }
   const reports = reportWorklist(store, projectId, [], currentResultRunIds, materialBoundary, requiresRealTargetConfirmation);
   return Array.isArray(reports.findings) && reports.findings.length > 0;
@@ -3851,17 +3861,15 @@ async function daemonPipelineWorklist(c: Ctx): Promise<void> {
       return sendJson(c.res, 200, { phase, requiresRealTargetConfirmation, inputRunDirs: [], confirmKeys: [] });
     }
     const currentDecisions = currentConfirmDecisions(c.store.listConfirmDecisions(projectId).filter((row) => rowBelongsToCurrentMaterial(row, currentResultRunIds, materialBoundary)));
-    const submissionWorkKeys = new Set(currentDecisions.filter((row) => needsSubmissionReadinessWork(row)).flatMap(confirmDecisionMemberKeys));
+    const decisionKeys = confirmDecisionKeySet(currentDecisions);
     const pending = c.store.pendingConfirmable(projectId)
       .filter((row) => confirmableRunDir(row as unknown as Record<string, unknown>))
-      .filter((row) => rowBelongsToCurrentMaterial(row as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary));
-    if (pending.length === 0 && submissionWorkKeys.size === 0) {
+      .filter((row) => rowBelongsToCurrentMaterial(row as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary))
+      .filter((row) => !findingRowCoveredByDecision(row as unknown as Record<string, unknown>, decisionKeys));
+    if (pending.length === 0) {
       return sendJson(c.res, 200, { phase, requiresRealTargetConfirmation, inputRunDirs: [], confirmKeys: [] });
     }
-    const context = c.store.confirmableContext(projectId)
-      .filter((row) => confirmableRunDir(row as unknown as Record<string, unknown>))
-      .filter((row) => rowBelongsToCurrentMaterial(row as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary));
-    const rows = context.length > 0 ? context : pending;
+    const rows = pending;
     return sendJson(c.res, 200, {
       phase,
       requiresRealTargetConfirmation,

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2126,6 +2126,7 @@ async function runLaunch(c: Ctx): Promise<void> {
   }
   const prepared = applyPreparedWorkspaceIfNeeded(spec, runs);
   if (!prepared.ok) return sendJson(c.res, 400, { error: prepared.error });
+  resumeInterruptedCoverageBatch(spec, progress, runs);
   promoteSettledPipelineCoverageBatch(spec, c.store, projectId, progress, currentResultRunIds, materialBoundary, runs);
   const materialDrift = verifyMaterialDrift(c.store, projectId, spec.verifyFindings, body.allowMaterialDrift === true);
   if (materialDrift) return sendJson(c.res, 409, materialDrift);
@@ -2235,6 +2236,31 @@ function resetPipelineCoverageForUnknownInventory(spec: LaunchSpec): void {
     spec.coverageTarget = undefined;
     spec.maxScopes = undefined;
   }
+}
+
+function resumeInterruptedCoverageBatch(spec: LaunchSpec, progress: Coverage, runs: Array<Record<string, unknown>>): void {
+  if (spec.verb !== "run" && spec.verb !== "audit") return;
+  if (spec.scope || spec.region || spec.verifyFindings !== undefined) return;
+  if (spec.maxScopes !== 0) return;
+  const pending = Math.max(0, Math.floor(progress.pending));
+  if (pending <= 0) return;
+  const remaining = latestInterruptedCoverageBatchRemainder(runs);
+  if (remaining <= 0) return;
+  spec.maxScopes = Math.min(pending, remaining);
+}
+
+function latestInterruptedCoverageBatchRemainder(runs: Array<Record<string, unknown>>): number {
+  const ordered = [...runs].sort((a, b) => numberValue(b.id) - numberValue(a.id));
+  for (const run of ordered) {
+    const kind = stringValue(run.kind);
+    if (kind !== "run" && kind !== "audit") continue;
+    const status = stringValue(run.status);
+    if (status !== "killed" && status !== "error") continue;
+    const target = Math.max(0, Math.floor(numberValue(run.run_scopes_target)));
+    const done = Math.max(0, Math.floor(numberValue(run.run_scopes_done)));
+    if (target > 0 && done < target) return target - done;
+  }
+  return 0;
 }
 
 function promoteSettledPipelineCoverageBatch(

--- a/src/server/run-manager.ts
+++ b/src/server/run-manager.ts
@@ -69,6 +69,7 @@ export interface LaunchSpec {
   confirmSettledRows?: ConfirmSettledRow[] | undefined; // confirm: prior reproduced/not-reproduced decisions to carry forward across batches
   reportFindings?: ReportFindingSpec[] | undefined; // report: confirmed/reproduced bugs to package as formal Markdown reports
   pipeline?: boolean | undefined; // run: project/CLI clue pipeline (prepare if needed -> map/dig -> verify -> confirm -> report)
+  continueCoverage?: boolean | undefined; // run pipeline: explicitly open another scope batch after current verify/confirm/report work is settled
   verifyFromStart?: boolean | undefined; // pipeline: re-run Verify from the beginning instead of only pending candidates
   region?: string | undefined; // audit: a pinned region
   scope?: string | undefined; // audit: scope id[,id...]

--- a/src/server/ui/src/App.tsx
+++ b/src/server/ui/src/App.tsx
@@ -60,7 +60,7 @@ type SettingsPane = "providers" | "daemons" | "archived";
 type ProjectTab = "overview" | "decisions" | "findings" | "scopes" | "runs" | "activity" | "setup";
 type ModalName = "new-project" | "run" | "edit-project" | "report" | "decision-report" | "run-log" | "artifact" | null;
 type ArtifactPreview = { title: string; runId: number; name: string };
-type LaunchAction = "run" | "prepare" | "map" | "audit" | "confirm" | "verify" | "report";
+type LaunchAction = "run" | "run-next-coverage" | "prepare" | "map" | "audit" | "confirm" | "verify" | "report";
 
 const PROJECT_TABS: Array<{ id: ProjectTab; label: string }> = [
   { id: "overview", label: "Overview" },
@@ -671,6 +671,15 @@ function coverageLabel(cfg: { scopeCoverageMode?: string; maxScopes?: number }):
   return `Custom - ${cfg.maxScopes ?? 30} scopes per run`;
 }
 
+function coverageModeName(cfg: { scopeCoverageMode?: string; maxScopes?: number }): string {
+  const mode = coverageModeFromConfig(cfg);
+  if (mode === "focused") return "Focused";
+  if (mode === "standard") return "Standard";
+  if (mode === "half") return "Half";
+  if (mode === "full") return "Full";
+  return "Custom";
+}
+
 function coverageCapText(mode: CoverageMode, maxScopes: string): string {
   if (mode === "focused") return "until 10 audited scopes";
   if (mode === "standard") return "until 30 audited scopes";
@@ -841,26 +850,49 @@ function pendingDecisionReports(decisions: ConfirmDecision[] | undefined): Confi
   return reportableDecisions(decisions).filter((decision) => !decision.has_report);
 }
 
+function configuredCoverageTarget(detail: ProjectDetail): number | undefined {
+  const total = Math.max(0, detail.progress.total ?? 0);
+  if (total <= 0) return undefined;
+  const cfg = projectConfig(detail).cfg;
+  const mode = coverageModeFromConfig(cfg);
+  if (mode === "standard") return Math.min(30, total);
+  if (mode === "focused") return Math.min(10, total);
+  if (mode === "half") return Math.min(Math.ceil(total / 2), total);
+  if (mode === "full") return total;
+  return Math.min(Math.max(1, cfg.maxScopes ?? 30), total);
+}
+
+function pipelineCoverageRoundComplete(detail: ProjectDetail): boolean {
+  const audited = Math.max(0, detail.progress.audited ?? 0);
+  const pending = Math.max(0, detail.progress.pending ?? 0);
+  const target = configuredCoverageTarget(detail);
+  if (target !== undefined && audited >= target) return true;
+  return audited > 0 && pending === 0;
+}
+
 function pipelineRunActionDetail(detail: ProjectDetail, hasPipelineRun: boolean): string {
   if (!hasPipelineRun) return "Run the automatic pipeline: Prepare when needed, then map/dig, confirm reproduced impact, and generate reports.";
   const requiresConfirmation = needsRealTargetConfirmation(detail);
   const verifyCount = rawPendingVerifyCount(detail.allFindings);
-  if (verifyCount > 0) return `Continue the current pipeline by verifying ${plural(verifyCount, "candidate")} before starting new scope coverage.`;
+  if (verifyCount > 0) return `Continue the current pipeline by verifying ${plural(verifyCount, "candidate")} before this round can finish.`;
   const confirmCount = pendingConfirmFindings(detail.allFindings, requiresConfirmation, detail.confirmDecisions).length;
-  if (confirmCount > 0) return `Continue the current pipeline by confirming ${plural(confirmCount, "finding")} before starting new scope coverage.`;
+  if (confirmCount > 0) return `Continue the current pipeline by confirming ${plural(confirmCount, "finding")} before this round can finish.`;
   const reportCount = requiresConfirmation ? pendingDecisionReports(detail.confirmDecisions).length : pendingFormalReports(detail.allFindings, requiresConfirmation).length;
-  if (reportCount > 0) return `Continue the current pipeline by generating ${plural(reportCount, "report")} before starting new scope coverage.`;
+  if (reportCount > 0) return `Continue the current pipeline by generating ${plural(reportCount, "report")} before this round can finish.`;
   const mode = coverageModeFromConfig(projectConfig(detail).cfg);
   const audited = Math.max(0, detail.progress.audited ?? 0);
   const pending = Math.max(0, detail.progress.pending ?? 0);
+  if (pipelineCoverageRoundComplete(detail)) {
+    return pending
+      ? `Current ${coverageModeName(projectConfig(detail).cfg)} round is complete. Continue stays stopped; use Start next scope round to open another batch from ${plural(pending, "pending scope")}.`
+      : "Current pipeline round is complete. Continue stays stopped; no pending mapped scopes remain.";
+  }
   if (mode === "standard") {
     if (pending === 0) return "Continue any remaining pipeline work; no pending mapped scopes remain.";
-    if (audited >= 30) return `Continue will start the next Standard batch of up to 30 scopes (${plural(pending, "pending scope")}).`;
     return `Continue will audit up to ${plural(Math.min(30 - audited, pending), "scope")} to finish the first Standard batch (${audited}/30 audited).`;
   }
   if (mode === "focused") {
     if (pending === 0) return "Continue any remaining pipeline work; no pending mapped scopes remain.";
-    if (audited >= 10) return `Continue will use the saved Focused coverage setting; choose Custom or Full for more scopes.`;
     return `Continue will audit up to ${plural(Math.min(10 - audited, pending), "scope")} to finish Focused coverage (${audited}/10 audited).`;
   }
   if (mode === "half") return pending ? `Continue will audit about half of the ${plural(pending, "pending scope")}.` : "Continue any remaining pipeline work; no pending mapped scopes remain.";
@@ -1849,6 +1881,7 @@ export function App() {
     if (!route.projectUuid) return;
     let verifyCandidates: FindingRow[] = [];
     let runHint = "";
+    const opensNextCoverage = action === "run-next-coverage";
     if (detail?.project.uuid === route.projectUuid) {
       const currentDetail = currentMaterialDetail(detail);
       const running = currentMaterialRuns(detail.runs, detail.material).find((run) => run.status === "running");
@@ -1875,7 +1908,13 @@ export function App() {
         return;
       }
       if (action === "run") runHint = pipelineRunActionDetail(currentDetail, currentDetail.runs.some((run) => run.kind === "run"));
+      if (opensNextCoverage) runHint = "Explicit next scope round requested; the control plane will still settle any current-round work first.";
       const requiresConfirmation = needsRealTargetConfirmation(currentDetail);
+      if (opensNextCoverage && (currentDetail.progress.pending ?? 0) === 0) {
+        setToast({ tone: "warning", message: "There are no pending mapped scopes for another scope round. Map new scopes first." });
+        setModal(null);
+        return;
+      }
       if (action === "confirm" && pendingConfirmFindings(currentDetail.allFindings, requiresConfirmation, currentDetail.confirmDecisions).length === 0) {
         setToast({ tone: "warning", message: "There are no audit-confirmed findings waiting for real-target confirmation yet." });
         setModal(null);
@@ -1908,21 +1947,22 @@ export function App() {
     }
     setBusy(true);
     try {
-      const verb = action === "verify" ? "audit" : action;
+      const verb = action === "verify" ? "audit" : opensNextCoverage ? "run" : action;
       const selected = selectedFindings && selectedFindings.length ? selectedFindings : undefined;
       const result = (await api.launchRun(route.projectUuid, {
         verb,
-        ...(action === "run" ? { pipeline: true } : {}),
+        ...(action === "run" || opensNextCoverage ? { pipeline: true } : {}),
+        ...(opensNextCoverage ? { continueCoverage: true } : {}),
         ...(action === "verify" ? { verifyFindings: selected ?? verifyCandidates } : {}),
         ...((action === "confirm" || action === "report") && selected ? { findingIds: selected.map((finding) => finding.id) } : {}),
       })) as LaunchResult;
       const waiting = (result.daemons ?? 0) === 0;
-      const label = action === "verify" ? "verify" : verb;
+      const label = action === "verify" ? "verify" : opensNextCoverage ? "run" : verb;
       setToast({
         tone: waiting ? "warning" : "success",
         message: waiting
           ? `${label} queued, but no online daemon is connected. Start a daemon to claim the job.`
-          : `${label} queued for ${plural(result.daemons ?? 0, "daemon")}.${runHint && action === "run" ? ` ${runHint}` : ""}`,
+          : `${label} queued for ${plural(result.daemons ?? 0, "daemon")}.${runHint && (action === "run" || opensNextCoverage) ? ` ${runHint}` : ""}`,
       });
       await refreshBase();
     } catch (error) {
@@ -2659,6 +2699,8 @@ function ProjectDetailView(props: {
   const reportLabel = pendingReports > 0 ? "to report" : "reports";
   const candidateStat = pendingVerify > 0 ? pendingVerify : needsEvidenceCount > 0 ? needsEvidenceCount : overviewCandidates.length;
   const candidateLabel = pendingVerify > 0 ? "to verify" : needsEvidenceCount > 0 ? "need evidence" : "top findings";
+  const currentRoundWorkPending = rawPendingVerify > 0 || pendingConfirmBase > 0 || pendingReports > 0;
+  const currentRoundComplete = hasPipelineRun && !currentRoundWorkPending && pipelineCoverageRoundComplete(currentDetail);
   const localVerifySummary = activeVerifySummary(runningVerify) || verifyStatusSummary(allFindings);
   const setupAttention = prepareMaterialsAttention(detail.prepareSummary);
   const sandboxStatus = daemonSandboxStatus(selectedDaemon);
@@ -2680,6 +2722,7 @@ function ProjectDetailView(props: {
     && setupReadWatermarks[project.uuid] !== setupAttentionSignature
   );
   const launchLocked = props.busy || Boolean(runningRun);
+  const runLaunchLocked = launchLocked || currentRoundComplete;
   const requiredProviders = requiredProviderProfiles(detail, providers);
   const authStatuses = requiredProviders.map((profile) => ({ profile, status: daemonHasProvider(selectedDaemon, profile.provider) }));
   const authUnknown = authStatuses.some((entry) => entry.status === null);
@@ -2860,7 +2903,7 @@ function ProjectDetailView(props: {
             <Button
               variant="primary"
               icon="play"
-              disabled={launchLocked}
+              disabled={runLaunchLocked}
               title={runningRun ? "A run is already active for this project." : pipelineActionDetail}
               onClick={() => props.onLaunch("run")}
             >
@@ -5525,6 +5568,8 @@ function RunModal({ detail, busy, onClose, onLaunch, onUpdateRunTarget, onError 
   const missingReports = requiresConfirmation ? pendingDecisionReports(detail.confirmDecisions).length : pendingFormalReports(detail.allFindings, requiresConfirmation).length;
   const hasPipelineRun = detail.runs.some((run) => run.kind === "run");
   const pipelineActionDetail = pipelineRunActionDetail(detail, hasPipelineRun);
+  const currentRoundWorkPending = verifiable > 0 || confirmable > 0 || missingReports > 0;
+  const currentRoundComplete = hasPipelineRun && !currentRoundWorkPending && pipelineCoverageRoundComplete(detail);
   const locked = busy || Boolean(running);
   const projectCoverageMode = coverageModeFromConfig(projectConfig(detail).cfg);
   const [runCoverageMode, setRunCoverageMode] = useState<CoverageMode>(projectCoverageMode);
@@ -5560,7 +5605,17 @@ function RunModal({ detail, busy, onClose, onLaunch, onUpdateRunTarget, onError 
     ? "Optionally re-run Prepare to close provenance, deployment-match, or real-target caveats. The current materials can still drive Map/Dig."
     : "Acquire official source/docs, pin provenance, and record material or real-target gaps before sealed auditing.";
   const options: Array<{ verb: LaunchAction; label: string; detail: string; disabled?: boolean }> = [
-    { verb: "run", label: hasPipelineRun ? "Continue" : "Run", detail: pipelineActionDetail, disabled: locked },
+    { verb: "run", label: hasPipelineRun ? "Continue" : "Run", detail: pipelineActionDetail, disabled: locked || currentRoundComplete },
+    ...(hasPipelineRun ? [{
+      verb: "run-next-coverage" as const,
+      label: "Start next scope round",
+      detail: currentRoundWorkPending
+        ? "Disabled until this round's verify, confirm, and report work is settled."
+        : pendingScopes
+          ? `Explicitly open another pipeline batch from ${plural(pendingScopes, "pending mapped scope")}.`
+          : "Disabled until Map scopes creates pending scope inventory.",
+      disabled: locked || currentRoundWorkPending || pendingScopes === 0,
+    }] : []),
     {
       verb: "prepare",
       label: prepareActionLabel,
@@ -5568,7 +5623,7 @@ function RunModal({ detail, busy, onClose, onLaunch, onUpdateRunTarget, onError 
       disabled: locked,
     },
     { verb: "map", label: "Map scopes only", detail: "Build or refresh the scope inventory without digging.", disabled: locked },
-    { verb: "audit", label: "Dig pending scopes", detail: pendingScopes ? `Deep-audit the next pending batch from ${plural(pendingScopes, "mapped scope")}.` : "Disabled until Map scopes creates pending scope inventory.", disabled: locked || pendingScopes === 0 },
+    { verb: "audit", label: "Dig pending scopes", detail: pendingScopes ? `Explicitly deep-audit pending mapped scopes without starting another full pipeline round.` : "Disabled until Map scopes creates pending scope inventory.", disabled: locked || pendingScopes === 0 },
     { verb: "verify", label: verifyButtonLabel(verifiable), detail: verifiable ? `Confirm-or-refute ${plural(verifiable, "candidate")} by local execution.` : "Disabled until synthesis or dig leaves suspected candidates.", disabled: locked || verifiable === 0 },
     { verb: "confirm", label: "Confirm", detail: requiresConfirmation ? (confirmable ? `Reproduce ${plural(confirmable, "execution-confirmed finding")} against the real target.` : "Disabled until local execution confirms a finding.") : "Not required for this source-only target.", disabled: locked || confirmable === 0 },
     { verb: "report", label: missingReports ? `Generate reports (${missingReports})` : "Regenerate reports", detail: reportable ? `Write formal Markdown reports for ${plural(reportable, requiresConfirmation ? "real-target decision" : "locally confirmed finding")}.` : requiresConfirmation ? "Disabled until confirm reproduces at least one decision." : "Disabled until local execution confirms at least one finding.", disabled: locked || reportable === 0 },

--- a/src/server/ui/src/App.tsx
+++ b/src/server/ui/src/App.tsx
@@ -804,14 +804,11 @@ function isExecutionConfirmedFinding(finding: FindingRow): boolean {
 
 function pendingConfirmFindings(rows: FindingRow[] | undefined, requiresConfirmation = true, decisions?: ConfirmDecision[]): FindingRow[] {
   if (!requiresConfirmation) return [];
-  const readinessWorkKeys = new Set((decisions ?? []).filter(needsSubmissionReadinessWork).flatMap(confirmDecisionMemberKeys));
-  const decidedFindingKeys = new Set((decisions ?? []).filter((decision) => !needsSubmissionReadinessWork(decision)).flatMap(confirmDecisionMemberKeys));
+  const decidedFindingKeys = new Set((decisions ?? []).flatMap(confirmDecisionMemberKeys));
   return activeFindings(rows).filter((finding) =>
     isExecutionConfirmedFinding(finding)
-    && (
-      (!finding.confirm_status && !(finding.finding_key && decidedFindingKeys.has(finding.finding_key.toLowerCase())))
-      || Boolean(finding.finding_key && readinessWorkKeys.has(finding.finding_key.toLowerCase()))
-    )
+    && !finding.confirm_status
+    && !(finding.finding_key && decidedFindingKeys.has(finding.finding_key.toLowerCase()))
   );
 }
 

--- a/src/server/ui/src/api.ts
+++ b/src/server/ui/src/api.ts
@@ -429,6 +429,7 @@ export interface LaunchPayload {
   quick?: boolean;
   mockLlm?: boolean;
   pipeline?: boolean;
+  continueCoverage?: boolean;
   remap?: boolean;
   verifyFromStart?: boolean;
   findingId?: number;

--- a/src/server/ui/src/domain.ts
+++ b/src/server/ui/src/domain.ts
@@ -600,11 +600,11 @@ export function phaseState(detail: ProjectDetail, progress: Coverage): PhaseStat
   const conf = latest("confirm");
   const synthesis = stages(latestRunWithStage(runs, "synthesis")).synthesis;
   const requiresConfirmation = needsRealTargetConfirmation(detail);
-  const readinessWorkKeys = new Set(decisions.filter(needsSubmissionReadinessWork).flatMap(confirmDecisionMemberKeys));
-  const decidedFindingKeys = new Set(decisions.filter((decision) => !needsSubmissionReadinessWork(decision)).flatMap(confirmDecisionMemberKeys));
+  const decidedFindingKeys = new Set(decisions.flatMap(confirmDecisionMemberKeys));
   const pendingConfirmRaw = requiresConfirmation
     ? findings.filter((finding) => isExecutionConfirmedFinding(finding)
-      && ((!finding.confirm_status && !findingCoveredByDecision(finding, decidedFindingKeys)) || findingCoveredByDecision(finding, readinessWorkKeys))).length
+      && !finding.confirm_status
+      && !findingCoveredByDecision(finding, decidedFindingKeys)).length
     : 0;
   const pendingVerify = findings.filter((finding) => finding.status === "suspected" || finding.status === "confirmed-source").length;
   const locallyVerified = findings.filter(isExecutionConfirmedFinding).length;

--- a/tests/agent.test.mjs
+++ b/tests/agent.test.mjs
@@ -913,6 +913,30 @@ test("confirm target-link parsing resolves Foundry rooted match paths without tr
   assert.equal(targetLink.linked, true);
 });
 
+test("confirm target-link parsing resolves cwd-relative Hardhat test files to pristine imports", () => {
+  const testPath = "sources/evm-smart-contracts/test/BridgeAdapterSourceBinding.poc.ts";
+  const session = {
+    scratchFiles: new Map([[
+      testPath,
+      "import PRISTINE_BRIDGE_SOURCE from '../contracts/bridge/Bridge.sol';\n"
+        + "it('reproduces through target source', () => console.log(PRISTINE_BRIDGE_SOURCE));\n",
+    ]]),
+    baselineFiles: new Set([
+      "sources/evm-smart-contracts/contracts/bridge/Bridge.sol",
+      "sources/evm-smart-contracts/test/Bridge.ts",
+    ]),
+  };
+  const command = {
+    program: "npx",
+    args: ["hardhat", "test", "--no-compile", "test/BridgeAdapterSourceBinding.poc.ts"],
+    cwd: "sources/evm-smart-contracts",
+  };
+
+  assert.deepEqual(commandFileArgsForTest(command, session), [testPath]);
+  const targetLink = confirmCommandTargetLinkForTest(command, session);
+  assert.equal(targetLink.linked, true);
+});
+
 test("confirm target-link parsing follows command-line remappings from scratch tests to pristine source", () => {
   const session = {
     scratchFiles: new Map([[

--- a/tests/agent.test.mjs
+++ b/tests/agent.test.mjs
@@ -792,6 +792,44 @@ test("bash blocks build when pinned toolchain does not match sandbox image", asy
   }
 });
 
+test("bash prepare ignores sibling pinned toolchains outside the focused build command", async () => {
+  const dir = await tempDir();
+  const oldPath = process.env.PATH;
+  try {
+    const target = path.join(dir, "target");
+    const binDir = path.join(dir, "bin");
+    const logPath = path.join(dir, "tool.log");
+    await mkdir(target, { recursive: true });
+    await mkdir(path.join(target, "cairo"), { recursive: true });
+    await mkdir(binDir, { recursive: true });
+    await writeFile(path.join(target, "package.json"), "{\"scripts\":{\"test\":\"echo ok\"}}\n");
+    await writeFile(path.join(target, "yarn.lock"), "");
+    await writeFile(path.join(target, "cairo", "Scarb.toml"), "[package]\nname = \"audit_target\"\nversion = \"0.1.0\"\n");
+    await writeFile(path.join(target, "cairo", ".tool-versions"), "scarb 2.12.0\nstarknet-foundry 0.49.0\n");
+    const fakeYarn = path.join(binDir, "yarn");
+    await writeFile(fakeYarn, `#!/usr/bin/env bash\necho "yarn $PWD $*" >> ${JSON.stringify(logPath)}\nexit 0\n`);
+    await chmod(fakeYarn, 0o755);
+    process.env.PATH = `${binDir}${path.delimiter}${oldPath ?? ""}`;
+
+    const cfg = defaultConfig();
+    cfg.sourcePaths = [target];
+    cfg.sandboxBackend = "host";
+    cfg.sandboxAllowHostFallback = true;
+    cfg.auditPrepare = true;
+    cfg.auditPrepareTimeoutMs = 10_000;
+    const logger = await tempLogger(dir);
+    const ctx = { cfg, source: [], corpus: [], memory: new ProjectMemory(path.join(dir, "memory.jsonl")), logger, session: newSession() };
+
+    const run = await tool("bash").run({ cmd: "yarn install --frozen-lockfile", purpose: "build" }, ctx);
+    assert.doesNotMatch(run.observation, /sandbox image\/toolchain preflight failed/);
+    assert.match(await readFile(logPath, "utf8"), /yarn .* install --frozen-lockfile/);
+    assert.equal(ctx.session.commandRuns.length, 1);
+  } finally {
+    process.env.PATH = oldPath;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("confirmed executable commands must link model-written tests to pristine target source", async () => {
   const dir = await tempDir();
   try {

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -1808,7 +1808,15 @@ test("api: startup reconciles error runs that have successful terminal artifacts
   const out = await mkdtemp(path.join(os.tmpdir(), "flounder-api-reconcile-"));
   const runDir = path.join(out, "artifact-success-run");
   await mkdir(runDir, { recursive: true });
-  await writeFile(path.join(runDir, "events.jsonl"), JSON.stringify({ ts: new Date().toISOString(), kind: "audit_done", stoppedReason: "finished", findings: 1 }) + "\n");
+  const priorEvents = Array.from({ length: 700 }, (_, i) => JSON.stringify({
+    ts: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+    kind: "audit_action",
+    detail: `historical activity ${i}`,
+  }));
+  await writeFile(
+    path.join(runDir, "events.jsonl"),
+    `${priorEvents.join("\n")}\n${JSON.stringify({ ts: new Date().toISOString(), kind: "audit_done", stoppedReason: "finished", findings: 1 })}\n`,
+  );
 
   const store = MetadataStore.openForOutput(out);
   let runId;
@@ -3694,7 +3702,12 @@ test("api: run log supports a bounded JSON tail for agents", async () => {
     } finally {
       store.close();
     }
-    await writeFile(path.join(runDir, "events.jsonl"), `${JSON.stringify({
+    const priorEvents = Array.from({ length: 75 }, (_, i) => JSON.stringify({
+      ts: new Date(Date.UTC(2026, 5, 22, 8, 0, i)).toISOString(),
+      kind: "audit_action",
+      detail: `older activity ${i}`,
+    }));
+    await writeFile(path.join(runDir, "events.jsonl"), `${priorEvents.join("\n")}\n${JSON.stringify({
       ts: "2026-06-22T08:12:50.000Z",
       kind: "audit_command_run",
       runId: "cmd23",
@@ -3704,7 +3717,7 @@ test("api: run log supports a bounded JSON tail for agents", async () => {
       output: "docker: Error response from daemon: exec: \"forge\": executable file not found in $PATH.",
     })}\n`);
 
-    const res = await fetch(base + `/api/runs/${runId}/log?tail=50`);
+    const res = await fetch(base + `/api/runs/${runId}/log?tail=1`);
     assert.equal(res.status, 200);
     assert.match(res.headers.get("content-type") ?? "", /application\/json/);
     const body = await res.json();
@@ -3715,7 +3728,7 @@ test("api: run log supports a bounded JSON tail for agents", async () => {
     assert.equal(body.events[0].passed, false);
     assert.equal(body.events[0].exitCode, 127);
     assert.match(body.events[0].output, /forge/);
-    assert.equal(body.limit, 50);
+    assert.equal(body.limit, 1);
   });
 });
 

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -505,7 +505,7 @@ test("api: standard pipeline continue finishes pending verify work before openin
   });
 });
 
-test("api: standard pipeline continue opens next scope batch when only needs-human decisions remain", async () => {
+test("api: standard pipeline continue keeps reproduced needs-human decisions in confirm before opening the next scope batch", async () => {
   await withServer(async (base, out) => {
     const json = (r) => r.json();
     const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
@@ -556,7 +556,7 @@ test("api: standard pipeline continue opens next scope batch when only needs-hum
     assert.equal(pipelineSpec.pipeline, true);
     assert.equal(pipelineSpec.coverageMode, "standard");
     assert.equal(pipelineSpec.coverageTarget, 30);
-    assert.equal(pipelineSpec.maxScopes, 12);
+    assert.equal(pipelineSpec.maxScopes, 0);
   });
 });
 
@@ -801,9 +801,10 @@ test("api: daemon pipeline worklist exposes verify candidates before confirm", a
       body: JSON.stringify({ project: "pipeline-verify-worklist", phase: "confirm" }),
     }));
     assert.ok(confirm.confirmKeys.includes("confirmed-bug"));
+    assert.ok(confirm.confirmKeys.includes("kgateblocked"), "confirm worklist retries reproduced needs-human decisions whose submission gates remain open");
     assert.ok(!confirm.confirmKeys.includes("kalreadyreproduced"), "confirm worklist skips prior decided findings");
-    assert.ok(!confirm.confirmKeys.includes("kgateblocked"), "confirm worklist skips needs-human decisions already covered by confirm_decision rows");
     assert.ok(confirm.confirmFindings.some((finding) => finding.id === "confirmed-bug" && finding.originId), "confirm worklist carries DB-backed finding seeds");
+    assert.ok(confirm.confirmFindings.some((finding) => finding.id === "kgateblocked" && finding.originId), "confirm worklist carries DB-backed seeds for submission-readiness retries");
     assert.deepEqual(confirm.confirmSettledRows.map((row) => row.bug), ["prior reproduced withdrawal proof"]);
     assert.ok(confirm.confirmKeys.some((key) => /^origin:\d+:confirmed-bug$/.test(key)), "worklist carries origin selector for verify-artifact recovery");
 

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -59,6 +59,7 @@ test("api: GET /api is a self-describing catalog of every resource + operation",
     const projectRun = cat.endpoints.find((e) => e.method === "POST" && e.path === "/api/projects/:uuid/runs");
     assert.match(projectRun.body.verb, /report/);
     assert.match(projectRun.body.verifyFromStart, /re-run Verify from the beginning/);
+    assert.match(projectRun.body.continueCoverage, /explicit opt-in/);
     assert.match(projectRun.body.scopeCoverageMode, /one-off coverage mode/);
     assert.match(projectRun.body.maxScopes, /one-off scope cap/);
     assert.match(projectRun.body.mapSteps, /one-off map turn cap/);
@@ -417,7 +418,7 @@ test("api: full coverage continues prepared pending inventory without a scope ca
   });
 });
 
-test("api: standard pipeline continue opens the next 30-scope batch after the first batch is settled", async () => {
+test("api: standard pipeline continue stops after a settled round unless coverage continuation is explicit", async () => {
   await withServer(async (base, out) => {
     const json = (r) => r.json();
     const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
@@ -437,11 +438,19 @@ test("api: standard pipeline continue opens the next 30-scope batch after the fi
       store.close();
     }
 
-    const pipeline = await json(await post(`/api/projects/${created.uuid}/runs`, { verb: "run", pipeline: true }));
+    const stopped = await post(`/api/projects/${created.uuid}/runs`, { verb: "run", pipeline: true });
+    assert.equal(stopped.status, 409);
+    const blocked = await json(stopped);
+    assert.equal(blocked.roundComplete, true);
+    assert.equal(blocked.continueCoverageRequired, true);
+    assert.equal(blocked.progress.pending, 35);
+
+    const pipeline = await json(await post(`/api/projects/${created.uuid}/runs`, { verb: "run", pipeline: true, continueCoverage: true }));
     assert.equal(pipeline.queued, true);
     const pipelineJob = (await json(await fetch(base + "/api/jobs/" + pipeline.jobId))).job;
     const pipelineSpec = JSON.parse(pipelineJob.spec_json);
     assert.equal(pipelineSpec.pipeline, true);
+    assert.equal(pipelineSpec.continueCoverage, true);
     assert.equal(pipelineSpec.coverageMode, "standard");
     assert.equal(pipelineSpec.coverageTarget, 30);
     assert.equal(pipelineSpec.maxScopes, 30);
@@ -449,8 +458,8 @@ test("api: standard pipeline continue opens the next 30-scope batch after the fi
 
     const continued = await post(`/api/projects/${created.uuid}/runs`, { verb: "run" });
     assert.equal(continued.status, 409);
-    const blocked = await json(continued);
-    assert.match(blocked.error, /Standard coverage is already complete/);
+    const nonPipelineBlocked = await json(continued);
+    assert.match(nonPipelineBlocked.error, /Standard coverage is already complete/);
 
     const launched = await json(await post(`/api/projects/${created.uuid}/runs`, { verb: "audit", scope: "pending-0" }));
     assert.equal(launched.queued, true);

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -505,6 +505,61 @@ test("api: standard pipeline continue finishes pending verify work before openin
   });
 });
 
+test("api: standard pipeline continue opens next scope batch when only needs-human decisions remain", async () => {
+  await withServer(async (base, out) => {
+    const json = (r) => r.json();
+    const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    const created = await json(await post("/api/projects", {
+      name: "standard-cumulative-needs-human",
+      sourcePaths: ["./src"],
+      config: { scopeCoverageMode: "standard" },
+    }));
+
+    const store = MetadataStore.openForOutput(out);
+    try {
+      store.upsertScopes(created.id, [
+        ...Array.from({ length: 30 }, (_, i) => ({ scopeId: `audited-${i}`, title: `Audited ${i}`, status: "audited", score: 30 - i })),
+        ...Array.from({ length: 12 }, (_, i) => ({ scopeId: `pending-${i}`, title: `Pending ${i}`, status: "pending", score: 12 - i })),
+      ]);
+      const auditRun = store.startRun({ projectId: created.id, kind: "audit", runDir: path.join(out, "standard-cumulative-needs-human-audit") });
+      store.upsertFindings(created.id, auditRun, [
+        {
+          findingKey: "kgated",
+          title: "Locally reproduced but human-gated",
+          location: "src/A.sol:1",
+          severity: "medium",
+          status: "confirmed-executable",
+          evidence: "local proof",
+        },
+      ]);
+      store.finishRun(auditRun, "done");
+      const confirmRun = store.startRun({ projectId: created.id, kind: "confirm", runDir: path.join(out, "standard-cumulative-needs-human-confirm") });
+      store.upsertConfirmDecisions(created.id, confirmRun, [
+        {
+          bug: "Locally reproduced but human-gated",
+          reproduced: "yes",
+          recommendation: "needs-human",
+          members: ["kgated"],
+          reproEvidence: "Forge harness used published source; live deployment and funds-at-risk were not established.",
+          humanGates: "Live deployment and payout eligibility need human review.",
+        },
+      ]);
+      store.finishRun(confirmRun, "done");
+    } finally {
+      store.close();
+    }
+
+    const pipeline = await json(await post(`/api/projects/${created.uuid}/runs`, { verb: "run", pipeline: true }));
+    assert.equal(pipeline.queued, true);
+    const pipelineJob = (await json(await fetch(base + "/api/jobs/" + pipeline.jobId))).job;
+    const pipelineSpec = JSON.parse(pipelineJob.spec_json);
+    assert.equal(pipelineSpec.pipeline, true);
+    assert.equal(pipelineSpec.coverageMode, "standard");
+    assert.equal(pipelineSpec.coverageTarget, 30);
+    assert.equal(pipelineSpec.maxScopes, 12);
+  });
+});
+
 test("api: standard pipeline continue resumes an interrupted batch before pending verify work", async () => {
   await withServer(async (base, out) => {
     const json = (r) => r.json();
@@ -746,8 +801,8 @@ test("api: daemon pipeline worklist exposes verify candidates before confirm", a
       body: JSON.stringify({ project: "pipeline-verify-worklist", phase: "confirm" }),
     }));
     assert.ok(confirm.confirmKeys.includes("confirmed-bug"));
-    assert.ok(confirm.confirmKeys.includes("kalreadyreproduced"), "confirm worklist carries prior decided findings as consolidation context");
-    assert.ok(confirm.confirmKeys.includes("kgateblocked"), "confirm worklist carries reproduced decisions whose submission gates are still open");
+    assert.ok(!confirm.confirmKeys.includes("kalreadyreproduced"), "confirm worklist skips prior decided findings");
+    assert.ok(!confirm.confirmKeys.includes("kgateblocked"), "confirm worklist skips needs-human decisions already covered by confirm_decision rows");
     assert.ok(confirm.confirmFindings.some((finding) => finding.id === "confirmed-bug" && finding.originId), "confirm worklist carries DB-backed finding seeds");
     assert.deepEqual(confirm.confirmSettledRows.map((row) => row.bug), ["prior reproduced withdrawal proof"]);
     assert.ok(confirm.confirmKeys.some((key) => /^origin:\d+:confirmed-bug$/.test(key)), "worklist carries origin selector for verify-artifact recovery");

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -331,6 +331,41 @@ test("api: standard coverage fills the project up to 30 audited scopes instead o
   });
 });
 
+test("api: standard coverage resumes an interrupted batch before requiring explicit coverage", async () => {
+  await withServer(async (base, out) => {
+    const json = (r) => r.json();
+    const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    const created = await json(await post("/api/projects", {
+      name: "standard-interrupted-batch",
+      sourcePaths: ["./src"],
+      config: { scopeCoverageMode: "standard" },
+    }));
+
+    const store = MetadataStore.openForOutput(out);
+    try {
+      store.upsertScopes(created.id, [
+        ...Array.from({ length: 58 }, (_, i) => ({ scopeId: `audited-${i}`, title: `Audited ${i}`, status: "audited", score: 100 - i })),
+        ...Array.from({ length: 34 }, (_, i) => ({ scopeId: `pending-${i}`, title: `Pending ${i}`, status: "pending", score: 34 - i })),
+      ]);
+      const runId = store.startRun({ projectId: created.id, kind: "run", runDir: path.join(out, "standard-interrupted-batch-run") });
+      store.updateRunScopes(runId, 28, 30);
+      store.finishRun(runId, "killed");
+    } finally {
+      store.close();
+    }
+
+    const launched = await json(await post(`/api/projects/${created.uuid}/runs`, { verb: "run" }));
+    assert.equal(launched.queued, true);
+    const job = (await json(await fetch(base + "/api/jobs/" + launched.jobId))).job;
+    const spec = JSON.parse(job.spec_json);
+
+    assert.equal(spec.pipeline, false);
+    assert.equal(spec.coverageMode, "standard");
+    assert.equal(spec.coverageTarget, 30);
+    assert.equal(spec.maxScopes, 2);
+  });
+});
+
 test("api: full coverage continues prepared pending inventory without a scope cap", async () => {
   await withServer(async (base, out) => {
     const json = (r) => r.json();
@@ -466,6 +501,51 @@ test("api: standard pipeline continue finishes pending verify work before openin
     assert.equal(pipelineSpec.coverageMode, "standard");
     assert.equal(pipelineSpec.coverageTarget, 30);
     assert.equal(pipelineSpec.maxScopes, 0);
+    assert.equal(pipelineSpec.sandboxConfirmNetwork, "enabled");
+  });
+});
+
+test("api: standard pipeline continue resumes an interrupted batch before pending verify work", async () => {
+  await withServer(async (base, out) => {
+    const json = (r) => r.json();
+    const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    const created = await json(await post("/api/projects", {
+      name: "standard-pipeline-interrupted-batch",
+      sourcePaths: ["./src"],
+      config: { scopeCoverageMode: "standard" },
+    }));
+
+    const store = MetadataStore.openForOutput(out);
+    try {
+      store.upsertScopes(created.id, [
+        ...Array.from({ length: 58 }, (_, i) => ({ scopeId: `audited-${i}`, title: `Audited ${i}`, status: "audited", score: 100 - i })),
+        ...Array.from({ length: 34 }, (_, i) => ({ scopeId: `pending-${i}`, title: `Pending ${i}`, status: "pending", score: 34 - i })),
+      ]);
+      const runId = store.startRun({ projectId: created.id, kind: "run", runDir: path.join(out, "standard-pipeline-interrupted-batch-run") });
+      store.updateRunScopes(runId, 28, 30);
+      store.upsertFindings(created.id, runId, [
+        {
+          findingKey: "ksuspected",
+          title: "Needs execution verification",
+          location: "src/A.sol:1",
+          severity: "high",
+          status: "suspected",
+          evidence: "candidate",
+        },
+      ]);
+      store.finishRun(runId, "killed");
+    } finally {
+      store.close();
+    }
+
+    const pipeline = await json(await post(`/api/projects/${created.uuid}/runs`, { verb: "run", pipeline: true }));
+    assert.equal(pipeline.queued, true);
+    const pipelineJob = (await json(await fetch(base + "/api/jobs/" + pipeline.jobId))).job;
+    const pipelineSpec = JSON.parse(pipelineJob.spec_json);
+    assert.equal(pipelineSpec.pipeline, true);
+    assert.equal(pipelineSpec.coverageMode, "standard");
+    assert.equal(pipelineSpec.coverageTarget, 30);
+    assert.equal(pipelineSpec.maxScopes, 2);
     assert.equal(pipelineSpec.sandboxConfirmNetwork, "enabled");
   });
 });

--- a/tests/cli-continue.test.mjs
+++ b/tests/cli-continue.test.mjs
@@ -18,12 +18,23 @@ test("cli continue builds the project run pipeline body", () => {
     verb: "run",
     verifyFromStart: true,
     mockLlm: true,
+    continueCoverage: true,
     scopeCoverageMode: "custom",
     maxScopes: 3,
     mapSteps: 5,
     digSteps: 7,
     digSamples: 2,
     digConcurrency: 2,
+  });
+});
+
+test("cli continue leaves coverage closed by default", () => {
+  assert.deepEqual(buildProjectContinueBody(["--project", "demo"]), {
+    verb: "run",
+  });
+  assert.deepEqual(buildProjectContinueBody(["--project", "demo", "--continue-coverage"]), {
+    verb: "run",
+    continueCoverage: true,
   });
 });
 

--- a/tests/sandbox-image.test.mjs
+++ b/tests/sandbox-image.test.mjs
@@ -24,6 +24,8 @@ test("foundry tools are copied into the non-root sandbox PATH", async () => {
 
 test("default sandbox image includes common JavaScript package managers", async () => {
   const dockerfile = await readFile(new URL("../docker/flounder-sandbox.Dockerfile", import.meta.url), "utf8");
+  assert.match(dockerfile, /setup_22\.x/);
+  assert.match(dockerfile, /node --version/);
   assert.match(dockerfile, /npm install -g yarn@1\.22\.22 pnpm@9\.15\.9/);
   assert.match(dockerfile, /yarn --version/);
   assert.match(dockerfile, /pnpm --version/);


### PR DESCRIPTION
## Summary
- Resume the remaining scopes from the latest interrupted run/audit batch when Standard coverage already appears complete cumulatively.
- Apply the same behavior to source-provided and pipeline Continue flows before verify/confirm/report work is considered.
- Add API regressions for the 58/60-style interrupted batch case.

## Tests
- npm run check
- npm run build:server
- node --test tests/api.test.mjs