### PR TITLE
Count only coverage-complete audit scopes

### DIFF
--- a/src/agent/audit.ts
+++ b/src/agent/audit.ts
@@ -631,12 +631,12 @@ export async function runAudit(
     };
 
     if (concurrency > 1) {
-      // Concurrent digs are scheduled as a bounded pool; runtime target changes can
-      // only affect scopes that have not been scheduled yet in sequential mode.
-      toDig = toDig.slice(0, reportedRunScopesTarget);
       // Concurrent dig: each scope runs in its OWN isolated workspace + session +
       // differential confirmation, so parallel digs cannot corrupt each other's
       // test files, build output, or findings. A bounded pool caps simultaneous digs.
+      // Schedule in small batches until the requested number of scopes reaches
+      // coverage-complete. An incomplete attempt remains pending and must not consume
+      // one of the run's audited-scope slots.
       const workspaceRoots = cfg.buildRoot ? [cfg.buildRoot] : cfg.sourcePaths;
       const digScope = async (scope: AuditScope): Promise<{ findings: AgentFinding[]; outcomes: ScopeOutcome[]; steps: TranscriptStep[]; commandRuns: typeof session.commandRuns; scratchFiles: Array<[string, string]>; resourceRequests: ResourceRequest[] }> => {
         scope.status = "auditing"; // mark in-progress so the live UI shows which scope is being dug
@@ -681,15 +681,24 @@ export async function runAudit(
           await appendScopeOutcomes(inventoryDir, outcomes);
           recorder.scopes(scopeInventory);
           recorder.findings(unioned, logger.runDir, "dig checkpoint"); // persist this scope's findings live (content-keyed upsert)
-          recorder.runScopes(++digDone, toDig.length);
+          if (completed) digDone += 1;
+          recorder.runScopes(digDone, reportedRunScopesTarget);
           return { findings: unioned, outcomes, steps: digSteps, commandRuns: scopedRuns, scratchFiles: scopedScratchFiles, resourceRequests: digSession.resourceRequests ?? [] };
         } catch (error) {
           await resetInFlightScope(scope);
           throw error;
         }
       };
-      await logger.event("audit_dig_concurrent_start", { scopes: toDig.length, concurrency });
-      const perScope = await runWithConcurrency(toDig, concurrency, digScope);
+      await logger.event("audit_dig_concurrent_start", { scopes: toDig.length, target: reportedRunScopesTarget, concurrency });
+      const perScope: Awaited<ReturnType<typeof digScope>>[] = [];
+      let cursor = 0;
+      while (cursor < toDig.length && digDone < reportedRunScopesTarget) {
+        const remaining = reportedRunScopesTarget - digDone;
+        const batchSize = Math.min(concurrency, remaining, toDig.length - cursor);
+        const batch = toDig.slice(cursor, cursor + batchSize);
+        cursor += batchSize;
+        perScope.push(...await runWithConcurrency(batch, concurrency, digScope));
+      }
       // Merge every dig's findings, transcript steps, and command runs into the run
       // aggregates so the persisted artifacts reflect the concurrent digs, not just
       // the map phase. runWithConcurrency preserves scope order.
@@ -731,7 +740,7 @@ export async function runAudit(
           await appendScopeOutcomes(inventoryDir, outcomes);
           await checkpointFindings();
           recorder.scopes(scopeInventory);
-          digDone += 1;
+          if (completed) digDone += 1;
           const targetAfter = effectiveRunScopesTarget(digDone);
           if (targetAfter !== reportedRunScopesTarget) {
             reportedRunScopesTarget = targetAfter;

--- a/tests/agent.test.mjs
+++ b/tests/agent.test.mjs
@@ -418,6 +418,30 @@ class IncompleteOutcomeLlmClient extends OutcomeOnlySynthesisLlmClient {
   }
 }
 
+class FirstIncompleteThenCompleteOutcomeLlmClient extends OutcomeOnlySynthesisLlmClient {
+  async complete(input) {
+    if (input.system.includes("DEEP, NARROW-SCOPE audit")
+      && input.user.includes("producer-region-marker")
+      && !input.user.includes('"path":"scope_outcome.json"')) {
+      return JSON.stringify({
+        thought: "Persist the first scope's unresolved coverage handoff.",
+        tool: "write",
+        args: {
+          path: "scope_outcome.json",
+          content: JSON.stringify({
+            scope_id: "S1",
+            coverage_complete: false,
+            obligations: [{ id: "O1", statement: "the blocked edge is checked", status: "blocked" }],
+            composition_edges: [],
+            blockers: ["required local fixture is unavailable"],
+          }),
+        },
+      });
+    }
+    return super.complete(input);
+  }
+}
+
 function tarGz(files) {
   const blocks = [];
   for (const [name, contentText] of Object.entries(files)) {
@@ -2143,6 +2167,36 @@ test("incomplete dig coverage remains pending after serial and concurrent attemp
       const events = (await readFile(path.join(runDir, "events.jsonl"), "utf8")).trim().split("\n").map((line) => JSON.parse(line));
       const done = events.find((event) => event.kind === "audit_dig_done");
       assert.equal(done.coverageComplete, false, `concurrency ${concurrency}`);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("standard dig target counts coverage-complete scopes instead of attempts", async () => {
+  const dir = await tempDir();
+  try {
+    for (const concurrency of [1, 2]) {
+      const cfg = defaultConfig();
+      cfg.targetName = `complete-scope-target-${concurrency}`;
+      cfg.sourcePaths = [fixtures];
+      cfg.outputDir = path.join(dir, `runs-${concurrency}`);
+      cfg.auditDeep = true;
+      cfg.auditMaxScopes = 1;
+      cfg.auditDigSamples = 1;
+      cfg.auditDigMaxSamples = 1;
+      cfg.auditDigConcurrency = concurrency;
+      cfg.auditSynthesize = false;
+      cfg.auditChallengeDischarges = false;
+      cfg.auditRefute = false;
+
+      const { runDir, scopeCoverage } = await runAudit(cfg, { llm: new FirstIncompleteThenCompleteOutcomeLlmClient() });
+      const scopes = JSON.parse(await readFile(path.join(runDir, "audit_scopes.json"), "utf8"));
+      assert.equal(scopes.find((scope) => scope.id === "S1").status, "pending", `concurrency ${concurrency}`);
+      assert.equal(scopes.find((scope) => scope.id === "S2").status, "audited", `concurrency ${concurrency}`);
+      assert.deepEqual(scopeCoverage, { total: 2, audited: 1, pending: 1, deferred: 0 }, `concurrency ${concurrency}`);
+      const events = (await readFile(path.join(runDir, "events.jsonl"), "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+      assert.equal(events.filter((event) => event.kind === "audit_dig_done").length, 2, `concurrency ${concurrency}`);
     }
   } finally {
     await rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- count only coverage-complete DIG scopes toward the per-run audited-scope target
- keep incomplete scopes pending without consuming a Standard coverage slot
- schedule additional pending scopes in bounded concurrent batches until the audited target is reached or candidates are exhausted
- preserve explicit scope selection boundaries

## Root cause

The DIG loop incremented run_scopes_done for every finished model attempt, even when scope_outcome.json left coverage incomplete and the scope returned to pending. Concurrent mode also truncated candidates to the target before results were known. A Standard target of 30 could therefore finish with fewer than 30 audited scopes.

## Validation

- new serial and concurrent incomplete-first/complete-next regression: passed
- tests/agent.test.mjs: 92 passed
- TypeScript server and UI checks: passed
- API catalog contract: passed
- database upgrade contract: passed
- mock audit: passed
- public-surface scan: passed
- full verify: 343 passed; the same four API-oriented test files hit the pre-existing Node 24.13.0 native InternalCallbackScope assertion that also reproduces on unmodified main

## Safety

No prompt strategy, command policy, database schema, or public report surface changes.