### PR TITLE
chore: release v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flounders",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flounders",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flounders",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Autonomous white-hat security auditor for AI-driven code review, exploit construction, and execution-grounded verification.",
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Summary
- Bump package metadata from 0.1.3 to 0.2.0.

## Release Gates
- npm run verify: passed, 323 tests.
- npm pack --dry-run: flounders@0.2.0, flounders-0.2.0.tgz.
- DB upgrade smoke: v0.1.2 schema upgrades to schema_version=4 with new release columns present.
- Public-surface scan: passed.
- Prompt release audit: no platform-specific default strategy, required taxonomy, or hardcoded search schedule found.