### PR TITLE
Compact completed audit workspaces

### DIFF
--- a/src/agent/audit.ts
+++ b/src/agent/audit.ts
@@ -14,7 +14,7 @@ import { publicPath } from "../util/paths.js";
 import { materialFingerprint, phaseInputFingerprint } from "../util/material-fingerprint.js";
 import { canonicalFindingKey } from "../util/finding-identity.js";
 import { positiveIntegerId } from "../util/ids.js";
-import { listWorkspaceFiles, normalizeRelativePath, prepareSandboxWorkspace, writeSandboxFiles, type SandboxWorkspace } from "../security/sandbox.js";
+import { compactSandboxWorkspace, listWorkspaceFiles, normalizeRelativePath, prepareSandboxWorkspace, writeSandboxFiles, type SandboxWorkspace } from "../security/sandbox.js";
 import { runDifferentialConfirmation, type DifferentialResult } from "./differential.js";
 import { runDischargeChallenge, runRefutation, type RefutationError, type RefutationVerdict } from "./refutation.js";
 import { runAuditLoop } from "./loop.js";
@@ -385,11 +385,13 @@ export async function runAudit(
       await logger.event("audit_verify_done", { index: idx + 1, of: toVerify.length, claim: claimLabel, produced: verifySession.findings.length, stoppedReason: phase.stoppedReason });
       const commandIdPrefix = `${verifyLabel}:`;
       for (const produced of verifySession.findings) if (produced.commandRunId) produced.commandRunId = `${commandIdPrefix}${produced.commandRunId}`;
+      const scratchFiles = [...verifySession.scratchFiles.entries()].map(([scratchPath, content]) => [`${verifyLabel}/${scratchPath}`, content] as [string, string]);
+      await compactCompletedAuditWorkspace(verifyWorkspace, verifySession, logger, "verify", verifyLabel);
       return {
         findings: verifySession.findings,
         steps: phase.steps,
         commandRuns: verifySession.commandRuns.map((run) => ({ ...run, id: `${commandIdPrefix}${run.id}` })),
-        scratchFiles: [...verifySession.scratchFiles.entries()].map(([scratchPath, content]) => [`${verifyLabel}/${scratchPath}`, content]),
+        scratchFiles,
       };
     };
     const verifyResults = await runWithConcurrency(toVerify, Math.max(1, Math.floor(cfg.auditVerifyConcurrency)), (finding, idx) => verifyOne(finding as Record<string, unknown>, idx));
@@ -683,6 +685,7 @@ export async function runAudit(
           recorder.findings(unioned, logger.runDir, "dig checkpoint"); // persist this scope's findings live (content-keyed upsert)
           if (completed) digDone += 1;
           recorder.runScopes(digDone, reportedRunScopesTarget);
+          await compactCompletedAuditWorkspace(ws, digSession, logger, "dig", scope.id);
           return { findings: unioned, outcomes, steps: digSteps, commandRuns: scopedRuns, scratchFiles: scopedScratchFiles, resourceRequests: digSession.resourceRequests ?? [] };
         } catch (error) {
           await resetInFlightScope(scope);
@@ -1775,6 +1778,26 @@ async function copyCorpusIntoWorkspace(workspace: SandboxWorkspace, corpus: Doc[
   });
   await writeSandboxFiles(workspace.absolute, files);
   return files.map((file) => file.path);
+}
+
+async function compactCompletedAuditWorkspace(
+  workspace: SandboxWorkspace,
+  auditSession: Pick<AgentSession, "baselineFiles" | "scratchFiles">,
+  logger: RunLogger,
+  phase: "verify" | "dig",
+  label: string,
+): Promise<void> {
+  if (!auditSession.baselineFiles) return;
+  try {
+    const result = await compactSandboxWorkspace(workspace.absolute, auditSession.baselineFiles, auditSession.scratchFiles);
+    await logger.event("audit_workspace_compacted", { phase, label, ...result });
+  } catch (error) {
+    await logger.event("audit_workspace_compaction_failed", {
+      phase,
+      label,
+      errorCode: (error as NodeJS.ErrnoException).code ?? "unknown",
+    });
+  }
 }
 
 function historyLocation(cfg: AuditorConfig): { outputDir: string; targetName: string; historyDir?: string } {

--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -16,6 +16,11 @@ export interface SandboxWorkspace {
   relative: string;
 }
 
+export interface SandboxWorkspaceCompactionResult {
+  removedDirectories: number;
+  restoredScratchFiles: number;
+}
+
 export const SANDBOX_BACKENDS = ["auto", "oci", "apple-container", "host"] as const;
 export type SandboxBackend = typeof SANDBOX_BACKENDS[number];
 export type SandboxNetworkMode = "none" | "enabled";
@@ -92,6 +97,53 @@ export async function prepareSandboxWorkspace(sourcePaths: string[], runDir: str
     }
   }
   return { absolute, relative };
