### PR TITLE
Fix Foundry confirm target linking

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -518,6 +518,7 @@ function commandFileArgs(command: ReproductionCommand, session: AgentSession): s
     "--test-dir",
     "-C",
     "--config",
+    "--config-path",
     "--manifest-path",
     "--package",
     "-p",
@@ -651,6 +652,7 @@ function scratchLinksToBaseline(filePath: string, content: string, baseline: Set
   const specifiers = sourceSpecifiers(content);
   const remappings = command ? commandRemappings(command) : [];
   for (const specifier of specifiers) {
+    if (baselineHasPathLike(baseline, specifier)) return true;
     if (specifier.startsWith("source/") && baselineHasPathLike(baseline, specifier)) return true;
     if (specifier.startsWith("./") || specifier.startsWith("../")) {
       const resolved = normalizeRelativePath(path.posix.join(dir, specifier));

--- a/tests/agent.test.mjs
+++ b/tests/agent.test.mjs
@@ -1042,6 +1042,36 @@ test("confirm target-link parsing follows command-line remappings from scratch t
   assert.equal(targetLink.linked, true);
 });
 
+test("confirm target-link parsing ignores Foundry config-path when matching scratch tests", () => {
+  const session = {
+    scratchFiles: new Map([[
+      "poc/test/OracleValueStopLossMidBasisPoC.t.sol",
+      "import 'metric-periphery/contracts/extensions/OracleValueStopLossExtension.sol';\ncontract Repro {}\n",
+    ]]),
+    baselineFiles: new Set([
+      "metric-periphery/contracts/extensions/OracleValueStopLossExtension.sol",
+      "poc/foundry.toml",
+    ]),
+  };
+  const command = {
+    program: "forge",
+    args: [
+      "test",
+      "--config-path",
+      "poc/foundry.toml",
+      "--match-path",
+      "poc/test/OracleValueStopLossMidBasisPoC.t.sol",
+      "--match-contract",
+      "OracleValueStopLossMidBasisPoCTest",
+      "-vv",
+    ],
+  };
+
+  assert.deepEqual(commandFileArgsForTest(command, session), ["poc/test/OracleValueStopLossMidBasisPoC.t.sol"]);
+  const targetLink = confirmCommandTargetLinkForTest(command, session);
+  assert.equal(targetLink.linked, true);
+});
+
 test("failed bash command events include an output preview for the UI", async () => {
   const dir = await tempDir();
   try {


### PR DESCRIPTION
## Summary
- ignore Foundry --config-path values when extracting explicit test-file arguments
- treat workspace-relative imports in generated scratch tests as links to pristine baseline source
- add regression coverage for Foundry config-path plus remapping-style imports

## Verification
- npm run build:server
- node --test tests/agent.test.mjs