### PR TITLE
Support append-map seeds and Foundry solc cache

### DIFF
--- a/src/agent/audit.ts
+++ b/src/agent/audit.ts
@@ -292,8 +292,9 @@ export async function runAudit(
     // dig. The resumable `flounder audit` digs from this inventory afterwards.
     const inventoryDir = projectHistoryDir(historyLocation(cfg));
     const existing = cfg.auditAppendMap ? await loadScopeInventory(inventoryDir) : [];
-    const mapSeed = await writeAppendMapExistingScopesSeed(existing, workspaceCwd);
-    if (existing.length > 0) await logger.event("audit_map_append_start", { existing: existing.length, seed: mapSeed });
+    const seedScopes = await loadAppendMapSeedScopes(cfg);
+    const mapSeed = await writeAppendMapExistingScopesSeed([...existing, ...seedScopes], workspaceCwd);
+    if (existing.length > 0 || seedScopes.length > 0) await logger.event("audit_map_append_start", { existing: existing.length, seedScopes: seedScopes.length, seed: mapSeed });
     const mapPhase = await runPhase(withRole(cfg, "map"), {
       mode: "map",
       maxSteps: cfg.auditMapSteps,
@@ -331,13 +332,14 @@ export async function runAudit(
     const picked = cfg.auditScopeIds ?? [];
     scopeInventory = cfg.auditRemap ? [] : await loadScopeInventory(inventoryDir);
     const appendExisting = cfg.auditAppendMap ? scopeInventory : [];
+    const appendSeedScopes = cfg.auditAppendMap ? await loadAppendMapSeedScopes(cfg) : [];
     const resuming = scopeInventory.length > 0 && !cfg.auditAppendMap;
     if (!resuming && (picked.length > 0 || cfg.auditRequireInventory)) {
       throw new Error("`flounder audit` needs an existing scope inventory; run `flounder map` first to enumerate scopes (then pick with `--scope` from audit_scopes.json), or `flounder run` to map and audit in one pass.");
     }
     if (!resuming) {
-      const mapSeed = await writeAppendMapExistingScopesSeed(appendExisting, workspaceCwd);
-      if (appendExisting.length > 0) await logger.event("audit_map_append_start", { existing: appendExisting.length, seed: mapSeed });
+      const mapSeed = await writeAppendMapExistingScopesSeed([...appendExisting, ...appendSeedScopes], workspaceCwd);
+      if (appendExisting.length > 0 || appendSeedScopes.length > 0) await logger.event("audit_map_append_start", { existing: appendExisting.length, seedScopes: appendSeedScopes.length, seed: mapSeed });
       const mapPhase = await runPhase(withRole(cfg, "map"), {
         mode: "map",
         maxSteps: cfg.auditMapSteps,
@@ -1197,6 +1199,37 @@ function deriveScopeNoteFromSource(sourcePaths: string[]): string | undefined {
 function renderMemoryHint(notes: { kind: string; note: string; sourceRef?: string }[]): string {
   if (notes.length === 0) return "";
   return notes.map((note) => `- [${note.kind}] ${note.note}${note.sourceRef ? ` (ref: ${note.sourceRef})` : ""}`).join("\n");
+}
+
+async function loadAppendMapSeedScopes(cfg: AuditorConfig): Promise<AuditScope[]> {
+  const out: AuditScope[] = [];
+  for (const seedPath of cfg.auditAppendMapSeedPaths) {
+    const parsed = JSON.parse(readFileSync(seedPath, "utf8")) as unknown;
+    const scopes = Array.isArray(parsed)
+      ? parsed
+      : parsed && typeof parsed === "object" && Array.isArray((parsed as { scopes?: unknown }).scopes)
+        ? (parsed as { scopes: unknown[] }).scopes
+        : undefined;
+    if (!scopes) throw new Error(`append-map seed must be a scope array or {scopes}: ${seedPath}`);
+    for (const scope of scopes) {
+      if (!scope || typeof scope !== "object") continue;
+      const candidate = scope as Partial<AuditScope>;
+      if (typeof candidate.region !== "string" || typeof candidate.obligation !== "string") continue;
+      out.push({
+        id: typeof candidate.id === "string" ? candidate.id : `seed-${out.length + 1}`,
+        status: candidate.status ?? "pending",
+        region: candidate.region,
+        obligation: candidate.obligation,
+        lenses: Array.isArray(candidate.lenses) ? candidate.lenses : [],
+        exposure: typeof candidate.exposure === "string" ? candidate.exposure : "",
+        difficulty: typeof candidate.difficulty === "string" ? candidate.difficulty : "",
+        score: typeof candidate.score === "number" ? candidate.score : 0,
+        why: typeof candidate.why === "string" ? candidate.why : "",
+        source: candidate.source ?? "map",
+      });
+    }
+  }
+  return out;
 }
 
 async function writeAppendMapExistingScopesSeed(scopes: AuditScope[], workspaceCwd: string): Promise<string | undefined> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -272,6 +272,7 @@ async function parseConfig(args: string[]): Promise<{ cfg: AuditorConfig }> {
   cfg.auditDigConcurrency = readIntFlag(args, "--dig-concurrency") ?? cfg.auditDigConcurrency;
   if (args.includes("--remap")) cfg.auditRemap = true;
   if (args.includes("--append-map") || args.includes("--expand-map")) cfg.auditAppendMap = true;
+  cfg.auditAppendMapSeedPaths = readMultiFlag(args, "--append-map-seed");
   if (args.includes("--dry-run")) cfg.dryRun = true;
   const thinking = readFlag(args, "--thinking");
   if (thinking === "off" || thinking === "minimal" || thinking === "low" || thinking === "medium" || thinking === "high" || thinking === "xhigh") {
@@ -566,6 +567,8 @@ function buildAuditSpec(cmd: "run" | "map" | "audit", rest: string[], cfg: Audit
   if (cmd === "run" && rest.includes("--quick")) spec.quick = true;
   if (rest.includes("--remap")) spec.remap = true;
   if (rest.includes("--append-map") || rest.includes("--expand-map")) spec.appendMap = true;
+  const appendMapSeedPaths = readMultiFlag(rest, "--append-map-seed");
+  if (appendMapSeedPaths.length > 0) spec.appendMapSeedPaths = appendMapSeedPaths;
   if (cmd === "run" && rest.includes("--verify-from-start")) spec.verifyFromStart = true;
   if (rest.includes("--mock-llm")) spec.mockLlm = true; // offline mock model, executed by the daemon
   if (cmd === "audit") {
@@ -736,7 +739,7 @@ function firstPositional(args: string[]): string | undefined {
     "--dig-concurrency", "--scope", "--scope-note", "--max-tokens", "--repro-timeout-ms",
     "--sandbox-backend", "--sandbox-image", "--prepare-network", "--confirm-network",
     "--sandbox-memory-mb", "--sandbox-cpus", "--prepare-timeout-ms", "--scope-coverage-mode",
-    "--coverage",
+    "--coverage", "--append-map-seed",
   ]);
   for (let i = 0; i < args.length; i += 1) {
     const token = args[i];

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,6 +65,10 @@ export interface AuditorConfig {
   // Expand the persisted scope inventory by running MAP with the existing
   // inventory visible, then append only novel scopes. Existing statuses are kept.
   auditAppendMap: boolean;
+  // Extra scope inventory artifact(s) to show MAP in append mode as already-covered
+  // reference material. These are seed-only and are not persisted into the current
+  // inventory unless MAP independently emits novel scopes.
+  auditAppendMapSeedPaths: string[];
   // After the per-scope dig, run one cross-scope SYNTHESIS pass (sink-driven composition) to find
   // bugs that only exist in the COMPOSITION of components. Default on for map→dig; set false to skip.
   auditSynthesize?: boolean;
@@ -199,6 +203,7 @@ export function defaultConfig(): AuditorConfig {
     auditDigConcurrency: 1,
     auditRemap: false,
     auditAppendMap: false,
+    auditAppendMapSeedPaths: [],
     auditMapOnly: false,
     auditRequireInventory: false,
     auditVerifyFromStart: false,

--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -146,6 +146,7 @@ export async function runSandboxCommand(
   // dependency builds are downloaded once and reused across runs. HOME stays the
   // per-run workspace either way, so host credentials/config are never exposed.
   if (cacheDir) await mkdir(cacheDir, { recursive: true });
+  await restoreSandboxToolCaches(workspaceAbsolute, cacheDir);
   const raw = await runWithSelectedBackend({
     command,
     workspaceAbsolute,
@@ -155,6 +156,7 @@ export async function runSandboxCommand(
     maxLogBytes,
     options: normalizeSandboxExecutionOptions(executionOptions),
   });
+  await persistSandboxToolCaches(workspaceAbsolute, cacheDir);
 
   const redactionScope = [workspaceAbsolute, tmpDir, ...redactPaths, ...machineRedactionPaths()];
   return {
@@ -166,6 +168,16 @@ export async function runSandboxCommand(
     stdout: redactMachineStrings(redactLocalPaths(raw.stdout, redactionScope)),
     stderr: redactMachineStrings(redactLocalPaths(raw.stderr, redactionScope)),
   };
+}
+
+async function restoreSandboxToolCaches(workspaceAbsolute: string, cacheDir?: string): Promise<void> {
+  if (!cacheDir) return;
+  await mergeDirectoryContents(path.join(cacheDir, "foundry-svm"), path.join(workspaceAbsolute, ".svm"));
+}
+
+async function persistSandboxToolCaches(workspaceAbsolute: string, cacheDir?: string): Promise<void> {
+  if (!cacheDir) return;
+  await mergeDirectoryContents(path.join(workspaceAbsolute, ".svm"), path.join(cacheDir, "foundry-svm"));
 }
 
 function normalizeSandboxExecutionOptions(input: SandboxExecutionOptions): SandboxProcessOptions {
@@ -618,6 +630,12 @@ async function copyDirectoryContents(sourceDir: string, targetDir: string): Prom
     if (shouldSkipCopyName(entry.name)) continue;
     await copySourcePath(path.join(sourceDir, entry.name), path.join(targetDir, entry.name));
   }
+}
+
+async function mergeDirectoryContents(sourceDir: string, targetDir: string): Promise<void> {
+  if (!(await isDirectory(sourceDir))) return;
+  await mkdir(targetDir, { recursive: true });
+  await copyDirectoryContents(sourceDir, targetDir);
 }
 
 async function copySourcePath(sourcePath: string, targetPath: string): Promise<void> {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -262,7 +262,7 @@ const ROUTES: Route[] = [
     params: { uuid: "project UUID" },
     body: {
       verb: "'run' | 'map' | 'audit' | 'confirm' | 'report' | 'prepare' (default 'run'; project run = prepare-if-needed→map/dig→synthesize→verify→confirm→report; source run = map→dig→synthesize→verify)",
-      remap: "boolean? — re-enumerate scopes (restart)", appendMap: "boolean? — expand the existing scope inventory by appending novel scopes", fresh: "boolean? — confirm: ignore a prior interrupted confirm",
+      remap: "boolean? — re-enumerate scopes (restart)", appendMap: "boolean? — expand the existing scope inventory by appending novel scopes", appendMapSeedPaths: "string[]? — extra prior scope inventories used only as append-map covered-reference seed", fresh: "boolean? — confirm: ignore a prior interrupted confirm",
       quick: "boolean? — run: single breadth pass", mockLlm: "boolean? — offline mock model",
       verifyFromStart: "boolean? — run/continue pipeline: re-run Verify from the beginning instead of only pending candidates",
       region: "string? — audit: pinned region e.g. src/Foo.sol:120-180", scope: "string? — audit: scope id(s)", verifyFindings: "object|array? — audit: inline suspected finding(s) to confirm-or-refute by execution; project finding rows with id are linked back to that original row",
@@ -440,7 +440,7 @@ const ROUTES: Route[] = [
       provider: "string?", model: "string?", thinking: "string?",
       scopeCoverageMode: "focused|standard|half|full|custom? — standard/focused are cumulative project targets, not per-run additions", maxScopes: "number?", mapSteps: "number?", digSteps: "number?", maxSteps: "number?", digSamples: "number?", digConcurrency: "number?",
       sandboxBackend: "'auto'|'oci'|'apple-container'|'host'?", sandboxImage: "string?", sandboxAllowHostFallback: "boolean?", sandboxPrepareNetwork: "'none'|'enabled'?", sandboxConfirmNetwork: "'none'|'enabled'?",
-      remap: "boolean?", appendMap: "boolean? — expand existing scope inventory by appending novel scopes", quick: "boolean?", mockLlm: "boolean?", pipeline: "boolean? — run clue pipeline: prepare if needed -> map/dig -> synthesize -> verify -> confirm -> report", continueCoverage: "boolean? — explicit opt-in to open the next mapped scope batch after the current pipeline round is fully settled", verifyFromStart: "boolean? — pipeline: re-run Verify from the beginning instead of only pending candidates", region: "string?", scope: "string?", scopeNote: "string? — map/audit: 'authorized scope note' that focuses map on the in-scope target (the pipeline auto-derives it from prepare's manifest)", verifyFindings: "object|array? — audit: inline suspected finding(s) to confirm-or-refute by execution",
+      remap: "boolean?", appendMap: "boolean? — expand existing scope inventory by appending novel scopes", appendMapSeedPaths: "string[]? — extra prior scope inventories used only as append-map covered-reference seed", quick: "boolean?", mockLlm: "boolean?", pipeline: "boolean? — run clue pipeline: prepare if needed -> map/dig -> synthesize -> verify -> confirm -> report", continueCoverage: "boolean? — explicit opt-in to open the next mapped scope batch after the current pipeline round is fully settled", verifyFromStart: "boolean? — pipeline: re-run Verify from the beginning instead of only pending candidates", region: "string?", scope: "string?", scopeNote: "string? — map/audit: 'authorized scope note' that focuses map on the in-scope target (the pipeline auto-derives it from prepare's manifest)", verifyFindings: "object|array? — audit: inline suspected finding(s) to confirm-or-refute by execution",
       inputRunDir: "string? — confirm", fresh: "boolean? — confirm",
       clue: "string? — prepare", posture: "string? — prepare", matchDeployed: "boolean? — prepare", endpoint: "string? — prepare",
     },
@@ -1344,11 +1344,11 @@ function latestScopeCheckpoint(runs: Array<Record<string, unknown>>): { scopes: 
   const run = runs.find((entry) => ["run", "map", "audit"].includes(String(entry.kind)) && typeof entry.run_dir === "string");
   if (!run) return null;
   const runDir = path.resolve(String(run.run_dir));
-  const candidates = [
-    path.join(runDir, "audit", "workspace", "scopes.json"),
-    path.join(runDir, "scopes.json"),
-    path.join(runDir, "inventory", "scopes.json"),
-  ];
+  const finalScopes = path.join(runDir, "audit_scopes.json");
+  const workspaceScopes = path.join(runDir, "audit", "workspace", "scopes.json");
+  const candidates = stringValue(run.status) === "running"
+    ? [workspaceScopes, finalScopes, path.join(runDir, "scopes.json"), path.join(runDir, "inventory", "scopes.json")]
+    : [finalScopes, workspaceScopes, path.join(runDir, "scopes.json"), path.join(runDir, "inventory", "scopes.json")];
   const file = candidates.find((candidate) => existsSync(candidate));
   if (!file) return null;
   try {
@@ -2767,6 +2767,7 @@ function normalizeLaunchSpec(body: Record<string, unknown>, target: string, verb
     sandboxCpus: num(body.sandboxCpus),
     remap: bool(body.remap),
     appendMap: bool(body.appendMap),
+    appendMapSeedPaths: list(body.appendMapSeedPaths),
     fresh: bool(body.fresh),
     quick: bool(body.quick),
     mockLlm: bool(body.mockLlm),
@@ -4417,6 +4418,7 @@ function launchSpec(store: MetadataStore, project: Record<string, unknown>, body
     sandboxCpus: num(merged.sandboxCpus),
     remap: Boolean(body.remap),
     appendMap: Boolean(body.appendMap),
+    appendMapSeedPaths: list(body.appendMapSeedPaths, undefined),
     fresh: Boolean(body.fresh),
     quick: Boolean(body.quick),
     mockLlm: Boolean(body.mockLlm),

--- a/src/server/run-manager.ts
+++ b/src/server/run-manager.ts
@@ -62,6 +62,7 @@ export interface LaunchSpec {
   digConcurrency?: number | undefined;
   remap?: boolean | undefined; // run/map/audit: re-enumerate the scope inventory (restart)
   appendMap?: boolean | undefined; // run/map: expand the existing scope inventory without replacing prior scopes
+  appendMapSeedPaths?: string[] | undefined; // run/map/audit append-map: extra prior scope inventories used only as covered-reference seed
   fresh?: boolean | undefined; // confirm: ignore a prior interrupted confirm
   inputRunDir?: string | undefined; // confirm: the finished run dir to reproduce
   inputRunDirs?: string[] | undefined; // confirm (aggregate): several run dirs whose confirmed findings are unioned + reproduced together
@@ -141,8 +142,10 @@ export function specToConfig(spec: LaunchSpec, out: string, workspace?: string):
   cfg.targetName = spec.target;
   const root = spec.dir !== undefined ? resolveUnder(path.resolve(workspace ?? "."), spec.dir, "project dir") : undefined;
   const resolveMat = (p: string): string => (root ? resolveUnder(root, p, "project material") : p);
+  const resolveSeed = (p: string): string => (root && !path.isAbsolute(p) ? resolveUnder(root, p, "append-map seed") : p);
   cfg.sourcePaths = spec.sourcePaths.map(resolveMat);
   cfg.corpusPaths = (spec.corpusPaths ?? []).map(resolveMat);
+  cfg.auditAppendMapSeedPaths = (spec.appendMapSeedPaths ?? []).map(resolveSeed);
   if (spec.buildRoot) cfg.buildRoot = resolveMat(spec.buildRoot);
   else if (root) cfg.buildRoot = root; // default the buildable root to the whole project dir
   if (spec.provider) cfg.provider = spec.provider;
@@ -260,6 +263,7 @@ export function buildArgs(spec: LaunchSpec): string[] {
   if (spec.digConcurrency !== undefined) args.push("--dig-concurrency", String(spec.digConcurrency));
   if (spec.remap && spec.verb !== "confirm") args.push("--remap");
   if (spec.appendMap && (spec.verb === "run" || spec.verb === "map")) args.push("--append-map");
+  for (const seedPath of spec.appendMapSeedPaths ?? []) args.push("--append-map-seed", seedPath);
   if (spec.fresh && spec.verb === "confirm") args.push("--fresh");
   if (spec.quick && spec.verb === "run") args.push("--quick");
   if (spec.mockLlm) args.push("--mock-llm");

--- a/src/server/ui/src/api.ts
+++ b/src/server/ui/src/api.ts
@@ -433,6 +433,7 @@ export interface LaunchPayload {
   continueCoverage?: boolean;
   remap?: boolean;
   appendMap?: boolean;
+  appendMapSeedPaths?: string[];
   verifyFromStart?: boolean;
   findingId?: number;
   findingIds?: number[];

--- a/tests/run-manager.test.mjs
+++ b/tests/run-manager.test.mjs
@@ -86,6 +86,20 @@ test("buildArgs: verify-from-start is an explicit run pipeline flag", () => {
   assert.equal(specToConfig({ verb: "run", target: "p", sourcePaths: ["./s"], verifyFromStart: true }, "runs").auditVerifyFromStart, true);
 });
 
+test("buildArgs/specToConfig: append-map can carry extra seed inventories", () => {
+  const args = buildArgs({ verb: "map", target: "p", sourcePaths: ["./s"], appendMap: true, appendMapSeedPaths: ["/old/audit_scopes.json", "local/scopes.json"] });
+  assert.ok(args.includes("--append-map"));
+  assert.deepEqual(args.slice(args.indexOf("--append-map-seed")), ["--append-map-seed", "/old/audit_scopes.json", "--append-map-seed", "local/scopes.json", "--out", defaultOutputDir()]);
+
+  const cfg = specToConfig(
+    { verb: "map", target: "p", dir: "proj", sourcePaths: ["src"], appendMap: true, appendMapSeedPaths: ["/old/audit_scopes.json", "local/scopes.json"] },
+    "runs",
+    "/ws",
+  );
+  assert.equal(cfg.auditAppendMap, true);
+  assert.deepEqual(cfg.auditAppendMapSeedPaths, ["/old/audit_scopes.json", path.resolve("/ws/proj/local/scopes.json")]);
+});
+
 test("buildArgs: confirm without a run dir is rejected", () => {
   assert.throws(() => buildArgs({ verb: "confirm", target: "p", sourcePaths: ["./s"] }), /inputRunDir/);
 });

--- a/tests/sandbox.test.mjs
+++ b/tests/sandbox.test.mjs
@@ -411,6 +411,46 @@ test("sandbox host backend is explicit and still uses isolated HOME and caches",
   }
 });
 
+test("sandbox reuses Foundry solc cache across isolated HOME directories", async () => {
+  const workspace = await tempDir("flounder-sandbox-svm-home-");
+  const cache = await tempDir("flounder-sandbox-svm-cache-");
+  try {
+    await mkdir(path.join(cache, "foundry-svm", "0.8.35"), { recursive: true });
+    await writeFile(path.join(cache, "foundry-svm", "0.8.35", "solc-0.8.35"), "cached-solc");
+
+    const result = await runSandboxCommand(
+      {
+        program: process.execPath,
+        args: [
+          "-e",
+          [
+            "const fs = require('node:fs');",
+            "const path = require('node:path');",
+            "const cached = path.join(process.env.HOME, '.svm', '0.8.35', 'solc-0.8.35');",
+            "console.log('cached=' + fs.existsSync(cached));",
+            "const installedDir = path.join(process.env.HOME, '.svm', '0.8.33');",
+            "fs.mkdirSync(installedDir, { recursive: true });",
+            "fs.writeFileSync(path.join(installedDir, 'solc-0.8.33'), 'installed-solc');",
+          ].join(" "),
+        ],
+        timeoutMs: 10_000,
+      },
+      workspace,
+      4000,
+      [cache],
+      cache,
+      { backend: "host", allowHostFallback: true, network: "none" },
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /cached=true/);
+    assert.equal(await readFile(path.join(cache, "foundry-svm", "0.8.33", "solc-0.8.33"), "utf8"), "installed-solc");
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+    await rm(cache, { recursive: true, force: true });
+  }
+});
+
 test("sandbox timeouts kill processes that ignore SIGTERM", async () => {
   const workspace = await tempDir("flounder-sandbox-timeout-");
   try {


### PR DESCRIPTION
## Summary
- add append-map seed paths so expansion runs can see prior inventories and avoid duplicate scopes
- prefer finalized audit_scopes.json for completed append-map scope projection
- reuse Foundry .svm compiler cache across isolated sandbox HOME directories

## Tests
- npm run check
- npm run build
- node --test tests/sandbox.test.mjs
- node --test tests/run-manager.test.mjs