### PR TITLE
Block remote URLs in generated confirm files

### DIFF
--- a/src/security/policy.ts
+++ b/src/security/policy.ts
@@ -170,6 +170,8 @@ export function analyzeConfirmBashCommandSafety(command: StructuredReproductionC
   if (workspaceDecision.blocked) return workspaceDecision;
   const destructiveDecision = analyzeDestructiveFilesystemCommandSafety(program, args);
   if (destructiveDecision.blocked) return destructiveDecision;
+  const inlineFileDecision = analyzeInlineGeneratedFileWriteSafety(program, args);
+  if (inlineFileDecision.blocked) return inlineFileDecision;
   const rendered = [program, ...args].join(" ");
   const broadcast = findMatch(rendered, CONFIRM_BROADCAST_PATTERNS);
   if (broadcast && targetsNonLocalNetwork(args)) {
@@ -181,6 +183,61 @@ export function analyzeConfirmBashCommandSafety(command: StructuredReproductionC
     };
   }
   return { blocked: false };
+}
+
+function analyzeInlineGeneratedFileWriteSafety(program: string, args: string[]): CommandSafetyDecision {
+  const payload = inlineCommandPayload(program, args);
+  if (!payload) return { blocked: false };
+  const matchedNetwork = firstNonLocalRemoteUrl(payload);
+  if (!matchedNetwork) return { blocked: false };
+  const matchedAction = firstInlineWriteTarget(payload);
+  if (!matchedAction) return { blocked: false };
+  return {
+    blocked: true,
+    reason: `Blocked by flounder guardrail: generated test file ${matchedAction} must not reference remote URLs.`,
+    matchedNetwork,
+    matchedAction,
+  };
+}
+
+function inlineCommandPayload(program: string, args: string[]): string | undefined {
+  const name = program.toLowerCase();
+  if (name === "python" || name === "python3" || name === "node" || name === "deno" || name === "bun") {
+    for (let idx = 0; idx < args.length - 1; idx += 1) {
+      const arg = args[idx];
+      if (arg === "-c" || arg === "-e" || arg === "--eval") return args[idx + 1];
+    }
+  }
+  if (name === "sh" || name === "bash" || name === "zsh") {
+    for (let idx = 0; idx < args.length - 1; idx += 1) {
+      const arg = args[idx] ?? "";
+      if (arg === "-c" || /^[+-]?[a-zA-Z]*c[a-zA-Z]*$/.test(arg)) return args[idx + 1];
+    }
+  }
+  return undefined;
+}
+
+function firstInlineWriteTarget(payload: string): string | undefined {
+  const patterns = [
+    /\bopen\(\s*["']([^"']+)["']\s*,\s*["'][^"']*[wa+][^"']*["']/g,
+    /\b(?:Path|pathlib\.Path)\(\s*["']([^"']+)["']\s*\)\.write_(?:text|bytes)\s*\(/g,
+    /\b(?:fs\.)?(?:writeFile|writeFileSync)\(\s*["']([^"']+)["']/g,
+    />\s*([A-Za-z0-9._/+:-]*(?:poc|repro|harness|verify|verification|flounder)[A-Za-z0-9._/+:-]*)/gi,
+  ];
+  for (const pattern of patterns) {
+    for (const match of payload.matchAll(pattern)) {
+      const target = match[1]?.trim();
+      if (target) return target;
+    }
+  }
+  return undefined;
+}
+
+function firstNonLocalRemoteUrl(input: string): string | undefined {
+  for (const url of input.match(/\bhttps?:\/\/[^\s"'`<>\\]+/gi) ?? []) {
+    if (!isLocalUrl(url)) return url;
+  }
+  return undefined;
 }
 
 /** True if any rpc/network flag points off-localhost, or a remote URL / RPC-secret reference appears in argv. */

--- a/tests/security-policy.test.mjs
+++ b/tests/security-policy.test.mjs
@@ -220,6 +220,37 @@ test("confirm-mode bash MAY fork and read live networks (the open-world differen
   assert.equal(analyzeAgentBashCommandSafety(cmd("forge", "test", "--fork-url", "https://eth.llamarpc.com")).blocked, true);
 });
 
+test("confirm-mode bash cannot smuggle remote URLs into generated test files", () => {
+  const pythonWrite = cmd(
+    "python3",
+    "-c",
+    "open('poc/Scarb.toml','w').write('[[tool.snforge.fork]]\\nurl = \"https://rpc.starknet.lava.build\"\\n')",
+  );
+  const nodeWrite = cmd(
+    "node",
+    "-e",
+    "require('fs').writeFileSync('repro/config.json', '{\"rpc\":\"https://mainnet.example\"}')",
+  );
+  for (const c of [pythonWrite, nodeWrite]) {
+    const decision = analyzeConfirmBashCommandSafety(c);
+    assert.equal(decision.blocked, true, `${c.program} ${c.args.join(" ")} must be blocked`);
+    assert.match(decision.reason, /generated test file.*remote URLs/i);
+  }
+
+  assert.equal(
+    analyzeConfirmBashCommandSafety(
+      cmd("python3", "-c", "open('poc/Scarb.toml','w').write('[dependencies]\\nstaking = { path = \"..\" }\\n')"),
+    ).blocked,
+    false,
+  );
+  assert.equal(
+    analyzeConfirmBashCommandSafety(
+      cmd("python3", "-c", "import urllib.request; print(urllib.request.urlopen('https://rpc.starknet.lava.build').status)"),
+    ).blocked,
+    false,
+  );
+});
+
 test("confirm-mode bash still NEVER broadcasts a transaction to a non-local network (white-hat line)", () => {
   for (const c of [
     cmd("cast", "send", "--rpc-url", "https://mainnet.example", "0xabc", "drain()"),


### PR DESCRIPTION
Summary:
- Block confirm-mode inline scripts from writing generated test or PoC files that contain non-local remote URLs.
- Keep direct read/fork usage of remote URLs allowed in confirm mode while preventing remote endpoints from being embedded into generated artifacts.
- Add regression coverage for Python and Node inline file writes.

Tests:
- Node 24.13.0: npm run build:server
- Node 24.13.0: node --test tests/security-policy.test.mjs