### PR TITLE
Fix Apple container timeout cleanup

### DIFF
--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -507,12 +507,6 @@ async function runAppleContainerSandboxProcess(input: ProcessRunInput): Promise<
     if (value !== undefined) containerArgs.push("--env", `${key}=${value}`);
   }
   containerArgs.push(input.options.image, input.command.program, ...input.command.args);
-  let cleanupStarted = false;
-  const cleanupTimedOutContainer = (): void => {
-    if (cleanupStarted) return;
-    cleanupStarted = true;
-    void forceRemoveAppleContainer(containerName);
-  };
   const result = await runSpawnedProcess({
     program: "container",
     args: containerArgs,
@@ -520,10 +514,21 @@ async function runAppleContainerSandboxProcess(input: ProcessRunInput): Promise<
     env: containerClientEnv(),
     timeoutMs: input.command.timeoutMs ?? 120_000,
     maxLogBytes: input.maxLogBytes,
-    onTimeout: cleanupTimedOutContainer,
-    timeoutKillDelayMs: 250,
   });
-  if (result.timedOut) cleanupTimedOutContainer();
+  if (result.timedOut) {
+    // The Apple CLI may still be unwinding its `container run` XPC session when
+    // the timeout fires. Deleting concurrently races that session and can leave
+    // the per-container VM running indefinitely, so wait for the client process
+    // to exit before retrying and observing cleanup.
+    const cleanup = await forceRemoveAppleContainer(containerName);
+    if (!cleanup.ok) {
+      result.stderr = appendLimited(
+        result.stderr,
+        `Apple container cleanup failed after command timeout: ${cleanup.message}`,
+        input.maxLogBytes,
+      );
+    }
+  }
   return result;
 }
 
@@ -1190,15 +1195,31 @@ async function forceRemoveContainer(name: string): Promise<void> {
   });
 }
 
-async function forceRemoveAppleContainer(name: string): Promise<void> {
-  await runSpawnedProcess({
-    program: "container",
-    args: ["delete", "--force", name],
-    cwd: process.cwd(),
-    env: containerClientEnv(),
-    timeoutMs: 10_000,
-    maxLogBytes: 2000,
-  });
+async function forceRemoveAppleContainer(name: string): Promise<{ ok: boolean; message: string }> {
+  const attempts = 3;
+  let message = "container delete did not complete";
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = await runSpawnedProcess({
+      program: "container",
+      args: ["delete", "--force", name],
+      cwd: process.cwd(),
+      env: containerClientEnv(),
+      timeoutMs: 10_000,
+      maxLogBytes: 2000,
+    });
+    const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    if (result.exitCode === 0 || appleContainerIsAlreadyAbsent(output)) return { ok: true, message: "removed" };
+    message = output || `container delete exited with code ${String(result.exitCode)}`;
+    if (attempt < attempts) {
+      await new Promise<void>((resolve) => setTimeout(resolve, attempt * 250));
+    }
+  }
+  return { ok: false, message };
+}
+
+function appleContainerIsAlreadyAbsent(output: string): boolean {
+  const normalized = output.toLowerCase();
+  return normalized.includes("container with id") && (normalized.includes("notfound") || normalized.includes("not found"));
 }
 
 function dockerClientEnv(): NodeJS.ProcessEnv {

--- a/tests/sandbox.test.mjs
+++ b/tests/sandbox.test.mjs
@@ -61,14 +61,22 @@ function truncatedMachO64() {
 async function fakeContainerCli(options = {}) {
   const dir = await tempDir("flounder-fake-container-bin-");
   const bin = path.join(dir, "container");
+  const deleteStateFile = path.join(dir, "delete-count");
   await writeFile(bin, `#!/usr/bin/env bash
 LOG_FILE=${JSON.stringify(options.logFile ?? "")}
 RUN_SLEEP_SECONDS=${JSON.stringify(String(options.runSleepSeconds ?? 0))}
+DELETE_FAIL_COUNT=${JSON.stringify(String(options.deleteFailCount ?? 0))}
+DELETE_STATE_FILE=${JSON.stringify(deleteStateFile)}
 if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then printf '%s' ${JSON.stringify(options.imageInspectStderr ?? "")} >&2; exit ${options.imageInspectExit ?? 0}; fi
 if [ "$1" = "network" ] && [ "$2" = "inspect" ]; then exit ${options.networkInspectExit ?? 0}; fi
 if [ "$1" = "network" ] && [ "$2" = "create" ]; then exit ${options.networkCreateExit ?? 0}; fi
 if [ "$1" = "delete" ]; then
   if [ -n "$LOG_FILE" ]; then printf 'DELETE:%s\\n' "\${3:-}" >> "$LOG_FILE"; fi
+  DELETE_COUNT=0
+  if [ -f "$DELETE_STATE_FILE" ]; then read -r DELETE_COUNT < "$DELETE_STATE_FILE"; fi
+  DELETE_COUNT=$((DELETE_COUNT + 1))
+  printf '%s\\n' "$DELETE_COUNT" > "$DELETE_STATE_FILE"
+  if [ "$DELETE_COUNT" -le "$DELETE_FAIL_COUNT" ]; then printf 'transient delete failure\\n' >&2; exit 1; fi
   exit ${options.deleteExit ?? 0}
 fi
 if [ "$1" = "run" ]; then
@@ -451,7 +459,7 @@ test("sandbox Apple container backend force-deletes timed-out containers", async
   const workspace = await tempDir("flounder-sandbox-apple-timeout-");
   const logDir = await tempDir("flounder-sandbox-apple-timeout-log-");
   const logFile = path.join(logDir, "container.log");
-  const fakeBin = await fakeContainerCli({ logFile, runSleepSeconds: 5 });
+  const fakeBin = await fakeContainerCli({ logFile, runSleepSeconds: 5, deleteFailCount: 1 });
   const oldPath = process.env.PATH;
   try {
     process.env.PATH = `${fakeBin}${path.delimiter}${oldPath ?? ""}`;
@@ -465,7 +473,8 @@ test("sandbox Apple container backend force-deletes timed-out containers", async
     );
 
     assert.equal(result.timedOut, true);
-    await waitForFileMatch(logFile, /DELETE:flounder-/);
+    const cleanupLog = await waitForFileMatch(logFile, /DELETE:flounder-[^\n]+\nDELETE:flounder-/);
+    assert.equal(cleanupLog.match(/DELETE:flounder-/g)?.length, 2);
   } finally {
     process.env.PATH = oldPath;
     await rm(workspace, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- wait for the Apple `container run` client to exit before cleanup
- retry `container delete --force` after transient failures
- treat an already-removed container as a successful cleanup
- surface a cleanup failure in sandbox command diagnostics
- cover the timeout race with a deterministic fake-CLI regression test

## Root cause

The Apple backend started a one-shot asynchronous delete at the same time the timed-out `container run` client was still unwinding. If that delete lost the race or failed transiently, the cleanup result was ignored and no later retry was possible. Repeated timeouts could therefore leave per-container VMs running and eventually degrade Apple vmnet connectivity.

## Impact

Timed-out Apple sandbox commands now return only after cleanup has either succeeded or produced an actionable diagnostic. This prevents silent VM accumulation while keeping the Apple backend selected; it does not introduce an OCI fallback.

## Validation

- `npm run verify`
  - 455 tests passed
  - API catalog contract passed
  - database upgrade contract passed
  - mock audit passed
  - public-surface scan passed
- live Apple Container timeout smoke test confirmed no residual VM after return
- live Apple Container egress probe reached the package registry successfully after stale VM cleanup and vmnet restart
