### PR TITLE
Drain confirm readiness work in pipeline

### DIFF
--- a/src/agent/confirm.ts
+++ b/src/agent/confirm.ts
@@ -312,6 +312,8 @@ export async function runConfirm(
       humanGates: row.humanGates,
       engagementProfile: row.engagementProfile,
       adjudication: row.adjudication,
+      evidenceLevel: row.evidenceLevel,
+      submissionConfidence: row.submissionConfidence,
       mergedFrom: row.mergedFrom,
       reproCommandId: row.reproCommandId,
     })),
@@ -457,6 +459,8 @@ function toLiveConfirmRows(raw: unknown[]): Array<{
   humanGates?: string;
   engagementProfile?: unknown;
   adjudication?: unknown;
+  evidenceLevel?: string;
+  submissionConfidence?: string;
   reproCommandId?: string;
 }> {
   const rows: Array<{
@@ -471,6 +475,8 @@ function toLiveConfirmRows(raw: unknown[]): Array<{
     humanGates?: string;
     engagementProfile?: unknown;
     adjudication?: unknown;
+    evidenceLevel?: string;
+    submissionConfidence?: string;
     reproCommandId?: string;
   }> = [];
   for (const entry of raw) {
@@ -489,6 +495,8 @@ function toLiveConfirmRows(raw: unknown[]): Array<{
       humanGates?: string;
       engagementProfile?: unknown;
       adjudication?: unknown;
+      evidenceLevel?: string;
+      submissionConfidence?: string;
       reproCommandId?: string;
     } = { bug: obj.bug };
     if (typeof obj.reproduced === "string") row.reproduced = obj.reproduced;
@@ -506,6 +514,10 @@ function toLiveConfirmRows(raw: unknown[]): Array<{
     if (engagementProfile) row.engagementProfile = engagementProfile;
     const adjudication = normalizeStructuredValue(obj.adjudication);
     if (adjudication) row.adjudication = adjudication;
+    if (typeof obj.evidence_level === "string") row.evidenceLevel = obj.evidence_level;
+    else if (typeof obj.evidenceLevel === "string") row.evidenceLevel = obj.evidenceLevel;
+    if (typeof obj.submission_confidence === "string") row.submissionConfidence = obj.submission_confidence;
+    else if (typeof obj.submissionConfidence === "string") row.submissionConfidence = obj.submissionConfidence;
     if (typeof obj.repro_command_id === "string") row.reproCommandId = obj.repro_command_id;
     else if (typeof obj.reproCommandId === "string") row.reproCommandId = obj.reproCommandId;
     rows.push(row);
@@ -526,6 +538,8 @@ export interface ConfirmDecisionRow {
   humanGates: string;
   engagementProfile?: unknown;
   adjudication?: unknown;
+  evidenceLevel?: string;
+  submissionConfidence?: string;
   recommendation: "submit-candidate" | "needs-human" | "drop" | "unknown";
   // Structured fields the fix-equivalence matrix needs (present when the row's PoC is a
   // source-level test with a declared fix). Not rendered; consumed by consolidation.
@@ -747,6 +761,8 @@ function normalizeDecisionRow(raw: Record<string, unknown>): ConfirmDecisionRow 
   const recommendation = ((value: string): ConfirmDecisionRow["recommendation"] =>
     value === "submit-candidate" || value === "needs-human" || value === "drop" ? value : "unknown")(str(raw.recommendation).toLowerCase());
   const reproCommandId = str(raw.repro_command_id) || str(raw.reproCommandId);
+  const evidenceLevel = str(raw.evidence_level) || str(raw.evidenceLevel);
+  const submissionConfidence = str(raw.submission_confidence) || str(raw.submissionConfidence);
   const fixPatch = parseFixPatch(raw.fix_patch ?? raw.fixPatch);
   const patched = asStringList(raw.patched_success_patterns ?? raw.patchedSuccessPatterns);
   const engagementProfile = normalizeStructuredValue(raw.engagement_profile ?? raw.engagementProfile);
@@ -763,6 +779,8 @@ function normalizeDecisionRow(raw: Record<string, unknown>): ConfirmDecisionRow 
     ...(engagementProfile ? { engagementProfile } : {}),
     ...(adjudication ? { adjudication } : {}),
     recommendation,
+    ...(evidenceLevel ? { evidenceLevel } : {}),
+    ...(submissionConfidence ? { submissionConfidence } : {}),
     ...(reproCommandId ? { reproCommandId } : {}),
     ...(fixPatch ? { fixPatch } : {}),
     ...(patched.length > 0 ? { patchedSuccessPatterns: patched } : {}),
@@ -897,9 +915,13 @@ function mergeRows(members: ConfirmDecisionRow[]): ConfirmDecisionRow {
   const uniq = (values: string[]): string[] => [...new Set(values.filter(Boolean))];
   const reproRank: Record<ConfirmDecisionRow["reproduced"], number> = { yes: 3, "could-not-set-up": 2, no: 1, unknown: 0 };
   const recRank: Record<ConfirmDecisionRow["recommendation"], number> = { "submit-candidate": 3, "needs-human": 2, drop: 1, unknown: 0 };
+  const evidenceRank: Record<string, number> = { unknown: 0, "not-reproduced": 1, "could-not-set-up": 1, reasoned: 2, "source-supported": 3, "source-only-local-confirmed": 4, "locally-reproduced": 4, "execution-reproduced": 4, "local-fork-reproduced": 5, "fork-reproduced": 5, "real-target-reproduced": 6 };
+  const confidenceRank: Record<string, number> = { unknown: 0, low: 1, medium: 2, high: 3 };
   const strongest = <T extends string>(values: T[], rank: Record<T, number>, fallback: T): T => values.reduce((best, value) => (rank[value] > rank[best] ? value : best), fallback);
   const engagementProfile = members.map((m) => m.engagementProfile).find(Boolean);
   const adjudication = members.map((m) => m.adjudication).find(Boolean);
+  const evidenceLevel = strongest(members.map((m) => m.evidenceLevel ?? "unknown"), evidenceRank, "unknown");
+  const submissionConfidence = strongest(members.map((m) => m.submissionConfidence ?? "unknown"), confidenceRank, "unknown");
   return {
     bug: members.map((m) => m.bug).join(" / "),
     members: uniq(members.flatMap((m) => [...m.members, m.bug])),
@@ -911,6 +933,8 @@ function mergeRows(members: ConfirmDecisionRow[]): ConfirmDecisionRow {
     humanGates: uniq(members.map((m) => m.humanGates)).join(" | "),
     ...(engagementProfile ? { engagementProfile } : {}),
     ...(adjudication ? { adjudication } : {}),
+    ...(evidenceLevel !== "unknown" ? { evidenceLevel } : {}),
+    ...(submissionConfidence !== "unknown" ? { submissionConfidence } : {}),
     recommendation: strongest(members.map((m) => m.recommendation), recRank, "unknown"),
     mergedFrom: members.map((m) => m.bug),
   };

--- a/src/agent/confirm.ts
+++ b/src/agent/confirm.ts
@@ -8,7 +8,7 @@ import { writeLastRunPointer } from "../trace/last-run.js";
 import { RunLogger } from "../trace/logger.js";
 import type { Doc } from "../types.js";
 import { publicPath } from "../util/paths.js";
-import { enforceSubmissionReadiness } from "../util/submission-readiness.js";
+import { enforceSubmissionReadiness, isResumeSettledDecision } from "../util/submission-readiness.js";
 import { consolidateByFixEquivalence, type FixEquivEdge, type FixEquivItem } from "./consolidate.js";
 import { RunRecorder, type RunTrackerFactory } from "../db/record.js";
 import { findingContentKey } from "../util/finding-key.js";
@@ -157,8 +157,8 @@ export async function runConfirm(
   };
   recordConfirmStage();
   // RESUME (auto, unless --fresh): an interrupted prior confirm of THIS input run left a
-  // decision sheet; carry its already-SETTLED rows (reproduced yes/no) forward and tell
-  // the model to skip them, so a re-run continues instead of re-reproducing from scratch.
+  // decision sheet; carry only rows that are actually final for the pipeline, so a re-run
+  // continues instead of re-reproducing settled work while still retrying open submit gates.
   const settled = options.fresh ? [] : mergeSettledRows([...(options.settledDecisions ?? []), ...await loadSettledFromPriorConfirm(confirmCfg.outputDir, confirmCfg.targetName, inputRunDir, logger.runDir, runDirs)]);
   let seed = renderFindingsSeed(priorFindings);
   if (settled.length > 0) {
@@ -543,7 +543,7 @@ function mergeSettledRows(rows: ConfirmDecisionRow[]): ConfirmDecisionRow[] {
     const keys = row.members.map((member) => member.trim().toLowerCase()).filter(Boolean);
     return keys.length > 0 ? keys : [row.bug.trim().toLowerCase()].filter(Boolean);
   };
-  for (const row of rows.filter((entry) => entry.reproduced === "yes" || entry.reproduced === "no")) {
+  for (const row of rows.filter((entry) => isResumeSettledDecision(entry))) {
     const keys = memberKeys(row);
     if (keys.length > 0 && keys.every((key) => covered.has(key))) continue;
     out.push(row);
@@ -868,7 +868,7 @@ export async function loadSettledFromPriorConfirm(outputDir: string, targetName:
       const settled = items
         .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === "object" && !Array.isArray(item))
         .map(normalizeDecisionRow);
-      for (const row of settled.filter((entry) => entry.reproduced === "yes" || entry.reproduced === "no")) {
+      for (const row of settled.filter((entry) => isResumeSettledDecision(entry))) {
         const keys = memberKeys(row);
         if (keys.length > 0 && keys.every((key) => covered.has(key))) continue;
         rows.push(row);

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -508,7 +508,7 @@ function inferredDecisionEvidenceLevel(row: Pick<ConfirmRow, "reproduced" | "rep
   if (hasSourceOnlyReproductionCrutch(row)) return "source-only-local-confirmed";
   if (hasLocalForkReproduction(row)) return "local-fork-reproduced";
   if (hasRealTargetReproduction(row)) return "real-target-reproduced";
-  return "real-target-reproduced";
+  return "source-only-local-confirmed";
 }
 
 function shouldDowngradeEvidence(stored: string, inferred: string): boolean {
@@ -520,7 +520,10 @@ function shouldDowngradeEvidence(stored: string, inferred: string): boolean {
 function decisionEvidenceLevel(row: Pick<ConfirmRow, "reproduced" | "evidenceLevel" | "reproEvidence" | "humanGates" | "corroboration" | "novelty" | "adjudication">): string {
   const inferred = inferredDecisionEvidenceLevel(row);
   const explicit = row.evidenceLevel?.trim();
-  if (explicit && !shouldDowngradeEvidence(explicit, inferred)) return explicit;
+  if (explicit) {
+    if (hasSourceOnlyReproductionCrutch(row) && shouldDowngradeEvidence(explicit, "source-only-local-confirmed")) return "source-only-local-confirmed";
+    return explicit;
+  }
   return inferred;
 }
 
@@ -1686,7 +1689,10 @@ export class MetadataStore {
 
   upsertConfirmDecisions(projectId: number, runId: number, rows: ConfirmRow[], decisionPath?: string): void {
     this.transaction(() => {
-      const readyRows = enforceSubmissionReadiness(rows, { requireImpactInventory: false });
+      const readyRows = enforceSubmissionReadiness(
+        rows.map((row) => ({ ...row, evidenceLevel: row.evidenceLevel ?? decisionEvidenceLevel(row) })),
+        { requireImpactInventory: false },
+      );
       // a confirm run's decision sheet is rewritten wholesale, so replace its rows
       this.db.prepare("DELETE FROM confirm_decision WHERE run_id = ?").run(runId);
       const stmt = this.db.prepare(
@@ -1770,7 +1776,13 @@ export class MetadataStore {
 
   /** Count bugs that actually reproduced on the real target (confirm's real output). */
   countConfirmedBugs(projectId: number): number {
-    return Number((this.db.prepare("SELECT COUNT(*) AS n FROM confirm_decision WHERE project_id = ? AND reproduced = 'yes'").get(projectId) as { n: number }).n);
+    return Number((this.db.prepare(
+      `SELECT COUNT(*) AS n
+         FROM confirm_decision
+        WHERE project_id = ?
+          AND reproduced = 'yes'
+          AND evidence_level IN ('real-target-reproduced', 'fork-reproduced', 'local-fork-reproduced')`,
+    ).get(projectId) as { n: number }).n);
   }
 
   // --- daemons + job queue (control plane for remote execution) -------------

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -875,7 +875,7 @@ async function projectGet(c: Ctx): Promise<void> {
     const confirmDecisions = activePrepareRefresh
       ? []
       : currentConfirmDecisions(c.store.listConfirmDecisions(id).filter((row) => rowBelongsToCurrentMaterial(row, currentRunIds, materialBoundary)));
-    const reproducedBugs = confirmDecisions.filter((row) => row.reproduced === "yes").length;
+    const reproducedBugs = confirmDecisions.filter((row) => row.reproduced === "yes" && isRealTargetDecisionEvidence(stringValue(row.evidence_level))).length;
     sendJson(c.res, 200, {
       project,
       progress,
@@ -4223,7 +4223,7 @@ function projectSnapshots(store: MetadataStore, options: ProjectListOptions = {}
     const confirmDecisions = activePrepareRefresh
       ? []
       : currentConfirmDecisions(store.listConfirmDecisions(id).filter((row) => rowBelongsToCurrentMaterial(row, currentRunIds, materialBoundary)));
-    const reproducedBugs = confirmDecisions.filter((row) => row.reproduced === "yes").length;
+    const reproducedBugs = confirmDecisions.filter((row) => row.reproduced === "yes" && isRealTargetDecisionEvidence(stringValue(row.evidence_level))).length;
     const submissionWorkKeys = new Set(confirmDecisions.filter((row) => needsSubmissionReadinessWork(row)).flatMap(confirmDecisionMemberKeys));
     const verifyPendingFindings = (counts.suspected ?? 0) + (counts["confirmed-source"] ?? 0);
     const requiresRealTargetConfirmation = latestPrepareRequiresRealTargetConfirmation(allRuns);

--- a/src/server/daemon.ts
+++ b/src/server/daemon.ts
@@ -272,36 +272,38 @@ async function runPipelineJob(
     await ctx.flushTracker();
   }
 
-  const confirm = await pipelineWorklist(base, headers, spec.target, "confirm");
-  if (confirm.inputRunDir && confirm.inputRunDirs.length > 0 && confirm.confirmKeys.length > 0) {
-    const confirmSpec: LaunchSpec = {
-      ...spec,
-      verb: "confirm",
-      dir: undefined,
-      sourcePaths: [staged],
-      buildRoot: staged,
-      inputRunDir: confirm.inputRunDir,
-      inputRunDirs: confirm.inputRunDirs,
-      confirmKeys: confirm.confirmKeys,
-      ...(confirm.confirmFindings ? { confirmFindings: confirm.confirmFindings } : {}),
-      ...(confirm.confirmSettledRows ? { confirmSettledRows: confirm.confirmSettledRows } : {}),
-    };
-    const confirmCfg = specToConfig(confirmSpec, ctx.out, ctx.workspace);
-    await requireSandboxReady(confirmCfg, "confirm", ctx);
-    await runConfirm(confirmCfg, {
-      inputRunDir: confirmSpec.inputRunDir!,
-      signal: ctx.signal,
-      makeTracker: ctx.makeTracker,
-      onActivity: ctx.onActivity,
-      ...(confirmSpec.inputRunDirs ? { inputRunDirs: confirmSpec.inputRunDirs } : {}),
-      ...(confirmSpec.confirmKeys ? { confirmKeys: confirmSpec.confirmKeys } : {}),
-      ...(confirmSpec.confirmFindings ? { inlineFindings: confirmSpec.confirmFindings } : {}),
-      ...(confirmSpec.confirmSettledRows ? { settledDecisions: confirmSpec.confirmSettledRows } : {}),
-      ...(spec.maxSteps !== undefined ? { maxSteps: spec.maxSteps } : {}),
-      ...(spec.fresh ? { fresh: true } : {}),
-    });
-    await ctx.flushTracker();
-  }
+  await drainPipelineConfirmWork(
+    () => pipelineWorklist(base, headers, spec.target, "confirm"),
+    async (confirm) => {
+      const confirmSpec: LaunchSpec = {
+        ...spec,
+        verb: "confirm",
+        dir: undefined,
+        sourcePaths: [staged],
+        buildRoot: staged,
+        inputRunDir: confirm.inputRunDir!,
+        inputRunDirs: confirm.inputRunDirs,
+        confirmKeys: confirm.confirmKeys,
+        ...(confirm.confirmFindings ? { confirmFindings: confirm.confirmFindings } : {}),
+        ...(confirm.confirmSettledRows ? { confirmSettledRows: confirm.confirmSettledRows } : {}),
+      };
+      const confirmCfg = specToConfig(confirmSpec, ctx.out, ctx.workspace);
+      await requireSandboxReady(confirmCfg, "confirm", ctx);
+      await runConfirm(confirmCfg, {
+        inputRunDir: confirmSpec.inputRunDir!,
+        signal: ctx.signal,
+        makeTracker: ctx.makeTracker,
+        onActivity: ctx.onActivity,
+        ...(confirmSpec.inputRunDirs ? { inputRunDirs: confirmSpec.inputRunDirs } : {}),
+        ...(confirmSpec.confirmKeys ? { confirmKeys: confirmSpec.confirmKeys } : {}),
+        ...(confirmSpec.confirmFindings ? { inlineFindings: confirmSpec.confirmFindings } : {}),
+        ...(confirmSpec.confirmSettledRows ? { settledDecisions: confirmSpec.confirmSettledRows } : {}),
+        ...(spec.maxSteps !== undefined ? { maxSteps: spec.maxSteps } : {}),
+        ...(spec.fresh ? { fresh: true } : {}),
+      });
+      await ctx.flushTracker();
+    },
+  );
 
   const report = await pipelineWorklist(base, headers, spec.target, "report");
   if (report.reportFindings.length > 0) {
@@ -324,7 +326,7 @@ async function runPipelineJob(
   }
 }
 
-async function pipelineWorklist(base: string, headers: Record<string, string>, project: string, phase: "verify" | "confirm" | "report", verifyFromStart = false): Promise<{
+type PipelineWorklist = {
   verifyFindings: unknown[];
   inputRunDir?: string;
   inputRunDirs: string[];
@@ -332,7 +334,34 @@ async function pipelineWorklist(base: string, headers: Record<string, string>, p
   confirmFindings?: Array<Record<string, unknown>>;
   confirmSettledRows?: LaunchSpec["confirmSettledRows"];
   reportFindings: ReportFindingSpec[];
-}> {
+};
+
+export async function drainPipelineConfirmWork(
+  loadWork: () => Promise<PipelineWorklist>,
+  runWork: (work: PipelineWorklist) => Promise<void>,
+): Promise<number> {
+  const seen = new Set<string>();
+  let runs = 0;
+  for (;;) {
+    const work = await loadWork();
+    if (!hasPipelineConfirmWork(work)) return runs;
+    const fingerprint = pipelineConfirmWorkFingerprint(work);
+    if (seen.has(fingerprint)) return runs;
+    seen.add(fingerprint);
+    await runWork(work);
+    runs += 1;
+  }
+}
+
+function hasPipelineConfirmWork(work: PipelineWorklist): boolean {
+  return Boolean(work.inputRunDir && work.inputRunDirs.length > 0 && work.confirmKeys.length > 0);
+}
+
+function pipelineConfirmWorkFingerprint(work: PipelineWorklist): string {
+  return [...new Set(work.confirmKeys.map((key) => key.trim()).filter(Boolean))].sort().join("\n");
+}
+
+async function pipelineWorklist(base: string, headers: Record<string, string>, project: string, phase: "verify" | "confirm" | "report", verifyFromStart = false): Promise<PipelineWorklist> {
   const res = await fetch(base + "/api/daemon/pipeline-worklist", {
     method: "POST",
     headers,

--- a/src/server/ui/src/App.tsx
+++ b/src/server/ui/src/App.tsx
@@ -3442,25 +3442,31 @@ function ProjectOverviewDecisions({
 }) {
   if (!decisions.length) return null;
   const reproduced = confirmedDecisions(decisions).length;
+  const submissionReady = submissionReadyCount(decisions);
   const submitCandidates = submitCandidateCount(decisions);
+  const droppedReproductions = droppedReproductionCount(decisions);
   const missingReports = pendingDecisionReports(decisions).length;
   const meta = decisionCalloutMeta(decisions);
   const preview = overviewDecisionPreview(decisions);
   const remaining = decisions.length - preview.length;
-  const headline = submitCandidates
-    ? plural(submitCandidates, "submit candidate")
-    : reproduced
-      ? plural(reproduced, "real-target reproduction")
-      : plural(decisions.length, "decision");
+  const headline = submissionReady
+    ? plural(submissionReady, "submission-ready bug")
+    : droppedReproductions
+      ? `${plural(droppedReproductions, "reproduced decision")} dropped`
+      : reproduced
+        ? `${plural(reproduced, "real-target reproduction")} not submission-ready`
+        : "No submission-ready bugs";
   const detailParts = [
     plural(decisions.length, "decision"),
+    submissionReady ? plural(submissionReady, "submission-ready bug") : "0 submission-ready",
     reproduced ? plural(reproduced, "real-target reproduction") : "",
+    droppedReproductions ? `${plural(droppedReproductions, "reproduced decision")} dropped` : "",
     missingReports ? `${plural(missingReports, "formal report")} missing` : "",
     meta,
   ].filter(Boolean);
   return (
     <div id="project-submission-decisions" className="section-anchor">
-      <Card title={<span>Submission decisions <Counter>{submitCandidates || reproduced || decisions.length}</Counter></span>}>
+      <Card title={<span>Submission decisions <Counter>{decisions.length}</Counter></span>}>
         <div className="candidate-head">
           <div>
             <strong>{headline}</strong>
@@ -3473,6 +3479,7 @@ function ProjectOverviewDecisions({
         <div className="decision-list overview-decision-list">
           {preview.map((decision) => {
             const metaChips = decisionMetaChips(decision);
+            const dropReason = decisionDropReason(decision);
             return (
               <div className={`decision-row overview-decision-row${isSubmitCandidateDecision(decision) ? " submit-candidate" : ""}`} key={decision.id ?? `${decision.run_id}-${decision.bug}`}>
                 <div className="decision-main">
@@ -3487,10 +3494,11 @@ function ProjectOverviewDecisions({
                       ))}
                     </div>
                   ) : null}
+                  {dropReason ? <small className="decision-drop-reason">{dropReason}</small> : null}
                 </div>
                 <div className="decision-actions">
-                  <Button size="sm" icon="file" title={decision.has_report ? "Open submission report" : "Open generated decision report draft"} onClick={() => onOpenDecisionReport(decision)}>
-                    {decision.has_report ? "Submission report" : "Draft report"}
+                  <Button size="sm" icon="file" title={decisionReportButtonTitle(decision)} onClick={() => onOpenDecisionReport(decision)}>
+                    {decisionReportButtonLabel(decision)}
                   </Button>
                 </div>
               </div>
@@ -3568,6 +3576,14 @@ function decisionLabel(decision: ConfirmDecision): string {
 
 function isSubmitCandidateDecision(decision: ConfirmDecision): boolean {
   return decision.reproduced === "yes" && decision.recommendation === "submit-candidate";
+}
+
+function submissionReadyCount(decisions: ConfirmDecision[]): number {
+  return decisions.filter(isSubmissionReadyDecision).length;
+}
+
+function droppedReproductionCount(decisions: ConfirmDecision[]): number {
+  return decisions.filter((decision) => decision.reproduced === "yes" && decision.recommendation === "drop").length;
 }
 
 function overviewDecisionPreview(decisions: ConfirmDecision[]): ConfirmDecision[] {
@@ -3725,6 +3741,47 @@ function decisionAdjudicationChips(decision: ConfirmDecision): DecisionChip[] {
   ].filter((entry): entry is DecisionChip => Boolean(entry));
 }
 
+function adjudicationGate(adjudication: DecisionObject | undefined, needles: string[]): DecisionObject | undefined {
+  const gates = recordArrayField(adjudication, ["gates", "required_gates", "requiredGates"]);
+  return gates.find((gate) => {
+    const name = [stringField(gate, ["id", "kind", "name", "gate"]), stringField(gate, ["description", "label"])].join(" ").toLowerCase();
+    return needles.some((needle) => name.includes(needle));
+  });
+}
+
+function decisionDropReason(decision: ConfirmDecision): string {
+  if (decision.recommendation !== "drop") return "";
+  const adjudication = decisionStructuredObject(decision, "adjudication", "adjudication_json");
+  const gateDefs = [
+    { label: "Live impact", needles: ["live", "impact", "fund", "exposure", "deployment"], fallback: ["live_impact_status", "liveImpactStatus", "funds_status", "fundsStatus"] },
+    { label: "Payout", needles: ["payout", "reward", "collectible", "bounty"], fallback: ["payout_status", "payoutStatus", "reward_status", "rewardStatus"] },
+    { label: "Scope", needles: ["scope", "venue", "eligib"], fallback: ["scope_status", "scopeStatus"] },
+    { label: "Known issue", needles: ["known", "novel", "duplicate", "disclos"], fallback: ["known_issue_status", "knownIssueStatus", "novelty_status", "noveltyStatus"] },
+  ];
+  for (const gateDef of gateDefs) {
+    const status = gateStatus(adjudication, gateDef.needles, gateDef.fallback);
+    const kind = gateStatusKind(status);
+    if (kind !== "fail" && kind !== "open") continue;
+    const gate = adjudicationGate(adjudication, gateDef.needles);
+    const evidence = stringField(gate, ["evidence", "reason", "basis", "detail"]);
+    return `${gateDef.label}: ${evidence || badgeLabel(status)}`;
+  }
+  if (decision.human_gates?.trim()) return decision.human_gates.trim();
+  if (decision.repro_evidence?.trim()) return decision.repro_evidence.trim();
+  return "Decision report records the non-submittable reason.";
+}
+
+function decisionReportButtonLabel(decision: ConfirmDecision): string {
+  if (decision.has_report) return "Submission report";
+  return isSubmissionReadyDecision(decision) ? "Draft report" : "Decision report";
+}
+
+function decisionReportButtonTitle(decision: ConfirmDecision): string {
+  if (decision.has_report) return "Open submission report";
+  if (isSubmissionReadyDecision(decision)) return "Open generated submission draft";
+  return "Open decision report with reproduction, gates, and drop rationale";
+}
+
 function SeverityBadge({ value }: { value?: string | null }) {
   if (!value?.trim()) return null;
   const token = badgeToken(value);
@@ -3826,6 +3883,7 @@ function ConfirmDecisionsCard({
           {orderedDecisions.map((decision) => {
             const linkedFindings = decisionFindings(decision, findings);
             const metaChips = decisionMetaChips(decision);
+            const dropReason = decisionDropReason(decision);
             return (
               <div className={`decision-row${decision.recommendation === "submit-candidate" ? " submit-candidate" : ""}`} key={decision.id ?? `${decision.run_id}-${decision.bug}`}>
                 <div className="decision-main">
@@ -3841,6 +3899,7 @@ function ConfirmDecisionsCard({
                       ))}
                     </div>
                   ) : null}
+                  {dropReason ? <small className="decision-drop-reason">{dropReason}</small> : null}
                   {linkedFindings.length ? (
                     <div className="linked-findings" aria-label="Linked findings">
                       {linkedFindings.map((finding) => (
@@ -3852,8 +3911,8 @@ function ConfirmDecisionsCard({
                   ) : null}
                 </div>
                 <div className="decision-actions">
-                  <Button size="sm" icon="file" title={decision.has_report ? "Open submission report" : "Open generated decision report draft"} onClick={() => onOpenDecisionReport(decision)}>
-                    {decision.has_report ? "Submission report" : "Draft report"}
+                  <Button size="sm" icon="file" title={decisionReportButtonTitle(decision)} onClick={() => onOpenDecisionReport(decision)}>
+                    {decisionReportButtonLabel(decision)}
                   </Button>
                 </div>
               </div>
@@ -3867,15 +3926,22 @@ function ConfirmDecisionsCard({
 
 function RealTargetCallout({ decisions, onOpen }: { decisions: ConfirmDecision[]; onOpen: () => void }) {
   const reproduced = decisions.filter((decision) => decision.reproduced === "yes").length;
-  const submitCandidates = submitCandidateCount(decisions);
+  const submissionReady = submissionReadyCount(decisions);
+  const droppedReproductions = droppedReproductionCount(decisions);
   const meta = decisionCalloutMeta(decisions);
   if (!decisions.length) return null;
+  const headline = submissionReady
+    ? plural(submissionReady, "submission-ready bug")
+    : droppedReproductions
+      ? `${plural(droppedReproductions, "reproduced decision")} dropped`
+      : "No submission-ready bugs";
+  const tone = submissionReady ? "ready" : droppedReproductions ? "blocked" : "neutral";
   return (
-    <button className="real-target-callout" type="button" onClick={onOpen}>
+    <button className={`real-target-callout ${tone}`} type="button" onClick={onOpen}>
       <span className="dot" />
       <span>
-        <strong>{plural(reproduced, "real-target reproduction")}</strong>
-        <small>{plural(decisions.length, "decision")} recorded{submitCandidates ? ` · ${plural(submitCandidates, "submit candidate")}` : ""}{meta ? ` · ${meta}` : ""}. Open decision reports.</small>
+        <strong>{headline}</strong>
+        <small>{plural(decisions.length, "decision")} recorded{reproduced ? ` · ${plural(reproduced, "real-target reproduction")}` : ""}{droppedReproductions ? ` · ${plural(droppedReproductions, "reproduced decision")} dropped` : ""}{meta ? ` · ${meta}` : ""}. Open decision reports.</small>
       </span>
       <Icon name="arrowright" size={14} />
     </button>
@@ -5946,7 +6012,7 @@ function DecisionReportModal({ decision, onClose }: { decision: ConfirmDecision;
     };
   }, [decision.id, fallback]);
   return (
-    <Modal title={`Submission report #${decision.id ?? ""}`} wide onClose={onClose}>
+    <Modal title={`${decision.has_report ? "Submission report" : "Decision report"} #${decision.id ?? ""}`} wide onClose={onClose}>
       {loading ? <EmptyInline>Loading report...</EmptyInline> : null}
       {!loading && error ? <div className="inline-note">Showing a generated decision summary because the DB report endpoint could not be loaded.</div> : null}
       <MarkdownReport markdown={markdown} fileName={`decision-${decision.id ?? "report"}.md`} />

--- a/src/server/ui/src/App.tsx
+++ b/src/server/ui/src/App.tsx
@@ -3925,7 +3925,7 @@ function ConfirmDecisionsCard({
 }
 
 function RealTargetCallout({ decisions, onOpen }: { decisions: ConfirmDecision[]; onOpen: () => void }) {
-  const reproduced = decisions.filter((decision) => decision.reproduced === "yes").length;
+  const reproduced = confirmedDecisions(decisions).length;
   const submissionReady = submissionReadyCount(decisions);
   const droppedReproductions = droppedReproductionCount(decisions);
   const meta = decisionCalloutMeta(decisions);

--- a/src/server/ui/src/domain.ts
+++ b/src/server/ui/src/domain.ts
@@ -212,7 +212,7 @@ export function sortScopes(scopes: ScopeRow[]): ScopeRow[] {
 }
 
 export function confirmedDecisions(rows: ConfirmDecision[] | undefined): ConfirmDecision[] {
-  return (rows ?? []).filter((row) => row.reproduced === "yes");
+  return (rows ?? []).filter((row) => row.reproduced === "yes" && hasRealTargetEvidence(row));
 }
 
 const DECISION_RECOMMENDATION_RANK: Record<string, number> = {

--- a/src/server/ui/src/styles.css
+++ b/src/server/ui/src/styles.css
@@ -1216,6 +1216,26 @@ small {
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--success) 16%, transparent);
 }
 
+.real-target-callout.blocked {
+  border-color: color-mix(in srgb, var(--danger) 28%, var(--border));
+  background: color-mix(in srgb, var(--danger) 6%, var(--canvas));
+}
+
+.real-target-callout.blocked .dot {
+  background: var(--danger);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--danger) 14%, transparent);
+}
+
+.real-target-callout.neutral {
+  border-color: var(--border);
+  background: var(--canvas-subtle);
+}
+
+.real-target-callout.neutral .dot {
+  background: var(--fg-muted);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--fg-muted) 12%, transparent);
+}
+
 .real-target-callout small {
   display: block;
   margin-top: 1px;
@@ -1224,6 +1244,14 @@ small {
 
 .real-target-callout:hover {
   border-color: color-mix(in srgb, var(--success) 52%, var(--border));
+}
+
+.real-target-callout.blocked:hover {
+  border-color: color-mix(in srgb, var(--danger) 46%, var(--border));
+}
+
+.real-target-callout.neutral:hover {
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
 }
 
 .setup-disclosure summary {
@@ -3365,6 +3393,14 @@ small {
 
 .decision-main small {
   color: var(--fg-muted);
+}
+
+.decision-drop-reason {
+  display: block;
+  max-width: 100%;
+  color: var(--fg-muted);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 
 .decision-meta-chips {

--- a/src/util/submission-readiness.ts
+++ b/src/util/submission-readiness.ts
@@ -54,6 +54,8 @@ export function isResumeSettledDecision(row: object): boolean {
 
 export function submissionReadinessBlocker(row: SubmissionDecisionLike, options: SubmissionReadinessOptions = {}): string | undefined {
   if (decisionReproduced(row) !== "yes") return "the row is not reproduced on the real target";
+  const evidenceLevel = normalizedWord(decisionEvidenceLevel(row));
+  if (evidenceLevel && !isRealTargetEvidenceLevel(evidenceLevel)) return `evidence level is ${evidenceLevel}, not real-target or local-fork reproduced`;
   if (!isBountyLikePolicy(row)) {
     return hasOpenSubmissionGate(row) ? "submission gates remain unsettled in human_gates or adjudication" : undefined;
   }
@@ -96,6 +98,14 @@ function decisionReproduced(row: SubmissionDecisionLike): string {
 
 function decisionRecommendation(row: SubmissionDecisionLike): string {
   return stringField(row, ["recommendation"]).toLowerCase();
+}
+
+function decisionEvidenceLevel(row: SubmissionDecisionLike): string {
+  return stringField(row, ["evidenceLevel", "evidence_level"]);
+}
+
+function isRealTargetEvidenceLevel(value: string): boolean {
+  return value === "real_target_reproduced" || value === "fork_reproduced" || value === "local_fork_reproduced";
 }
 
 function decisionHumanGates(row: SubmissionDecisionLike): string {

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -758,7 +758,7 @@ test("api: daemon pipeline worklist exposes verify candidates before confirm", a
       ], "differential");
       const confirmRun = store.startRun({ projectId: created.id, kind: "confirm", runDir: path.join(out, "pipeline-confirm-run") });
       store.upsertConfirmDecisions(created.id, confirmRun, [
-        { bug: "prior reproduced withdrawal proof", reproduced: "yes", recommendation: "submit-candidate", members: ["kalreadyreproduced"] },
+        { bug: "prior reproduced withdrawal proof", reproduced: "yes", recommendation: "submit-candidate", evidenceLevel: "real-target-reproduced", members: ["kalreadyreproduced"] },
         {
           bug: "gate-blocked reproduced proof",
           reproduced: "yes",
@@ -839,7 +839,7 @@ test("api: current confirm decisions hide older rows superseded by newer member 
       store.finishRun(oldConfirm, "done");
       const newConfirm = store.startRun({ projectId: created.id, kind: "confirm", runDir: path.join(out, "new-confirm") });
       store.upsertConfirmDecisions(created.id, newConfirm, [
-        { bug: "new reproduced result", reproduced: "yes", recommendation: "submit-candidate", members: ["kabc123"] },
+        { bug: "new reproduced result", reproduced: "yes", recommendation: "submit-candidate", evidenceLevel: "real-target-reproduced", members: ["kabc123"] },
       ]);
       store.finishRun(newConfirm, "done");
       const setupFailedConfirm = store.startRun({ projectId: created.id, kind: "confirm", runDir: path.join(out, "setup-failed-confirm") });
@@ -2108,7 +2108,7 @@ test("api: project detail summarizes the latest prepare manifest and workspace q
       ]);
       const confirmRunId = confirmStore.startRun({ projectId: created.id, kind: "confirm", runDir: path.join(out, "prepared-target-confirm-test"), provider: "openai-codex", model: "gpt-5.5" });
       confirmStore.upsertConfirmDecisions(created.id, confirmRunId, [
-        { bug: "prior prepared source bug", reproduced: "yes", recommendation: "submit-candidate", members: ["kalreadyreproduced"] },
+        { bug: "prior prepared source bug", reproduced: "yes", recommendation: "submit-candidate", evidenceLevel: "real-target-reproduced", members: ["kalreadyreproduced"] },
       ]);
       confirmStore.finishRun(confirmRunId, "done");
     } finally {

--- a/tests/confirm-resume.test.mjs
+++ b/tests/confirm-resume.test.mjs
@@ -7,8 +7,9 @@ import { enforceBountySubmitReadiness, loadSettledFromPriorConfirm } from "../di
 import { publicPath } from "../dist/util/paths.js";
 
 // `flounder confirm` auto-resumes a prior interrupted confirm of the same input run: it finds
-// the latest prior confirm dir (matched by frozen provenance) and carries its SETTLED rows
-// (reproduced yes/no) forward. This pins that detection.
+// the latest prior confirm dir (matched by frozen provenance) and carries only rows that
+// are final for the pipeline forward. Reproduced rows with open submission gates must be
+// retried, not treated as settled.
 
 async function mkConfirmRun(outDir, name, inputRunDir, rows) {
   const dir = path.join(outDir, name);
@@ -31,11 +32,11 @@ test("confirm resume: loads SETTLED rows from the latest prior confirm of the sa
   const inputX = "/some/input-run-X";
   const inputY = "/some/input-run-Y";
   await mkConfirmRun(out, "tgt-confirm-20260101T000000Z", inputX, [
-    { bug: "Bug A", reproduced: "yes" },
+    { bug: "Bug A", reproduced: "yes", recommendation: "submit-candidate", humanGates: "" },
     { bug: "Bug B", reproduced: "could-not-set-up" },
   ]);
   await mkConfirmRun(out, "tgt-confirm-20260102T000000Z", inputX, [
-    { bug: "Bug A", reproduced: "yes" },
+    { bug: "Bug A", reproduced: "yes", recommendation: "submit-candidate", humanGates: "" },
     { bug: "Bug B", reproduced: "no" },
   ]);
   await mkConfirmRun(out, "tgt-confirm-20260103T000000Z", inputY, [{ bug: "Bug Z", reproduced: "yes" }]); // different input → ignored
@@ -43,6 +44,25 @@ test("confirm resume: loads SETTLED rows from the latest prior confirm of the sa
   const settled = await loadSettledFromPriorConfirm(out, "tgt", inputX, path.join(out, "tgt-confirm-20260104T000000Z"));
   assert.deepEqual(settled.map((r) => r.bug).sort(), ["Bug A", "Bug B"]); // both settled, from the LATEST matching run
   assert.equal(settled.every((r) => r.reproduced === "yes" || r.reproduced === "no"), true);
+});
+
+test("confirm resume: reproduced needs-human rows are not settled and remain retry work", async () => {
+  const out = await mkdtemp(path.join(os.tmpdir(), "flounder-confirm-resume-gates-"));
+  const inputX = "/some/input-run-X";
+  await mkConfirmRun(out, "tgt-confirm-20260101T000000Z", inputX, [
+    {
+      bug: "Gate blocked bug",
+      reproduced: "yes",
+      recommendation: "needs-human",
+      humanGates: "Live funded exposure and payout tier remain unknown.",
+      adjudication: { live_impact_status: "unknown" },
+    },
+    { bug: "Not reproduced bug", reproduced: "no", recommendation: "drop" },
+    { bug: "Dropped bug", reproduced: "yes", recommendation: "drop", humanGates: "Deprecated deployment." },
+  ]);
+
+  const settled = await loadSettledFromPriorConfirm(out, "tgt", inputX, path.join(out, "tgt-confirm-cur"));
+  assert.deepEqual(settled.map((r) => r.bug).sort(), ["Dropped bug", "Not reproduced bug"]);
 });
 
 test("confirm resume: no prior confirm → empty (fresh start)", async () => {
@@ -53,7 +73,7 @@ test("confirm resume: no prior confirm → empty (fresh start)", async () => {
 test("confirm resume: skips a latest run with no decision sheet (killed before first checkpoint), falls back to an older one", async () => {
   const out = await mkdtemp(path.join(os.tmpdir(), "flounder-confirm-resume-fallback-"));
   const inputX = "/some/input-run-X";
-  await mkConfirmRun(out, "tgt-confirm-20260101T000000Z", inputX, [{ bug: "Bug A", reproduced: "yes" }]);
+  await mkConfirmRun(out, "tgt-confirm-20260101T000000Z", inputX, [{ bug: "Bug A", reproduced: "yes", recommendation: "drop" }]);
   await mkConfirmRun(out, "tgt-confirm-20260102T000000Z", inputX, null); // no decision yet
   const settled = await loadSettledFromPriorConfirm(out, "tgt", inputX, path.join(out, "tgt-confirm-cur"));
   assert.deepEqual(settled.map((r) => r.bug), ["Bug A"]);
@@ -64,12 +84,12 @@ test("confirm resume: aggregate input carries settled rows from prior subset con
   const inputA = "/some/input-run-A";
   const inputB = "/some/input-run-B";
   const inputC = "/some/input-run-C";
-  await mkConfirmRun(out, "tgt-confirm-20260101T000000Z", inputA, [{ bug: "Bug A", reproduced: "yes", members: ["ka"] }]);
+  await mkConfirmRun(out, "tgt-confirm-20260101T000000Z", inputA, [{ bug: "Bug A", reproduced: "yes", recommendation: "drop", members: ["ka"] }]);
   await mkAggregateConfirmRun(out, "tgt-confirm-20260102T000000Z", [inputA, inputB], [
     { bug: "Bug A newer", reproduced: "no", members: ["ka"] },
-    { bug: "Bug B", reproduced: "yes", members: ["kb"] },
+    { bug: "Bug B", reproduced: "yes", recommendation: "submit-candidate", humanGates: "", members: ["kb"] },
   ]);
-  await mkAggregateConfirmRun(out, "tgt-confirm-20260103T000000Z", [inputA, inputC], [{ bug: "Bug C", reproduced: "yes", members: ["kc"] }]);
+  await mkAggregateConfirmRun(out, "tgt-confirm-20260103T000000Z", [inputA, inputC], [{ bug: "Bug C", reproduced: "yes", recommendation: "drop", members: ["kc"] }]);
 
   const settled = await loadSettledFromPriorConfirm(out, "tgt", inputA, path.join(out, "tgt-confirm-cur"), [inputA, inputB]);
   assert.deepEqual(settled.map((r) => r.bug).sort(), ["Bug A newer", "Bug B"]);

--- a/tests/confirm-status.test.mjs
+++ b/tests/confirm-status.test.mjs
@@ -32,7 +32,7 @@ test("pendingConfirmable + decision -> confirm_status (finding-grained, resumabl
   // a confirm settles A=reproduced, B=not. Models sometimes include the title next to the
   // content key, so the store accepts both exact keys and "key title" members.
   store.upsertConfirmDecisions(pid, runId, [
-    { bug: "Bug A", reproduced: "yes", members: [`${keyA} Bug A`] },
+    { bug: "Bug A", reproduced: "yes", evidenceLevel: "real-target-reproduced", members: [`${keyA} Bug A`] },
     { bug: "Bug B", reproduced: "no", members: [`[${keyB}] Bug B`] },
   ]);
 

--- a/tests/daemon-flow.test.mjs
+++ b/tests/daemon-flow.test.mjs
@@ -244,7 +244,7 @@ test("daemon: full job handoff — enqueue → claim → run start → ingest �
     // Daemon reports findings (with a status reason for the timeline) and a confirm decision.
     await asDaemon(base, token, "PATCH", `/api/daemon/runs/${runId}`, { findings: [{ findingKey: "f1", title: "unbound input", location: "src/x:10", status: "suspected" }], reason: "first sighting" });
     await asDaemon(base, token, "PATCH", `/api/daemon/runs/${runId}`, { findings: [{ findingKey: "f1", title: "unbound input", location: "src/x:10", status: "confirmed-differential" }], reason: "differential passed" });
-    await asDaemon(base, token, "PATCH", `/api/daemon/runs/${runId}`, { confirmDecisions: [{ bug: "unbound input", reproduced: "yes", recommendation: "submit-candidate" }], decisionPath: "/tmp/acme-run-1/confirm_report.md" });
+    await asDaemon(base, token, "PATCH", `/api/daemon/runs/${runId}`, { confirmDecisions: [{ bug: "unbound input", reproduced: "yes", recommendation: "submit-candidate", evidenceLevel: "real-target-reproduced" }], decisionPath: "/tmp/acme-run-1/confirm_report.md" });
 
     const findings = await j(await ui(base, "GET", projectPath + "/findings"));
     assert.equal(findings.findings.length, 1);

--- a/tests/daemon-sandbox.test.mjs
+++ b/tests/daemon-sandbox.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { daemonVisibleSandboxReadiness } from "../dist/server/daemon.js";
+import { daemonVisibleSandboxReadiness, drainPipelineConfirmWork } from "../dist/server/daemon.js";
 import { DEFAULT_SANDBOX_IMAGE } from "../dist/security/sandbox.js";
 
 test("daemon: missing default sandbox image is an auto-recoverable capability", () => {
@@ -42,4 +42,32 @@ test("daemon: missing Apple container image does not trigger Docker auto-build",
   assert.equal(visible.ok, false);
   assert.equal(visible.autoBuild, undefined);
   assert.match(visible.message ?? "", /Apple container/);
+});
+
+test("daemon: pipeline confirm drains readiness work until the worklist stops changing", async () => {
+  const work = (keys) => ({
+    verifyFindings: [],
+    inputRunDir: keys.length > 0 ? "/tmp/run-a" : undefined,
+    inputRunDirs: keys.length > 0 ? ["/tmp/run-a"] : [],
+    confirmKeys: keys,
+    reportFindings: [],
+  });
+  const worklists = [
+    work(["finding-a", "finding-b"]),
+    work(["finding-b"]),
+    work(["finding-b"]),
+  ];
+  const ran = [];
+  let index = 0;
+
+  const runs = await drainPipelineConfirmWork(
+    async () => worklists[Math.min(index, worklists.length - 1)],
+    async (current) => {
+      ran.push(current.confirmKeys);
+      index += 1;
+    },
+  );
+
+  assert.equal(runs, 2);
+  assert.deepEqual(ran, [["finding-a", "finding-b"], ["finding-b"]]);
 });

--- a/tests/db-store.test.mjs
+++ b/tests/db-store.test.mjs
@@ -549,7 +549,43 @@ test("store: source-level confirm evidence is not promoted to real-target submis
   const [decision] = db.listConfirmDecisions(projectId);
   assert.equal(decision.evidence_level, "source-only-local-confirmed");
   assert.equal(decision.submission_confidence, "low");
+  assert.equal(decision.recommendation, "needs-human");
+  assert.match(decision.human_gates, /evidence level is source_only_local_confirmed|source-only-local-confirmed/);
   const [finding] = db.listFindings(projectId);
   assert.equal(finding.confirm_status, null);
+  db.close();
+});
+
+test("store: ambiguous reproduced decisions do not default to real-target evidence", async () => {
+  const db = await tempDb();
+  const projectId = db.upsertProject({ name: "p" });
+  const auditRun = db.startRun({ projectId, kind: "run", runDir: "/runs/p-audit-1" });
+  db.upsertFindings(projectId, auditRun, [
+    {
+      findingKey: "kambiguous",
+      title: "Ambiguous reproduction",
+      severity: "high",
+      status: "confirmed-executable",
+    },
+  ]);
+  const confirmRun = db.startRun({ projectId, kind: "confirm", runDir: "/runs/p-confirm-1" });
+  db.upsertConfirmDecisions(projectId, confirmRun, [
+    {
+      bug: "Ambiguous reproduction",
+      reproduced: "yes",
+      recommendation: "submit-candidate",
+      members: ["kambiguous"],
+      reproEvidence: "Prior settled row carried forward: cmd28 testAmbiguousPoC passed.",
+      reproCommandId: "cmd28",
+    },
+  ]);
+
+  const [decision] = db.listConfirmDecisions(projectId);
+  assert.equal(decision.evidence_level, "source-only-local-confirmed");
+  assert.equal(decision.submission_confidence, "low");
+  assert.equal(decision.recommendation, "needs-human");
+  const [finding] = db.listFindings(projectId);
+  assert.equal(finding.confirm_status, null);
+  assert.equal(db.countConfirmedBugs(projectId), 0);
   db.close();
 });


### PR DESCRIPTION
## Summary
- keep pipeline confirm running while submission-readiness worklist makes progress
- stop at a repeated worklist fingerprint to avoid infinite needs-human loops
- add a daemon helper test for draining changing confirm worklists

## Tests
- npm run build
- node --test tests/daemon-sandbox.test.mjs
- node --test tests/run-manager.test.mjs
- git diff --check

Note: node --test tests/daemon-flow.test.mjs hit the local Node 24.13 native assertion in InternalCallbackScope::Close before assertions beyond startup, matching the known local runtime issue.