+}
+
+/**
+ * Remove rebuildable dependency and compiler output from a completed isolated
+ * workspace while retaining target source and model-authored evidence. A
+ * directory that contained a pristine baseline file is never removed. Scratch
+ * files are restored after pruning so even an unusual PoC path under a build
+ * directory remains durable.
+ */
+export async function compactSandboxWorkspace(
+  workspaceAbsolute: string,
+  baselineFiles: ReadonlySet<string>,
+  scratchFiles: ReadonlyMap<string, string>,
+): Promise<SandboxWorkspaceCompactionResult> {
+  const removed: string[] = [];
+  const walk = async (absoluteDir: string, relativeDir: string): Promise<void> => {
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await readdir(absoluteDir, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const relative = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+      const absolute = path.join(absoluteDir, entry.name);
+      if (isRebuildableSandboxDirectory(entry.name) && !hasBaselineDescendant(baselineFiles, relative)) {
+        await rm(absolute, { recursive: true, force: true });
+        removed.push(relative);
+        continue;
+      }
+      await walk(absolute, relative);
+    }
+  };
+
+  await walk(workspaceAbsolute, "");
+  const filesToRestore: ReproductionFile[] = [];
+  for (const [scratchPath, content] of scratchFiles) {
+    const normalized = normalizeRelativePath(scratchPath);
+    if (!normalized) continue;
+    if (removed.some((directory) => normalized.startsWith(`${directory}/`))) {
+      filesToRestore.push({ path: normalized, content });
+    }
+  }
+  await writeSandboxFiles(workspaceAbsolute, filesToRestore);
+  return { removedDirectories: removed.length, restoredScratchFiles: filesToRestore.length };
 }
 
 /** Reject command-level policy violations (live networks, non-test runners, remote RPC). */
