### PR TITLE
Fix settle-only pipeline worklist loading

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -5025,7 +5025,9 @@ async function daemonPipelineWorklist(c: Ctx): Promise<void> {
   if (typeof body.jobId !== "number") return sendJson(c.res, 400, { error: "jobId is required" });
   const job = authorizedDaemonJob(c, daemon, body.jobId);
   if (!job) return;
-  if (job.status !== "running") return sendJson(c.res, 409, { error: "pipeline worklists require a running job" });
+  if (job.status !== "dispatched" && job.status !== "running") {
+    return sendJson(c.res, 409, { error: "pipeline worklists require a dispatched or running job" });
+  }
   const projectName = typeof body.project === "string" ? body.project.trim() : "";
   if (!projectName) return sendJson(c.res, 400, { error: "project is required" });
   if (projectName !== String(job.project)) return sendJson(c.res, 403, { error: "pipeline project does not match the claimed job" });

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -997,7 +997,7 @@ test("api: daemon pipeline worklist exposes verify candidates before confirm", a
       ], "synthesis");
       jobId = store.enqueueJob("pipeline-verify-worklist", { verb: "run", pipeline: true }, daemon.id);
       assert.equal(store.claimJob(daemon.id)?.id, jobId);
-      store.setJobRun(jobId, runId);
+      assert.equal(store.getJob(jobId)?.status, "dispatched", "settle-only pipelines request work before their first phase creates a run");
       suspectedId = Number(store.listFindings(created.id)[0].id);
       store.upsertFindings(created.id, runId, [
         {


### PR DESCRIPTION
## Summary
- allow an authenticated, assigned daemon to load a pipeline worklist while its claimed job is still dispatched
- preserve the existing running-job path and all daemon/job/project ownership checks
- exercise the settle-only state directly in the API regression test

## Root cause
A continue job with pipelineStart=settle skips the map/dig phase and requests its Verify worklist before any phase tracker creates a run. The claimed job is therefore dispatched, but the worklist endpoint previously accepted only running jobs and returned HTTP 409.

## Verification
- targeted pipeline worklist API regression: pass
- full API suite on Node 24.13.0: 92/92 pass
- full test suite on Node 24.13.0: 457/457 pass
- npm run check: pass
- npm run check:public: pass

Node 25.8.1 hit a native event-loop assertion before executing the full API suite; the same suite passed completely under the project runtime used by the daemon.