### PR TITLE
Add duplicate finding links

### DIFF
--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -286,6 +286,7 @@ CREATE TABLE IF NOT EXISTS finding(
   severity TEXT,
   status TEXT NOT NULL,
   confirm_status TEXT,            -- per-finding real-target confirm state: NULL=not confirmed yet | confirming | reproduced | not-reproduced
+  duplicate_of_finding_id INTEGER REFERENCES finding(id),
   report_path TEXT,
   report_markdown TEXT,           -- user-facing per-finding report markdown; local artifacts are only provenance/debug fallback
   scope_id TEXT,
@@ -657,6 +658,7 @@ export class MetadataStore {
       "ALTER TABLE scope ADD COLUMN priority INTEGER DEFAULT 0", // manual dig-queue ordering, separate from score
       "ALTER TABLE finding ADD COLUMN tracking_status TEXT", // submission tracking: open|triaging|submitted|accepted|fixed|duplicate|rejected|ignored
       "ALTER TABLE finding ADD COLUMN confirm_status TEXT", // per-finding real-target confirm state
+      "ALTER TABLE finding ADD COLUMN duplicate_of_finding_id INTEGER REFERENCES finding(id)",
       "ALTER TABLE finding ADD COLUMN report_markdown TEXT", // user-facing per-finding report markdown
       "ALTER TABLE finding ADD COLUMN description TEXT", // rich finding content, previously only in run-dir artifacts
       "ALTER TABLE finding ADD COLUMN evidence TEXT",
@@ -1591,8 +1593,9 @@ export class MetadataStore {
 
   /** Update a finding's submission-tracking state (does NOT touch updated_at, so the audit
    * "found" time and newest-first ordering are preserved). */
-  setFindingTracking(id: number, status: string): boolean {
-    return this.db.prepare("UPDATE finding SET tracking_status = ? WHERE id = ?").run(status || null, id).changes > 0;
+  setFindingTracking(id: number, status: string, duplicateOfFindingId?: number | null): boolean {
+    const duplicateOf = status === "duplicate" ? (duplicateOfFindingId ?? null) : null;
+    return this.db.prepare("UPDATE finding SET tracking_status = ?, duplicate_of_finding_id = ? WHERE id = ?").run(status || null, duplicateOf, id).changes > 0;
   }
 
   /** Persist a user-facing formal report for one finding. The project id guard preserves

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -425,9 +425,9 @@ const ROUTES: Route[] = [
   }),
   route({
     method: "PATCH", path: "/api/findings/:id/tracking",
-    summary: "Set a finding's submission-tracking state (open|triaging|submitted|accepted|fixed|duplicate|rejected|ignored) — for following a bug from discovery to vendor disclosure.",
+    summary: "Set a finding's submission-tracking state (open|triaging|submitted|accepted|fixed|duplicate|rejected|ignored) — for following a bug from discovery to vendor disclosure. When status is duplicate, duplicateOfFindingId may link to the canonical finding in the same project.",
     params: { id: "finding id" },
-    body: { status: "open|triaging|submitted|accepted|fixed|duplicate|rejected|ignored" },
+    body: { status: "open|triaging|submitted|accepted|fixed|duplicate|rejected|ignored", duplicateOfFindingId: "number? — canonical finding id when status is duplicate" },
     handler: findingTracking,
   }),
 
@@ -2865,6 +2865,7 @@ function findingSummaryRow(row: Record<string, unknown>): Record<string, unknown
     "severity",
     "status",
     "confirm_status",
+    "duplicate_of_finding_id",
     "scope_id",
     "confidence",
     "tracking_status",
@@ -3420,7 +3421,21 @@ async function findingTracking(c: Ctx): Promise<void> {
   const body = (await readBody(c.req)) as Record<string, unknown>;
   const status = typeof body.status === "string" ? body.status : "";
   if (!TRACKING_STATES.has(status)) return sendJson(c.res, 400, { error: "invalid tracking status", allowed: [...TRACKING_STATES] });
-  const ok = c.store.setFindingTracking(Number(c.params.id), status);
+  const id = Number(c.params.id);
+  const finding = c.store.getFinding(id);
+  if (!finding) return sendJson(c.res, 404, { error: "no such finding" });
+  const rawDuplicateOf = body.duplicateOfFindingId ?? body.duplicate_of_finding_id;
+  let duplicateOfFindingId: number | null = null;
+  if (rawDuplicateOf !== undefined && rawDuplicateOf !== null && rawDuplicateOf !== "") {
+    const parsed = Number(rawDuplicateOf);
+    if (!Number.isInteger(parsed) || parsed <= 0) return sendJson(c.res, 400, { error: "duplicateOfFindingId must be a positive integer" });
+    if (parsed === id) return sendJson(c.res, 400, { error: "a finding cannot be marked duplicate of itself" });
+    const target = c.store.getFinding(parsed);
+    if (!target) return sendJson(c.res, 400, { error: "duplicate target finding does not exist" });
+    if (Number(target.project_id) !== Number(finding.project_id)) return sendJson(c.res, 400, { error: "duplicate target must be in the same project" });
+    duplicateOfFindingId = parsed;
+  }
+  const ok = c.store.setFindingTracking(id, status, duplicateOfFindingId);
   ok ? sendJson(c.res, 200, { ok: true }) : sendJson(c.res, 404, { error: "no such finding" });
 }
 

--- a/src/server/ui/src/App.tsx
+++ b/src/server/ui/src/App.tsx
@@ -553,9 +553,14 @@ function findingTrackingOptionLabel(status: string): string {
   }[status] ?? status;
 }
 
+function duplicateOfLabel(finding: FindingRow): string | null {
+  return finding.duplicate_of_finding_id ? `Duplicate of #${finding.duplicate_of_finding_id}` : null;
+}
+
 function nextAction(finding: FindingRow): string {
   const tracking = finding.tracking_status ?? "open";
   if (tracking === "ignored") return "Ignored";
+  if (tracking === "duplicate") return duplicateOfLabel(finding) ?? "Duplicate";
   if (tracking === "submitted") return "Watch vendor response";
   if (tracking === "accepted") return "Track fix";
   if (tracking === "fixed") return "Close";
@@ -572,6 +577,7 @@ function nextAction(finding: FindingRow): string {
 function findingWorkflow(finding: FindingRow): { label: string; detail: string; className: string } {
   const tracking = finding.tracking_status ?? "open";
   if (tracking === "ignored") return { label: "Ignored", detail: "Hidden from active workflow", className: "s-discharged" };
+  if (tracking === "duplicate") return { label: "Duplicate", detail: duplicateOfLabel(finding) ?? "Linked duplicate", className: "s-discharged" };
   if (tracking === "accepted" || tracking === "fixed") return { label: tracking === "accepted" ? "Accepted" : "Fixed", detail: nextAction(finding), className: "s-confirmed-executable" };
   if (tracking === "submitted") return { label: "Submitted", detail: "Waiting for vendor response", className: "s-confirmed-source" };
   if (finding.status === "refuted" || finding.status === "discharged") return { label: "Closed", detail: nextAction(finding), className: "s-discharged" };
@@ -1983,7 +1989,21 @@ export function App() {
 
   async function updateTracking(finding: FindingRow, status: string) {
     try {
-      await api.trackFinding(finding.id, status);
+      let duplicateOfFindingId: number | null = null;
+      if (status === "duplicate") {
+        const raw = window.prompt("Canonical finding id this duplicates", finding.duplicate_of_finding_id ? String(finding.duplicate_of_finding_id) : "");
+        if (raw === null) return;
+        const trimmed = raw.trim().replace(/^#/, "");
+        if (trimmed) {
+          const parsed = Number(trimmed);
+          if (!Number.isInteger(parsed) || parsed <= 0) {
+            setToast({ tone: "error", message: "Duplicate target must be a positive finding id." });
+            return;
+          }
+          duplicateOfFindingId = parsed;
+        }
+      }
+      await api.trackFinding(finding.id, status, { duplicateOfFindingId });
       if (route.view === "findings") {
         setBugReloadKey((key) => key + 1);
       } else if (route.projectUuid) {
@@ -4694,6 +4714,7 @@ function FindingList({ findings, compact, empty, onOpenReport }: { findings: Fin
             <span className="grow">
               <strong>{finding.title}</strong>
               <small>{finding.location}</small>
+              {duplicateOfLabel(finding) ? <small>{duplicateOfLabel(finding)}</small> : null}
             </span>
             <span className="candidate-meta">
               {origin ? <span className="label origin-label" title={origin.title}>{origin.label}</span> : null}
@@ -4783,6 +4804,7 @@ function FindingTable({
                   <td className="finding-cell">
                     <strong>{finding.title || "Untitled finding"}</strong>
                     <small>{finding.location || "No location"}{finding.scope_id ? ` · ${finding.scope_id}` : ""}</small>
+                    {duplicateOfLabel(finding) ? <small>{duplicateOfLabel(finding)}</small> : null}
                   </td>
                   <td className="evidence-cell">
                     <StatusBadge status={finding.status} />
@@ -6068,6 +6090,7 @@ function findingReportMarkdown(finding: FindingRow): string {
     finding.location ? `- Location: \`${finding.location}\`` : "",
     finding.severity ? `- Severity: ${finding.severity}` : "",
     finding.confidence != null ? `- Confidence: ${Math.round(finding.confidence * 100)}%` : "",
+    duplicateOfLabel(finding) ? `- Duplicate: ${duplicateOfLabel(finding)}` : "",
     "",
   ].filter(Boolean);
   if (finding.description) lines.push("## Description", "", finding.description, "");

--- a/src/server/ui/src/api.ts
+++ b/src/server/ui/src/api.ts
@@ -164,6 +164,7 @@ export interface FindingRow {
   status: FindingStatus;
   tracking_status?: string | null;
   confirm_status?: string | null;
+  duplicate_of_finding_id?: number | null;
   report_path?: string | null;
   report_markdown?: string | null;
   has_report?: boolean | null;
@@ -504,7 +505,8 @@ export const api = {
     fetchJson<{ findings: FindingRow[]; total: number; limit: number; offset: number; stats: { total: number; active: number; byStatus: Record<string, number>; byTracking: Record<string, number> } }>(`/api/bugs?${params.toString()}`),
   findingReport: (id: number) => fetchJson<{ markdown: string; source: "db" | "generated" }>(`/api/findings/${id}/report`),
   decisionReport: (id: number) => fetchJson<{ markdown: string; source: "db" | "generated" }>(`/api/confirm-decisions/${id}/report`),
-  trackFinding: (id: number, status: string) => patchJson<unknown>(`/api/findings/${id}/tracking`, { status }),
+  trackFinding: (id: number, status: string, opts?: { duplicateOfFindingId?: number | null }) =>
+    patchJson<unknown>(`/api/findings/${id}/tracking`, { status, duplicateOfFindingId: opts?.duplicateOfFindingId ?? null }),
   artifact: (runId: number, name: string) => fetch(`/api/runs/${runId}/artifact?name=${encodeURIComponent(name)}`),
 };
 

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -89,6 +89,7 @@ test("api: GET /api is a self-describing catalog of every resource + operation",
     assert.match(globalFindings.query.limit, /default 200/);
     const findingTracking = cat.endpoints.find((e) => e.method === "PATCH" && e.path === "/api/findings/:id/tracking");
     assert.match(findingTracking.body.status, /ignored/);
+    assert.match(findingTracking.body.duplicateOfFindingId, /canonical finding id/);
     const runLog = cat.endpoints.find((e) => e.method === "GET" && e.path === "/api/runs/:id/log");
     assert.match(runLog.query.tail, /JSON/);
     const runPatch = cat.endpoints.find((e) => e.method === "PATCH" && e.path === "/api/runs/:id");
@@ -3477,6 +3478,57 @@ test("api: ignored findings are hidden from active filters and can be recovered"
     await patch(`/api/findings/${ignored.id}/tracking`, { status: "open" });
     const restored = await json(await fetch(base + `/api/projects/${created.uuid}/findings?tracking=active`));
     assert.deepEqual(restored.findings.map((finding) => finding.finding_key).sort(), ["ignore", "keep"]);
+  });
+});
+
+test("api: duplicate tracking can link to a canonical finding in the same project", async () => {
+  await withServer(async (base, out) => {
+    const json = (r) => r.json();
+    const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    const patch = (p, body) => fetch(base + p, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+
+    const created = await json(await post("/api/projects", { name: "duplicate-finding-links", sourcePaths: ["./src"] }));
+    const other = await json(await post("/api/projects", { name: "duplicate-finding-other", sourcePaths: ["./src"] }));
+    const store = MetadataStore.openForOutput(out);
+    try {
+      const runId = store.startRun({ projectId: created.id, kind: "audit", runDir: await mkdtemp(path.join(out, "duplicate-finding-links-run-")) });
+      store.upsertFindings(created.id, runId, [
+        { findingKey: "canonical", title: "Canonical helper reentry", location: "src/Router.sol:1", severity: "high", status: "confirmed-executable" },
+        { findingKey: "variant", title: "Variant helper reentry", location: "src/Router.sol:2", severity: "medium", status: "confirmed-executable" },
+      ]);
+      const otherRunId = store.startRun({ projectId: other.id, kind: "audit", runDir: await mkdtemp(path.join(out, "duplicate-finding-other-run-")) });
+      store.upsertFindings(other.id, otherRunId, [
+        { findingKey: "other", title: "Other project finding", location: "src/Other.sol:1", severity: "medium", status: "confirmed-executable" },
+      ]);
+    } finally {
+      store.close();
+    }
+
+    const all = await json(await fetch(base + `/api/projects/${created.uuid}/findings`));
+    const canonical = all.findings.find((finding) => finding.finding_key === "canonical");
+    const variant = all.findings.find((finding) => finding.finding_key === "variant");
+    assert.ok(canonical);
+    assert.ok(variant);
+
+    const linkedResponse = await patch(`/api/findings/${variant.id}/tracking`, { status: "duplicate", duplicateOfFindingId: canonical.id });
+    assert.equal(linkedResponse.status, 200);
+    const duplicates = await json(await fetch(base + `/api/projects/${created.uuid}/findings?tracking=duplicate`));
+    assert.equal(duplicates.total, 1);
+    assert.equal(duplicates.findings[0].finding_key, "variant");
+    assert.equal(duplicates.findings[0].duplicate_of_finding_id, canonical.id);
+
+    const selfResponse = await patch(`/api/findings/${variant.id}/tracking`, { status: "duplicate", duplicateOfFindingId: variant.id });
+    assert.equal(selfResponse.status, 400);
+
+    const otherAll = await json(await fetch(base + `/api/projects/${other.uuid}/findings`));
+    const otherFinding = otherAll.findings[0];
+    const crossProjectResponse = await patch(`/api/findings/${variant.id}/tracking`, { status: "duplicate", duplicateOfFindingId: otherFinding.id });
+    assert.equal(crossProjectResponse.status, 400);
+
+    await patch(`/api/findings/${variant.id}/tracking`, { status: "triaging" });
+    const reopened = await json(await fetch(base + `/api/projects/${created.uuid}/findings?q=%23${variant.id}`));
+    assert.equal(reopened.findings[0].tracking_status, "triaging");
+    assert.equal(reopened.findings[0].duplicate_of_finding_id, null);
   });
 });
 

--- a/tests/db-store.test.mjs
+++ b/tests/db-store.test.mjs
@@ -170,6 +170,33 @@ test("store: finding status transitions land on a timeline", async () => {
   db.close();
 });
 
+test("store: duplicate tracking preserves the canonical finding link", async () => {
+  const db = await tempDb();
+  const projectId = db.upsertProject({ name: "duplicates" });
+  const runId = db.startRun({ projectId, kind: "run", runDir: "/runs/duplicates-1" });
+  db.upsertFindings(projectId, runId, [
+    { findingKey: "canonical", title: "router payment helper reentry", status: "confirmed-executable" },
+    { findingKey: "variant", title: "alternate reentry path", status: "confirmed-executable" },
+  ]);
+
+  const findings = db.listFindings(projectId).sort((a, b) => String(a.finding_key).localeCompare(String(b.finding_key)));
+  const canonical = findings.find((finding) => finding.finding_key === "canonical");
+  const variant = findings.find((finding) => finding.finding_key === "variant");
+  assert.ok(canonical);
+  assert.ok(variant);
+
+  assert.equal(db.setFindingTracking(variant.id, "duplicate", canonical.id), true);
+  const duplicate = db.getFinding(variant.id);
+  assert.equal(duplicate.tracking_status, "duplicate");
+  assert.equal(duplicate.duplicate_of_finding_id, canonical.id);
+
+  assert.equal(db.setFindingTracking(variant.id, "triaging"), true);
+  const reopened = db.getFinding(variant.id);
+  assert.equal(reopened.tracking_status, "triaging");
+  assert.equal(reopened.duplicate_of_finding_id, null);
+  db.close();
+});
+
 test("record: verify REFUTED verdicts become structured refuted rows", () => {
   const base = {
     id: "f1",


### PR DESCRIPTION
Summary:
- Persist canonical duplicate links on finding tracking state.
- Expose duplicate target metadata through project findings APIs.
- Show duplicate relationship details in the findings UI.

Tests:
- Node 24.13.0: node --test tests/api.test.mjs tests/db-store.test.mjs