@@ -1010,6 +1062,51 @@ async function isDirectory(input: string): Promise<boolean> {
 
 function shouldSkipCopyName(name: string): boolean {
   return new Set([".git", ".hg", ".svn", "node_modules", "vendor", "target", "build", "dist", "coverage", "runs", "__pycache__", ".cache", ".next", ".nuxt", ".turbo"]).has(name);
+}
+
+const REBUILDABLE_SANDBOX_DIRECTORIES = new Set([
+  ".build",
+  ".cache",
+  ".gradle",
+  ".mypy_cache",
+  ".next",
+  ".nuxt",
+  ".pytest_cache",
+  ".ruff_cache",
+  ".svm",
+  ".tmp",
+  ".turbo",
+  ".venv",
+  "__pycache__",
+  "artifacts",
+  "bin",
+  "broadcast",
+  "build",
+  "cache",
+  "coverage",
+  "dist",
+  "node_modules",
+  "obj",
+  "out",
+  "runs",
+  "target",
+  "typechain-types",
+  "vendor",
+  "venv",
+  "zig-cache",
+  "zig-out",
+]);
+
+function isRebuildableSandboxDirectory(name: string): boolean {
+  return REBUILDABLE_SANDBOX_DIRECTORIES.has(name.toLowerCase());
+}
+
+function hasBaselineDescendant(baselineFiles: ReadonlySet<string>, directory: string): boolean {
+  const prefix = `${directory}/`;
+  for (const file of baselineFiles) {
+    if (file.startsWith(prefix)) return true;
+  }
+  return false;
 }
 
 function appendLimited(current: string, next: string, maxBytes: number): string {

--- a/tests/sandbox.test.mjs
+++ b/tests/sandbox.test.mjs
@@ -4,11 +4,45 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { defaultConfig, sandboxExecutionOptions, sandboxNetworkForPurpose } from "../dist/config.js";
-import { autoPrefersAppleContainer, checkSandboxReadiness, clearSandboxAvailabilityCache, runSandboxCommand, sandboxToolPath } from "../dist/security/sandbox.js";
+import { autoPrefersAppleContainer, checkSandboxReadiness, clearSandboxAvailabilityCache, compactSandboxWorkspace, runSandboxCommand, sandboxToolPath } from "../dist/security/sandbox.js";
 
 async function tempDir(prefix) {
   return mkdtemp(path.join(os.tmpdir(), prefix));
 }
+
+test("completed sandbox workspaces discard rebuildable output but retain source and scratch evidence", async () => {
+  const workspace = await tempDir("flounder-sandbox-compact-");
+  try {
+    await mkdir(path.join(workspace, "src"), { recursive: true });
+    await mkdir(path.join(workspace, "out"), { recursive: true });
+    await mkdir(path.join(workspace, "target", "debug"), { recursive: true });
+    await mkdir(path.join(workspace, "node_modules", "pkg"), { recursive: true });
+    await mkdir(path.join(workspace, "notes"), { recursive: true });
+    await writeFile(path.join(workspace, "src", "lib.rs"), "pub fn audited() {}\n");
+    await writeFile(path.join(workspace, "out", "checked-in.json"), "{}\n");
+    await writeFile(path.join(workspace, "target", "debug", "large-binary"), "rebuildable\n");
+    await writeFile(path.join(workspace, "node_modules", "pkg", "index.js"), "module.exports = {};\n");
+    await writeFile(path.join(workspace, "notes", "trace.txt"), "keep non-build output\n");
+    await writeFile(path.join(workspace, "target", "poc.rs"), "#[test] fn poc() {}\n");
+
+    const result = await compactSandboxWorkspace(
+      workspace,
+      new Set(["src/lib.rs", "out/checked-in.json"]),
+      new Map([["target/poc.rs", "#[test] fn poc() {}\n"]]),
+    );
+
+    assert.equal(result.removedDirectories, 2);
+    assert.equal(result.restoredScratchFiles, 1);
+    assert.equal(await readFile(path.join(workspace, "src", "lib.rs"), "utf8"), "pub fn audited() {}\n");
+    assert.equal(await readFile(path.join(workspace, "out", "checked-in.json"), "utf8"), "{}\n");
+    assert.equal(await readFile(path.join(workspace, "target", "poc.rs"), "utf8"), "#[test] fn poc() {}\n");
+    assert.equal(await readFile(path.join(workspace, "notes", "trace.txt"), "utf8"), "keep non-build output\n");
+    await assert.rejects(readFile(path.join(workspace, "target", "debug", "large-binary")), /ENOENT/);
+    await assert.rejects(readFile(path.join(workspace, "node_modules", "pkg", "index.js")), /ENOENT/);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
 
 function truncatedElf64() {
   const elf = Buffer.alloc(64);


### PR DESCRIPTION
Summary:
- prune rebuildable dependency and compiler output after isolated Verify and concurrent Dig workspaces finish
- preserve pristine baseline directories and restore model-authored scratch evidence after compaction
- record compaction success or failure without changing an already-persisted audit verdict

Verification:
- npm run check
- targeted sandbox compaction regression passed
- npm run check:public
- npm test: 345 tests passed; four API files hit a Node 24.13 native node:sqlite assertion that reproduces unchanged on main, so CI remains the independent full-suite gate