### PR TITLE
docs: clarify maintainer harness boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ Flounder supports white-hat audits of publicly available source, your own code, 
 - [Architecture](docs/ARCHITECTURE.md): thin-agent design, sandbox boundary, confirmation boundary, control/execution split, and tracking model.
 - [Product validation](docs/VALIDATION.md): current release-readiness evidence, limits, and remaining validation work.
 - [Capability expansion plan](docs/PRODUCT_CAPABILITY_PLAN.md): accepted design direction for future batch, evidence, and target-preparation capabilities.
+- [Versioned coverage loop](docs/VERSIONED_COVERAGE_LOOP.md): material-versioned Map/Dig state, adaptive sampling, Evaluation isolation, and maintainer Harness safety invariants.
 - [Agent skill](skills/flounder/SKILL.md): Codex / Claude Code operating manual.
 - [Domain profiles](configs/README.md): optional answer-free context packs. They are not product modes and are off by default.
 - [Optional Solidity/EVM notes](docs/SOLIDITY.md), [Cairo/Starknet notes](docs/STARKNET.md), [TON/FunC notes](docs/TON.md), and [ZK constraint profile](configs/zk-constraint-audit.default.json): high-signal context examples and verification-environment setup, not Flounder's core limit.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -86,9 +86,11 @@ evidence requirements, but they cannot execute their own commands, enable host
 execution, relax network policy, bypass allowed sandbox backends, or mint
 findings. Harness experiments use persisted baseline results to cluster terminal
 verifier causes, record passing behavior that must be preserved, and propose
-changes only inside an explicit file allowlist. The evaluator, expected answers,
-command policy, material boundary, confirmation/refutation gate, promotion
-policy, merge, and deployment authority remain outside the optimization loop.
+changes only inside an explicit file allowlist covering prompts, skills, memory
+routing, and the legacy agent loop. Audit orchestration, run-health
+classification, preparation, the evaluator, expected answers, command policy,
+material boundary, confirmation/refutation gate, promotion policy, merge, and
+deployment authority remain outside the optimization loop.
 
 ```mermaid
 flowchart LR

--- a/docs/PRODUCT_CAPABILITY_PLAN.md
+++ b/docs/PRODUCT_CAPABILITY_PLAN.md
@@ -34,8 +34,10 @@ Implemented foundation:
   decisions;
 - verifier-grounded harness experiments that cluster baseline misses, control
   failures, blocked execution, and policy-invalid work by terminal cause;
-- bounded candidate proposals limited to approved prompt, skill, and agent
-  harness files, with passing baseline behavior recorded as a preservation set;
+- bounded candidate proposals limited to prompts, skills, memory routing, and the
+  legacy agent loop, with passing non-holdout baseline behavior recorded as a
+  preservation set; audit orchestration, health classification, and preparation
+  remain protected;
 - paired baseline/candidate scoring with stable work-item and contract identity,
   repeated positive/control minimums, zero-regression checks, blocked/duration/
   attempt budgets, and deterministic `promote | reject | needs-more-samples`

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -381,7 +381,9 @@ They do not let a model change its own judge or deploy itself:
    causal status, and terminal reason rather than text similarity alone.
 2. Record passing positive/control behavior that a candidate must preserve.
 3. Produce a candidate proposal whose files are limited to an explicit allowlist
-   under `prompts/`, `skills/`, or approved agent-harness modules.
+   under `prompts/`, `skills/`, `src/agent/prompts.ts`,
+   `src/agent/memory.ts`, or `src/agent/loop.ts`. Audit orchestration, health
+   classification, and preparation are not editable candidate surfaces.
 4. Run the same stable work-item keys and contracts as a candidate Evaluation,
    normally from a daemon/workspace running the candidate branch.
 5. Apply the product-owned gate: sufficient repeated positive/control samples,
@@ -389,9 +391,11 @@ They do not let a model change its own judge or deploy itself:
    holdout passing, zero paired regressions, every safe control passing, no
    unresolved blocked or invalid work, and configured duration/attempt budgets.
 
-`caseId`, `caseFamily`, `targetStack`, and `holdout` live only in the evaluator
-contract. Holdouts are excluded from failure mining, so a candidate cannot learn
-their mechanism from the experiment that later judges it.
+`caseId`, `caseFamily`, `targetStack`, and `holdout` live in the evaluator
+contract. Candidate briefs exclude holdout failures and preserved-behavior
+details. The maintainer workflow must give a fresh coding-agent context only that
+brief and the approved checkout; the evaluation-operator context retains the
+baseline manifest, item-level holdout identities, expected answers, and results.
 
 The gate returns `promote`, `reject`, or `needs-more-samples`. It never changes
 code, creates an unreviewed merge, or deploys a release. The evaluator, expected

--- a/docs/VERSIONED_COVERAGE_LOOP.md
+++ b/docs/VERSIONED_COVERAGE_LOOP.md
@@ -50,8 +50,9 @@ strategy to use.
 - Adaptive sampling may allocate more model work; it may not declare a scope safe.
 - Finding consolidation is authoritative only when execution proves fix
   equivalence.
-- Harness candidates cannot edit the evaluator, evidence gates, material policy,
-  sandbox policy, promotion policy, tests, merge authority, or deployment logic.
+- Harness candidates cannot edit audit orchestration, run-health classification,
+  preparation, the evaluator, evidence gates, material policy, sandbox policy,
+  promotion policy, tests, merge authority, or deployment logic.
 - Harness is a maintainer-only source-improvement capability. Ordinary Project
   runs never trigger it, and the default control plane neither advertises nor
   accepts its operations.
@@ -86,9 +87,10 @@ strategy to use.
   than a safe result.
 - Blocked build preparation remains a resource request, not a negative security
   outcome.
-- A Harness holdout cannot be mined into the candidate proposal.
-- Candidate and baseline groups with different evidence contracts remain
-  incomparable.
+- A Harness holdout cannot be mined into the candidate proposal or preservation
+  brief; the coding-agent context receives only the exported brief.
+- Candidate and baseline groups with different evidence contracts or effective
+  provider/model/thinking settings remain incomparable.
 
 ### UI and API
 


### PR DESCRIPTION
## Summary

- link the versioned coverage design from the README documentation index
- document the exact candidate-editable surface and protected audit orchestration, health, and preparation boundary
- clarify that holdout secrecy depends on a fresh coding-agent context receiving only the exported candidate brief
- document provider, model, and thinking-level comparability in the Harness gate

## Verification

- public-surface scan passed
- documentation cross-reference completed

This is the post-merge documentation audit follow-up for #50. Version remains v0.3.1.