### PR TITLE
Fix multi-package dependency warm-up

### DIFF
--- a/src/agent/prepare.ts
+++ b/src/agent/prepare.ts
@@ -381,7 +381,9 @@ async function detectToolchains(workspaceAbsolute: string): Promise<ToolchainPla
     if (dirs.length === 0) return undefined;
     return dirs.sort((a, b) => a.split("/").length - b.split("/").length || a.length - b.length)[0];
   };
-  const hasIn = (dir: string, name: string): boolean => manifests.some((entry) => entry.dir === dir && entry.name === name);
+  const hasIn = (dir: string, name: string): boolean => manifests.some((entry) =>
+    normalizePlanDir(entry.dir) === normalizePlanDir(dir) && entry.name === name,
+  );
 
   // Order matters: dependency-install toolchains (npm/pnpm/yarn) run FIRST, because
   // a Solidity/Foundry project often imports its dependencies (e.g. @openzeppelin)
@@ -389,13 +391,12 @@ async function detectToolchains(workspaceAbsolute: string): Promise<ToolchainPla
   // mod download, then the compile toolchains (cargo, Scarb/Cairo, Blueprint/TON,
   // forge).
   //
-  // The package manager is chosen by the lockfile CO-LOCATED with the shallowest
-  // package.json (the project root), NOT by any lockfile anywhere in the tree: a
-  // vendored Foundry lib (e.g. lib/solmate) can ship its own yarn.lock, and a global
-  // match would wrongly run `yarn install` in that sub-dir instead of the root
-  // install that actually fetches the project's dependencies.
-  const pkgDir = shallowest((name) => name === "package.json");
-  if (pkgDir !== undefined) {
+  // Choose the package manager from the lockfile CO-LOCATED with each outermost
+  // package.json. A multi-project audit root can contain sibling buildable packages
+  // that each need their own dependency closure before their Foundry build. Nested
+  // package manifests remain covered by their nearest outer package, so a vendored
+  // Foundry lib cannot redirect installation into its own subdirectory.
+  for (const pkgDir of outermostManifestDirs(manifests, "package.json")) {
     if (hasIn(pkgDir, "pnpm-lock.yaml")) plans.push({ toolchain: "pnpm", ...cwd(pkgDir), commands: [["pnpm", "install", "--frozen-lockfile"]] });
     else if (hasIn(pkgDir, "yarn.lock")) plans.push({ toolchain: "yarn", ...cwd(pkgDir), commands: [["yarn", "install", "--frozen-lockfile"]] });
     else if (hasIn(pkgDir, "package-lock.json")) plans.push({ toolchain: "npm", ...cwd(pkgDir), commands: [["npm", "install", "--no-audit", "--no-fund"]] });

--- a/tests/prepare.test.mjs
+++ b/tests/prepare.test.mjs
@@ -208,6 +208,52 @@ test("prepareWorkspaceToolchain limits eager warm-up to the selected scope build
   }
 });
 
+test("prepareWorkspaceToolchain installs dependencies for every outermost package root", async () => {
+  const workspace = await tempDir("flounder-prepare-multi-package-");
+  const binDir = await tempDir("flounder-prepare-bin-");
+  const cacheDir = await tempDir("flounder-prepare-cache-");
+  const logPath = path.join(workspace, "tools.log");
+  const oldPath = process.env.PATH;
+  try {
+    for (const project of ["aqua", "swap-vm"]) {
+      const projectDir = path.join(workspace, "sources", project);
+      await mkdir(projectDir, { recursive: true });
+      await writeFile(path.join(projectDir, "package.json"), `{\"name\":\"${project}\"}\n`);
+      await writeFile(path.join(projectDir, "yarn.lock"), "# yarn lockfile v1\n");
+      await writeFile(path.join(projectDir, "foundry.toml"), "[profile.default]\nsrc = \"src\"\n");
+    }
+    await writeFakeTool(binDir, "yarn", logPath);
+    await writeFakeTool(binDir, "forge", logPath);
+    process.env.PATH = `${binDir}${path.delimiter}${oldPath ?? ""}`;
+
+    const cfg = defaultConfig();
+    cfg.sandboxBackend = "host";
+    cfg.sandboxAllowHostFallback = true;
+    cfg.auditPrepareTimeoutMs = 10_000;
+    cfg.reproductionMaxLogBytes = 4000;
+    cfg.sourcePaths = [workspace];
+
+    const report = await prepareWorkspaceToolchain({
+      workspace: { absolute: workspace, relative: "workspace" },
+      cfg,
+      logger: logger(),
+      cacheDir,
+    });
+
+    assert.deepEqual(report.results.map((result) => [result.toolchain, result.command, result.cwd, result.ok]), [
+      ["yarn", "yarn install --frozen-lockfile", "sources/aqua", true],
+      ["yarn", "yarn install --frozen-lockfile", "sources/swap-vm", true],
+      ["forge", "forge build", "sources/aqua", true],
+      ["forge", "forge build", "sources/swap-vm", true],
+    ]);
+  } finally {
+    process.env.PATH = oldPath;
+    await rm(workspace, { recursive: true, force: true });
+    await rm(binDir, { recursive: true, force: true });
+    await rm(cacheDir, { recursive: true, force: true });
+  }
+});
+
 test("prepareWorkspaceToolchain does not report installer progress as an actual tool version", async () => {
   const workspace = await tempDir("flounder-prepare-version-progress-");
   const binDir = await tempDir("flounder-prepare-bin-");


### PR DESCRIPTION
## Summary

- install dependencies for every outermost package root in a prepared multi-project workspace
- keep package-manager selection tied to the lockfile co-located with each package root
- preserve focused-toolchain and nested-vendor filtering behavior
- add a regression fixture with two sibling Yarn + Foundry projects

## Root cause

Toolchain detection enumerated every outermost Foundry root but selected only one globally shallowest `package.json`. In a workspace containing sibling projects, only the first project's dependencies were installed before all Foundry builds ran. Later sibling builds therefore failed when imports such as `forge-std` were expected under their own `node_modules` tree.

## Impact

Prepared multi-repository and composition audits now warm each independent package before compilation, so execution confirmation remains available across sibling build roots.

## Validation

- regression test failed before the implementation change and passes afterward
- `tests/prepare.test.mjs`: 6/6 passed
- focused sibling pinned-toolchain regression passed
- TypeScript server build passed
- API catalog contract passed
- database upgrade contract passed
- mock audit passed
- public-surface scan passed

The repository-wide test command also exposed an existing Node 24.13.0 native `InternalCallbackScope` assertion in four API/daemon test files. The same crash reproduces on the unmodified checkout; no JavaScript assertion from this change remains failing.
