### PR TITLE
Surface refutation infrastructure errors

### DIFF
--- a/src/agent/audit.ts
+++ b/src/agent/audit.ts
@@ -199,6 +199,7 @@ export async function runAudit(
   // Set when concurrent digs already ran differential confirmation in their own
   // isolated workspaces, so the shared post-loop differential stage skips them.
   let digDifferentialDone = false;
+  const refutationErrors: Array<{ phase: "refutation" | "appeal-refutation"; findingId: string; error: string }> = [];
 
   if (cfg.auditVerify) {
     auditMode = "verify";
@@ -630,7 +631,8 @@ export async function runAudit(
       const pocFiles = [...session.scratchFiles.entries()]
         .filter(([scratchPath]) => /\.t\.(sol|rs|ts|js)$/i.test(scratchPath) || /(^|\/)tests?\//i.test(scratchPath) || /(poc|exploit)/i.test(scratchPath))
         .map(([scratchPath, content]) => ({ path: scratchPath, content }));
-      const verdicts = await runRefutation({ findings: candidates, source, cfg: refuteCfg, llm: refuteLlm, logger, max: 8, onProgress: (id) => options.onActivity?.({ kind: "step", tool: `refute ${id}` }), ...(pocFiles.length > 0 ? { pocFiles } : {}) });
+      const refutation = await runRefutation({ findings: candidates, source, cfg: refuteCfg, llm: refuteLlm, logger, max: 8, onProgress: (id) => options.onActivity?.({ kind: "step", tool: `refute ${id}` }), ...(pocFiles.length > 0 ? { pocFiles } : {}) });
+      refutationErrors.push(...refutation.errors.map((error) => ({ phase: "refutation" as const, ...error })));
       for (const finding of candidates) {
         if (!finding.refutation?.refuted) continue;
         if (finding.refutation.unrealistic) {
@@ -646,7 +648,7 @@ export async function runAudit(
           finding.disputed = true;
         }
       }
-      if (verdicts.length > 0) await logger.artifact("audit_refutation.json", verdicts);
+      if (refutation.verdicts.length > 0) await logger.artifact("audit_refutation.json", refutation.verdicts);
 
       // Appeal: a finding the skeptic rejected as UNREALISTIC gets ONE chance to
       // answer the objection with a faithful PoC. A real bug whose first PoC was
@@ -676,8 +678,9 @@ export async function runAudit(
             const appealPocFiles = [...session.scratchFiles.entries()]
               .filter(([scratchPath]) => /\.t\.(sol|rs|ts|js)$/i.test(scratchPath) || /(^|\/)tests?\//i.test(scratchPath) || /(poc|exploit)/i.test(scratchPath))
               .map(([scratchPath, content]) => ({ path: scratchPath, content }));
-            await runRefutation({ findings: [reConfirmed], source, cfg: refuteCfg, llm: refuteLlm, logger, max: 1, ...(appealPocFiles.length > 0 ? { pocFiles: appealPocFiles } : {}) });
-            upheld = !(reConfirmed.refutation?.refuted && reConfirmed.refutation.unrealistic);
+            const appealRefutation = await runRefutation({ findings: [reConfirmed], source, cfg: refuteCfg, llm: refuteLlm, logger, max: 1, ...(appealPocFiles.length > 0 ? { pocFiles: appealPocFiles } : {}) });
+            refutationErrors.push(...appealRefutation.errors.map((error) => ({ phase: "appeal-refutation" as const, ...error })));
+            upheld = appealRefutation.errors.length === 0 && !(reConfirmed.refutation?.refuted && reConfirmed.refutation.unrealistic);
             if (upheld) {
               finding.confirmationStatus = reConfirmed.confirmationStatus;
               if (reConfirmed.commandRunId) finding.commandRunId = reConfirmed.commandRunId;
@@ -690,7 +693,9 @@ export async function runAudit(
             upheld,
             reason: upheld
               ? "rebuilt a faithful PoC that survived re-refutation"
-              : reConfirmed?.refutation?.reason ?? "no faithful PoC produced on appeal",
+              : refutationErrors.some((error) => error.phase === "appeal-refutation" && error.findingId === reConfirmed?.id)
+                ? "appeal re-refutation did not produce a verdict"
+                : reConfirmed?.refutation?.reason ?? "no faithful PoC produced on appeal",
           };
           await logger.event("audit_appeal", { findingId: finding.id, upheld });
           recorder.findings(session.findings, logger.runDir, "appeal"); // reflect this finding's appeal outcome live
@@ -699,9 +704,13 @@ export async function runAudit(
       }
       recorder.stage("refutation", {
         candidates: candidates.length,
+        attempted: refutation.attempted,
+        verdicts: refutation.verdicts.length,
+        errors: refutation.errors.length,
         refuted: candidates.filter((f) => f.refutation?.refuted).length, // funnel: confirmations the skeptic broke
         disputed: candidates.filter((f) => f.disputed).length, // execution-proven but flagged for humans
       });
+      if (refutationErrors.length > 0) await logger.artifact("audit_refutation_errors.json", refutationErrors);
     }
     recorder.findings(session.findings, logger.runDir, "refutation"); // push refutation downgrades (suspected/refuted) to the UI
   }
@@ -755,6 +764,7 @@ export async function runAudit(
     resourceRequests,
     followupScopes,
     findingParseErrors: findingParse.errors.length,
+    infraErrors: refutationErrors.length,
     mode: auditMode,
   });
   await logger.artifact(RUN_HEALTH_FILE, runHealth);

--- a/src/agent/discovery-artifacts.ts
+++ b/src/agent/discovery-artifacts.ts
@@ -59,6 +59,7 @@ export interface RunHealth {
     resourceRequests: number;
     followupScopes: number;
     findingParseErrors: number;
+    infraErrors: number;
   };
 }
 
@@ -114,6 +115,7 @@ export function buildRunHealth(input: {
   resourceRequests: ResourceRequest[];
   followupScopes: AuditScope[];
   findingParseErrors?: number;
+  infraErrors?: number;
   mode?: "breadth" | "map" | "map-dig" | "verify" | "dig" | "confirm";
 }): RunHealth {
   const modelErrorSteps = input.steps.filter((step) => step.tool === "(model-error)" || step.tool === "(session-error)").length;
@@ -127,6 +129,7 @@ export function buildRunHealth(input: {
   const openResources = input.resourceRequests.filter((request) => request.status !== "resolved").length;
   const followupScopes = input.followupScopes.length;
   const findingParseErrors = input.findingParseErrors ?? 0;
+  const infraErrors = input.infraErrors ?? 0;
 
   const reasons: string[] = [];
   let status: RunHealthStatus = "healthy";
@@ -137,6 +140,10 @@ export function buildRunHealth(input: {
 
   if (input.stoppedReason === "error" || input.stoppedReason === "stalled" || modelErrorSteps > 0) {
     setStatus("infra-failed", `run stopped as ${input.stoppedReason} or recorded model/session errors`);
+  }
+  if (infraErrors > 0) {
+    if (status === "healthy") status = "infra-failed";
+    reasons.push(`${infraErrors} post-dig infrastructure error(s) prevented a required verdict`);
   }
   if (findingParseErrors > 0 || parseErrorSteps > 0) {
     if (status === "healthy") status = "infra-failed";
@@ -176,6 +183,7 @@ export function buildRunHealth(input: {
       resourceRequests: openResources,
       followupScopes,
       findingParseErrors,
+      infraErrors,
     },
   };
 }

--- a/src/agent/refutation.ts
+++ b/src/agent/refutation.ts
@@ -29,6 +29,17 @@ export interface RefutationVerdict {
   reason: string;
 }
 
+export interface RefutationError {
+  findingId: string;
+  error: string;
+}
+
+export interface RefutationResult {
+  attempted: number;
+  verdicts: RefutationVerdict[];
+  errors: RefutationError[];
+}
+
 export async function runRefutation(input: {
   findings: AgentFinding[];
   source: Doc[];
@@ -43,9 +54,11 @@ export async function runRefutation(input: {
   // Reports which finding is being refuted, so the caller can surface progress in the live UI
   // (the refutation runs after the dig's scope batch, where the activity stream otherwise goes quiet).
   onProgress?: (findingId: string) => void;
-}): Promise<RefutationVerdict[]> {
-  const out: RefutationVerdict[] = [];
-  for (const finding of input.findings.slice(0, Math.max(0, input.max))) {
+}): Promise<RefutationResult> {
+  const attemptedFindings = input.findings.slice(0, Math.max(0, input.max));
+  const verdicts: RefutationVerdict[] = [];
+  const errors: RefutationError[] = [];
+  for (const finding of attemptedFindings) {
     input.onProgress?.(finding.id);
     const user = buildRefutationPrompt(finding, sourceForLocation(input.source, finding.location), input.pocFiles ?? []);
     try {
@@ -63,14 +76,16 @@ export async function runRefutation(input: {
         const unrealistic = parsed.unrealistic === true && parsed.refuted === true;
         const verdict: RefutationVerdict = { findingId: finding.id, refuted: parsed.refuted, unrealistic, reason: typeof parsed.reason === "string" ? parsed.reason.slice(0, 800) : "" };
         finding.refutation = { refuted: verdict.refuted, reason: verdict.reason, unrealistic };
-        out.push(verdict);
+        verdicts.push(verdict);
         await input.logger.event("audit_refutation", { findingId: finding.id, refuted: verdict.refuted, unrealistic });
       }
     } catch (error) {
-      await input.logger.event("audit_refutation_error", { findingId: finding.id, error: error instanceof Error ? error.message.slice(0, 300) : String(error) });
+      const message = error instanceof Error ? error.message.slice(0, 300) : String(error).slice(0, 300);
+      errors.push({ findingId: finding.id, error: message });
+      await input.logger.event("audit_refutation_error", { findingId: finding.id, error: message });
     }
   }
-  return out;
+  return { attempted: attemptedFindings.length, verdicts, errors };
 }
 
 // Discharge challenge — the FALSE-NEGATIVE counterpart of runRefutation. The dig marks many

--- a/tests/agent.test.mjs
+++ b/tests/agent.test.mjs
@@ -293,6 +293,7 @@ test("run health distinguishes blocked, shallow, and coverage-incomplete runs", 
     coverageGaps: [{ id: "G1", status: "open", obligation: "Parser length must bind payload bytes", reason: "Budget ended before parser sink was audited" }],
   }).status, "needs-coverage");
   assert.equal(buildRunHealth({ ...base, stoppedReason: "error" }).status, "infra-failed");
+  assert.equal(buildRunHealth({ ...base, infraErrors: 1 }).status, "infra-failed");
 });
 
 test("prepare checkpoint guard blocks optional work after source is staged but manifest components are empty", () => {
@@ -1269,11 +1270,34 @@ test("independent refutation: a skeptic verdict is attached to each confirmed fi
         return JSON.stringify({ refuted: false, reason: "could not refute" });
       },
     };
-    const verdicts = await runRefutation({ findings, source, cfg, llm, logger, max: 8 });
+    const result = await runRefutation({ findings, source, cfg, llm, logger, max: 8 });
+    const verdicts = result.verdicts;
     assert.equal(verdicts.length, 2);
+    assert.equal(result.errors.length, 0);
     assert.equal(findings[0].refutation.refuted, false);
     assert.equal(findings[1].refutation.refuted, true);
     assert.match(findings[1].refutation.reason, /enforced/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("refutation reports model-call errors without manufacturing a verdict", async () => {
+  const dir = await tempDir();
+  try {
+    const cfg = defaultConfig();
+    const logger = await tempLogger(dir);
+    const source = [{ path: "x.rs", kind: "source", content: "fn check() {}\n" }];
+    const findings = [
+      { id: "f1", title: "candidate", severity: "high", location: "x.rs:1", description: "", evidence: "", exploitSketch: "", fix: "", confidence: 0.9, confirmationStatus: "confirmed-executable" },
+    ];
+    const llm = { async complete() { throw new Error("session completion returned no text"); } };
+    const result = await runRefutation({ findings, source, cfg, llm, logger, max: 8 });
+    assert.equal(result.attempted, 1);
+    assert.equal(result.verdicts.length, 0);
+    assert.equal(result.errors.length, 1);
+    assert.equal(findings[0].refutation, undefined);
+    assert.match(result.errors[0].error, /no text/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Summary:
- Return explicit refutation result metadata with attempted, verdict, and error counts.
- Record refutation model-call failures as artifacts instead of manufacturing verdicts.
- Mark run health as infra-failed when required post-dig refutation verdicts are missing.

Tests:
- Node 24.13.0: npm run build:server
- Node 24.13.0: npm run check:ui
- Node 24.13.0: node --test tests/agent.test.mjs
- Node 24.13.0: npm run check:api-catalog:dist