### PR TITLE
chore: release v0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flounders",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flounders",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flounders",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Autonomous white-hat security auditor for AI-driven code review, exploit construction, and execution-grounded verification.",
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Summary

- bump package metadata from 0.2.0 to 0.3.0
- prepare the merged gpt-5.6-sol default, safety-boundary hardening, persistence fixes, database migration work, and UI/documentation updates for an annotated v0.3.0 tag
- keep npm publishing out of scope; the tag workflow validates and uploads the generated `.tgz` artifact

## Verification

- `npm run verify` (342 tests; API catalog, v0.2.0 database upgrade, mock audit, and public-surface scan passed)
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `npm pack --dry-run` (`flounders-0.3.0.tgz`, 261 files, 1.6 MB)
- independent `gpt-5.6-sol` / xhigh pre-landing review: PASS
- independent `gpt-5.6-sol` / xhigh release safety challenge: PASS after confirming the bump is committed
