### PR TITLE
fix: settle completed verification batches

### DIFF
--- a/src/agent/audit.ts
+++ b/src/agent/audit.ts
@@ -407,7 +407,7 @@ export async function runAudit(
     digDifferentialDone = true;
     manualFindings = true;
     steps = aggregatedSteps;
-    stoppedReason = phaseFailureReason ?? "finished";
+    stoppedReason = verifyBatchStoppedReason(phaseFailureReason, verifyDone, toVerify.length);
   } else if (cfg.auditMapOnly) {
     auditMode = "map";
     // MAP only (`flounder map`): enumerate and persist the scope inventory, then stop — no
@@ -1196,6 +1196,18 @@ export async function runAudit(
     summary,
     ...(finalCoverage ? { scopeCoverage: finalCoverage } : {}),
   };
+}
+
+export function verifyBatchStoppedReason(
+  phaseFailureReason: string | undefined,
+  settledVerdicts: number,
+  totalClaims: number,
+): string {
+  // A provider transport may close after the model has already persisted a valid
+  // terminal verdict. Durable verdicts are the Verify completion contract; only a
+  // claim without one remains blocked by the transport failure.
+  if (totalClaims > 0 && settledVerdicts === totalClaims) return "finished";
+  return phaseFailureReason ?? "finished";
 }
 
 export function dischargeChallengeFindingTitle(verdict: { title?: string }, fallback: string): string {

--- a/src/agent/discovery-artifacts.ts
+++ b/src/agent/discovery-artifacts.ts
@@ -148,7 +148,7 @@ export function buildRunHealth(input: {
     reasons.push(reason);
   };
 
-  if (input.stoppedReason === "error" || input.stoppedReason === "stalled" || modelErrorSteps > 0) {
+  if (input.stoppedReason === "error" || input.stoppedReason === "stalled") {
     setStatus("infra-failed", `run stopped as ${input.stoppedReason} or recorded model/session errors`);
   }
   if (infraErrors > 0) {

--- a/src/agent/pi-session.ts
+++ b/src/agent/pi-session.ts
@@ -99,12 +99,13 @@ export function verifyHasRequiredVerdict(session: ToolContext["session"]): boole
  * findings array). A provider transport error after that boundary must remain
  * visible in activity, but it must not turn the completed scope attempt into an
  * infrastructure failure. Incomplete handoffs still fail closed. */
-export function digSessionHasDurableHandoff(input: {
+export function auditSessionHasDurableHandoff(input: {
   deep: boolean;
   synthesize: boolean;
   hasScopeOutcome: boolean;
   hasFindingsArtifact: boolean;
 }): boolean {
+  if (input.synthesize) return input.hasFindingsArtifact;
   return input.deep
     && !input.synthesize
     && input.hasScopeOutcome
@@ -444,18 +445,20 @@ export async function runAuditSession(input: {
 
   const settleSessionError = async (message: string): Promise<SessionDriverResult> => {
     steps.push({ n: stepNo + 1, thought: "", tool: "(session-error)", args: {}, observation: message.slice(0, 500) });
-    const durableHandoff = digSessionHasDurableHandoff({
+    const hasScopeOutcome = scratchHasScopeOutcome(input.ctx.session);
+    const hasFindingsArtifact = scratchHasFindingsArtifact(input.ctx.session);
+    const durableHandoff = auditSessionHasDurableHandoff({
       deep: input.deep === true,
       synthesize: input.synthesize !== undefined,
-      hasScopeOutcome: scratchHasScopeOutcome(input.ctx.session),
-      hasFindingsArtifact: scratchHasFindingsArtifact(input.ctx.session),
+      hasScopeOutcome,
+      hasFindingsArtifact,
     });
     if (!durableHandoff) return { steps, stoppedReason: "error" };
     await input.logger.event("audit_session_error_after_terminal_handoff", {
       error: message.slice(0, 500),
-      phase: "dig",
-      hasScopeOutcome: true,
-      hasFindingsArtifact: true,
+      phase: input.synthesize !== undefined ? "synthesize" : "dig",
+      hasScopeOutcome,
+      hasFindingsArtifact,
       ...activityMeta,
     });
     return { steps, stoppedReason: "finished" };

--- a/src/agent/pi-session.ts
+++ b/src/agent/pi-session.ts
@@ -94,6 +94,23 @@ export function verifyHasRequiredVerdict(session: ToolContext["session"]): boole
   return scratchHasFindings(session);
 }
 
+/** A deep-audit worker has completed its durable handoff once it persisted both
+ * the obligation ledger and a findings artifact (including an explicit empty
+ * findings array). A provider transport error after that boundary must remain
+ * visible in activity, but it must not turn the completed scope attempt into an
+ * infrastructure failure. Incomplete handoffs still fail closed. */
+export function digSessionHasDurableHandoff(input: {
+  deep: boolean;
+  synthesize: boolean;
+  hasScopeOutcome: boolean;
+  hasFindingsArtifact: boolean;
+}): boolean {
+  return input.deep
+    && !input.synthesize
+    && input.hasScopeOutcome
+    && input.hasFindingsArtifact;
+}
+
 export async function promptWithWallClockAbort(
   session: { prompt: (message: string) => Promise<unknown>; abort: () => unknown },
   prompt: string,
@@ -425,6 +442,25 @@ export async function runAuditSession(input: {
     await input.logger.event("audit_findings_finalize_done", { hasFindings: scratchHasFindings(input.ctx.session), hasArtifact: scratchHasFindingsArtifact(input.ctx.session) });
   };
 
+  const settleSessionError = async (message: string): Promise<SessionDriverResult> => {
+    steps.push({ n: stepNo + 1, thought: "", tool: "(session-error)", args: {}, observation: message.slice(0, 500) });
+    const durableHandoff = digSessionHasDurableHandoff({
+      deep: input.deep === true,
+      synthesize: input.synthesize !== undefined,
+      hasScopeOutcome: scratchHasScopeOutcome(input.ctx.session),
+      hasFindingsArtifact: scratchHasFindingsArtifact(input.ctx.session),
+    });
+    if (!durableHandoff) return { steps, stoppedReason: "error" };
+    await input.logger.event("audit_session_error_after_terminal_handoff", {
+      error: message.slice(0, 500),
+      phase: "dig",
+      hasScopeOutcome: true,
+      hasFindingsArtifact: true,
+      ...activityMeta,
+    });
+    return { steps, stoppedReason: "finished" };
+  };
+
   try {
     try {
       await session.prompt(buildSessionPrompt({
@@ -454,8 +490,7 @@ export async function runAuditSession(input: {
             `audit session could not authenticate provider "${input.cfg.provider}". Run \`flounder daemon provider login ${input.cfg.provider}\` on the daemon machine, or start the daemon with that provider's credentials in the environment. For an offline check, run with --mock-llm. Underlying: ${message.slice(0, 300)}`,
           );
         }
-        steps.push({ n: stepNo + 1, thought: "", tool: "(session-error)", args: {}, observation: message.slice(0, 500) });
-        return { steps, stoppedReason: "error" };
+        return await settleSessionError(message);
       }
       // budgetAborted: fall through to the forced finalize below
     }
@@ -466,8 +501,7 @@ export async function runAuditSession(input: {
           `audit session could not authenticate provider "${input.cfg.provider}". Run \`flounder daemon provider login ${input.cfg.provider}\` on the daemon machine, or start the daemon with that provider's credentials in the environment. For an offline check, run with --mock-llm. Underlying: ${sessionError.slice(0, 300)}`,
         );
       }
-      steps.push({ n: stepNo + 1, thought: "", tool: "(session-error)", args: {}, observation: sessionError.slice(0, 500) });
-      return { steps, stoppedReason: "error" };
+      return await settleSessionError(sessionError);
     }
     await finalizeIfEmpty();
     return { steps, stoppedReason: verifyMissingVerdict ? "error" : budgetAborted ? "step-budget" : "finished" };

--- a/tests/agent.test.mjs
+++ b/tests/agent.test.mjs
@@ -19,7 +19,7 @@ import { differentialNetworkForExploitRun, runDifferentialConfirmation } from ".
 import { runDischargeChallenge, runRefutation } from "../dist/agent/refutation.js";
 import { renderReportFileManifest } from "../dist/agent/report.js";
 import { stagePackageSource } from "../dist/agent/package-source.js";
-import { assistantMessageError, buildSessionPrompt, createIsolatedResourceLoader, digSessionHasDurableHandoff, FINDINGS_FINALIZE_PROMPT, isPiSessionProvider, mapCheckpointDirective, mapThinkingLevel, prepareCheckpointDirective, promptWithWallClockAbort, resolveFinalizePromptTimeoutMs, toolSchemas, withDetailedCodexReasoningSummary } from "../dist/agent/pi-session.js";
+import { assistantMessageError, auditSessionHasDurableHandoff, buildSessionPrompt, createIsolatedResourceLoader, FINDINGS_FINALIZE_PROMPT, isPiSessionProvider, mapCheckpointDirective, mapThinkingLevel, prepareCheckpointDirective, promptWithWallClockAbort, resolveFinalizePromptTimeoutMs, toolSchemas, withDetailedCodexReasoningSummary } from "../dist/agent/pi-session.js";
 import { MockAuditLlmClient } from "../dist/llm/mock.js";
 import { RunLogger } from "../dist/trace/logger.js";
 import { renderDisclosure } from "../dist/reports/disclosure.js";
@@ -647,32 +647,38 @@ test("run health distinguishes blocked, shallow, and coverage-incomplete runs", 
   assert.equal(verifyBatchStoppedReason("error", 6, 7), "error");
 });
 
-test("deep sessions settle post-handoff transport errors only after both durable artifacts exist", () => {
-  assert.equal(digSessionHasDurableHandoff({
+test("audit sessions settle post-handoff transport errors only after phase-required artifacts exist", () => {
+  assert.equal(auditSessionHasDurableHandoff({
     deep: true,
     synthesize: false,
     hasScopeOutcome: true,
     hasFindingsArtifact: true,
   }), true);
-  assert.equal(digSessionHasDurableHandoff({
+  assert.equal(auditSessionHasDurableHandoff({
     deep: true,
     synthesize: false,
     hasScopeOutcome: false,
     hasFindingsArtifact: true,
   }), false);
-  assert.equal(digSessionHasDurableHandoff({
+  assert.equal(auditSessionHasDurableHandoff({
     deep: true,
     synthesize: false,
     hasScopeOutcome: true,
     hasFindingsArtifact: false,
   }), false);
-  assert.equal(digSessionHasDurableHandoff({
+  assert.equal(auditSessionHasDurableHandoff({
     deep: true,
     synthesize: true,
     hasScopeOutcome: true,
     hasFindingsArtifact: true,
+  }), true);
+  assert.equal(auditSessionHasDurableHandoff({
+    deep: true,
+    synthesize: true,
+    hasScopeOutcome: true,
+    hasFindingsArtifact: false,
   }), false);
-  assert.equal(digSessionHasDurableHandoff({
+  assert.equal(auditSessionHasDurableHandoff({
     deep: false,
     synthesize: false,
     hasScopeOutcome: true,

--- a/tests/agent.test.mjs
+++ b/tests/agent.test.mjs
@@ -10,7 +10,7 @@ import { ProjectMemory } from "../dist/agent/memory.js";
 import { buildTools, describeAction, ingestFindingsFromScratch, newSession, dedupeFindings, readScratchScopes, isReportFile, scratchHasFindings, scratchHasFindingsArtifact, commandFileArgsForTest, confirmCommandTargetLinkForTest, splitCommandLineForTest } from "../dist/agent/tools.js";
 import { buildRunHealth, mergeFollowupScopes, readScratchCoverageGaps, readScratchFollowupScopes, readScratchResourceRequests } from "../dist/agent/discovery-artifacts.js";
 import { mergeScopeInventory } from "../dist/agent/scope-store.js";
-import { dedupeVerifyInputs, dischargeChallengeFindingTitle, dischargeChallengeScopeOutcomes, normalizeVerifyVerdicts, runAudit } from "../dist/agent/audit.js";
+import { dedupeVerifyInputs, dischargeChallengeFindingTitle, dischargeChallengeScopeOutcomes, normalizeVerifyVerdicts, runAudit, verifyBatchStoppedReason } from "../dist/agent/audit.js";
 import { normalizePrepareManifest, prepareValidationBlockingIssues, readPrepareManifest } from "../dist/agent/acquire.js";
 import { runAuditLoop, isTransientError } from "../dist/agent/loop.js";
 import { MetadataStore } from "../dist/db/store.js";
@@ -641,7 +641,10 @@ test("run health distinguishes blocked, shallow, and coverage-incomplete runs", 
     coverageGaps: [{ id: "G1", status: "open", obligation: "Parser length must bind payload bytes", reason: "Budget ended before parser sink was audited" }],
   }).status, "needs-coverage");
   assert.equal(buildRunHealth({ ...base, stoppedReason: "error" }).status, "infra-failed");
+  assert.equal(buildRunHealth({ ...base, mode: "verify", steps: [...base.steps, { tool: "(session-error)" }] }).status, "healthy");
   assert.equal(buildRunHealth({ ...base, infraErrors: 1 }).status, "infra-failed");
+  assert.equal(verifyBatchStoppedReason("error", 7, 7), "finished");
+  assert.equal(verifyBatchStoppedReason("error", 6, 7), "error");
 });
 
 test("scope inventory merge appends novel scopes while preserving existing status", () => {

--- a/tests/agent.test.mjs
+++ b/tests/agent.test.mjs
@@ -19,7 +19,7 @@ import { differentialNetworkForExploitRun, runDifferentialConfirmation } from ".
 import { runDischargeChallenge, runRefutation } from "../dist/agent/refutation.js";
 import { renderReportFileManifest } from "../dist/agent/report.js";
 import { stagePackageSource } from "../dist/agent/package-source.js";
-import { assistantMessageError, buildSessionPrompt, createIsolatedResourceLoader, FINDINGS_FINALIZE_PROMPT, isPiSessionProvider, mapCheckpointDirective, mapThinkingLevel, prepareCheckpointDirective, promptWithWallClockAbort, resolveFinalizePromptTimeoutMs, toolSchemas, withDetailedCodexReasoningSummary } from "../dist/agent/pi-session.js";
+import { assistantMessageError, buildSessionPrompt, createIsolatedResourceLoader, digSessionHasDurableHandoff, FINDINGS_FINALIZE_PROMPT, isPiSessionProvider, mapCheckpointDirective, mapThinkingLevel, prepareCheckpointDirective, promptWithWallClockAbort, resolveFinalizePromptTimeoutMs, toolSchemas, withDetailedCodexReasoningSummary } from "../dist/agent/pi-session.js";
 import { MockAuditLlmClient } from "../dist/llm/mock.js";
 import { RunLogger } from "../dist/trace/logger.js";
 import { renderDisclosure } from "../dist/reports/disclosure.js";
@@ -645,6 +645,39 @@ test("run health distinguishes blocked, shallow, and coverage-incomplete runs", 
   assert.equal(buildRunHealth({ ...base, infraErrors: 1 }).status, "infra-failed");
   assert.equal(verifyBatchStoppedReason("error", 7, 7), "finished");
   assert.equal(verifyBatchStoppedReason("error", 6, 7), "error");
+});
+
+test("deep sessions settle post-handoff transport errors only after both durable artifacts exist", () => {
+  assert.equal(digSessionHasDurableHandoff({
+    deep: true,
+    synthesize: false,
+    hasScopeOutcome: true,
+    hasFindingsArtifact: true,
+  }), true);
+  assert.equal(digSessionHasDurableHandoff({
+    deep: true,
+    synthesize: false,
+    hasScopeOutcome: false,
+    hasFindingsArtifact: true,
+  }), false);
+  assert.equal(digSessionHasDurableHandoff({
+    deep: true,
+    synthesize: false,
+    hasScopeOutcome: true,
+    hasFindingsArtifact: false,
+  }), false);
+  assert.equal(digSessionHasDurableHandoff({
+    deep: true,
+    synthesize: true,
+    hasScopeOutcome: true,
+    hasFindingsArtifact: true,
+  }), false);
+  assert.equal(digSessionHasDurableHandoff({
+    deep: false,
+    synthesize: false,
+    hasScopeOutcome: true,
+    hasFindingsArtifact: true,
+  }), false);
 });
 
 test("scope inventory merge appends novel scopes while preserving existing status", () => {


### PR DESCRIPTION
## Summary
- align job and run terminal states when any required phase genuinely fails
- preserve provider transport errors in activity for diagnostics
- settle Verify batches once every claim has a durable terminal verdict
- settle completed dig handoffs only after both scope outcome and findings artifacts exist
- settle completed synthesis handoffs only after the fresh findings artifact exists
- keep missing or incomplete terminal artifacts fail-closed

## Verification
- npm run check
- npm test (455/455)
- npm run check:api-catalog:dist
- npm run check:db-upgrade:dist
- npm run check:public
- git diff --check
- live five-scope audit completed with finished status and zero model, parse, or infrastructure errors
