### PR TITLE
Fix prepared workspace and sandbox reliability

### DIFF
--- a/src/agent/acquire.ts
+++ b/src/agent/acquire.ts
@@ -148,7 +148,9 @@ export async function runPrepare(
     blockingIssues: blockingIssues.length,
   });
 
-  stagedCfg.materialFingerprint = await preparedWorkspaceMaterialFingerprint(workspace.absolute, stagedCfg.corpusPaths);
+  // The staged workspace is the complete handoff to sealed audit. Project-local
+  // corpus inputs are acquisition hints, not additional post-Prepare material.
+  stagedCfg.materialFingerprint = await preparedWorkspaceMaterialFingerprint(workspace.absolute, []);
   recorder.materialFingerprint?.(stagedCfg.materialFingerprint);
 
   const finalStatus: RunStatus = options.signal?.aborted ? "killed" : manifest !== undefined && blockingIssues.length === 0 ? "done" : "error";

--- a/src/agent/acquire.ts
+++ b/src/agent/acquire.ts
@@ -11,8 +11,7 @@ import { isPiSessionProvider, runAuditSession } from "./pi-session.js";
 import { buildTools, newSession, type AgentSession, type ToolContext } from "./tools.js";
 import { RunRecorder, type RunTrackerFactory } from "../db/record.js";
 import type { RunStatus } from "../db/store.js";
-import { loadCorpus, loadSource } from "../ingest/source.js";
-import { materialFingerprint } from "../util/material-fingerprint.js";
+import { preparedWorkspaceMaterialFingerprint } from "../util/prepared-material-fingerprint.js";
 
 // `flounder prepare` — the open-world ACQUISITION phase that runs BEFORE map. Given a clue
 // (a tx, an address, a project, a package, a repo, a link), it resolves the complete dependency
@@ -160,16 +159,6 @@ export async function runPrepare(
   }
 
   return { runDir: logger.runDir, workspaceDir: workspace.absolute, manifest: manifest ?? null, validation };
-}
-
-export async function preparedWorkspaceMaterialFingerprint(workspaceDir: string, corpusPaths: string[]): Promise<string> {
-  const preparedSource = await loadSource([workspaceDir], { publicRoot: workspaceDir });
-  const preparedCorpus = corpusPaths.length > 0 ? await loadCorpus(corpusPaths) : [];
-  return materialFingerprint([
-    { label: "source", docs: preparedSource },
-    { label: "build", docs: preparedSource },
-    { label: "corpus", docs: preparedCorpus },
-  ]);
 }
 
 export function prepareValidationBlockingIssues(validation: PrepareValidation): string[] {

--- a/src/agent/acquire.ts
+++ b/src/agent/acquire.ts
@@ -149,13 +149,7 @@ export async function runPrepare(
     blockingIssues: blockingIssues.length,
   });
 
-  const preparedSource = await loadSource([workspace.absolute]);
-  const preparedCorpus = stagedCfg.corpusPaths.length > 0 ? await loadCorpus(stagedCfg.corpusPaths) : [];
-  stagedCfg.materialFingerprint = materialFingerprint([
-    { label: "source", docs: preparedSource },
-    { label: "build", docs: preparedSource },
-    { label: "corpus", docs: preparedCorpus },
-  ]);
+  stagedCfg.materialFingerprint = await preparedWorkspaceMaterialFingerprint(workspace.absolute, stagedCfg.corpusPaths);
   recorder.materialFingerprint?.(stagedCfg.materialFingerprint);
 
   const finalStatus: RunStatus = options.signal?.aborted ? "killed" : manifest !== undefined && blockingIssues.length === 0 ? "done" : "error";
@@ -166,6 +160,16 @@ export async function runPrepare(
   }
 
   return { runDir: logger.runDir, workspaceDir: workspace.absolute, manifest: manifest ?? null, validation };
+}
+
+export async function preparedWorkspaceMaterialFingerprint(workspaceDir: string, corpusPaths: string[]): Promise<string> {
+  const preparedSource = await loadSource([workspaceDir], { publicRoot: workspaceDir });
+  const preparedCorpus = corpusPaths.length > 0 ? await loadCorpus(corpusPaths) : [];
+  return materialFingerprint([
+    { label: "source", docs: preparedSource },
+    { label: "build", docs: preparedSource },
+    { label: "corpus", docs: preparedCorpus },
+  ]);
 }
 
 export function prepareValidationBlockingIssues(validation: PrepareValidation): string[] {

--- a/src/agent/audit.ts
+++ b/src/agent/audit.ts
@@ -463,14 +463,27 @@ export async function runAudit(
     // incomplete. Requeue generally from durable evidence, never a local id list.
     const latestOutcomesByScope = new Map(latestScopeOutcomes(scopeOutcomes).map((outcome) => [outcome.scopeId, outcome]));
     const requeuedIncompleteScopes: string[] = [];
+    const reconciledCompletedScopes: string[] = [];
     for (const scope of scopeInventory) {
       const outcome = latestOutcomesByScope.get(scope.id);
-      if (scope.status !== "audited" || !outcome || !scopeOutcomeNeedsCoverage(outcome)) continue;
-      scope.status = "pending";
-      requeuedIncompleteScopes.push(scope.id);
+      if (!outcome) continue;
+      const needsCoverage = scopeOutcomeNeedsCoverage(outcome);
+      if (scope.status === "audited" && needsCoverage) {
+        scope.status = "pending";
+        requeuedIncompleteScopes.push(scope.id);
+      } else if (scope.status === "pending" && !needsCoverage) {
+        // Releases that treated unresolved composition leads as incomplete left
+        // fully handed-off scopes pending. Repair those checkpoints from the
+        // durable outcome so resume advances instead of repeating the same DIG.
+        scope.status = "audited";
+        reconciledCompletedScopes.push(scope.id);
+      }
     }
     if (requeuedIncompleteScopes.length > 0) {
       await logger.event("audit_scope_coverage_requeued", { scopes: requeuedIncompleteScopes });
+    }
+    if (reconciledCompletedScopes.length > 0) {
+      await logger.event("audit_scope_coverage_reconciled", { scopes: reconciledCompletedScopes });
     }
     if (!resuming && !cfg.auditAppendMap) {
       await clearCurrentMaterialScopeOutcomes(inventoryDir, cfg.materialFingerprint);

--- a/src/agent/scope-outcomes.ts
+++ b/src/agent/scope-outcomes.ts
@@ -152,11 +152,15 @@ export function nextScopeOutcomeSample(outcomes: ScopeOutcome[], scopeId: string
     .reduce((maximum, outcome) => Math.max(maximum, outcome.sample), 0) + 1;
 }
 
+/** Region coverage is incomplete only when the model says so or leaves an
+ * uncertain/blocked obligation. An unresolved composition edge remains useful
+ * input for adaptive sampling and synthesis, but may itself be the already
+ * established missing binding behind a finding; it must not force the same
+ * completed region to be re-audited forever. */
 export function scopeOutcomeNeedsCoverage(outcome: ScopeOutcome): boolean {
   return !outcome.coverageComplete
     || outcome.blockers.length > 0
-    || outcome.obligations.some((obligation) => obligation.status === "uncertain" || obligation.status === "blocked")
-    || outcome.compositionEdges.some((edge) => edge.status === "unresolved");
+    || outcome.obligations.some((obligation) => obligation.status === "uncertain" || obligation.status === "blocked");
 }
 
 export function mergeScopeOutcomes(existing: ScopeOutcome[], additions: ScopeOutcome[]): ScopeOutcome[] {

--- a/src/security/policy.ts
+++ b/src/security/policy.ts
@@ -678,7 +678,11 @@ function isAllowedBuildCommand(program: string, args: string[]): boolean {
       (second === "pip" && lower[2] === "install")
     );
   }
-  if (name === "forge") return ["build", "install", "compile", "update"].includes(first ?? "");
+  // `forge inspect` is compiler-backed, read-only introspection (for example,
+  // storage-layout or ABI output). Treat it like a build command so sealed
+  // audits run it against the prepared build workspace with dependencies
+  // available, while it remains ineligible for executable confirmation.
+  if (name === "forge") return ["build", "install", "compile", "update", "inspect"].includes(first ?? "");
   if (name === "cmake") return isAllowedCmakeBuild(args);
   if (name === "ninja") return true;
   if (name === "make" || name === "gmake") return true;

--- a/src/security/policy.ts
+++ b/src/security/policy.ts
@@ -669,7 +669,10 @@ function isAllowedBuildCommand(program: string, args: string[]): boolean {
   if (name === "cargo") return ["build", "fetch", "check", "generate-lockfile", "vendor", "update"].includes(cargoSubcommand(args) ?? "");
   if (name === "go") return first === "build" || first === "mod"; // go build / go mod download|tidy|vendor
   if (name === "npm") return ["install", "ci", "i"].includes(first ?? "");
-  if (name === "pnpm" || name === "yarn" || name === "bun") return ["install", "i", "ci"].includes(first ?? "") || (name === "yarn" && args.length === 0) || (first === "blueprint" && second === "build");
+  if (name === "pnpm" || name === "yarn" || name === "bun") return ["install", "i", "ci"].includes(first ?? "")
+    || (name === "yarn" && args.length === 0)
+    || (first === "hardhat" && second === "compile")
+    || (first === "blueprint" && second === "build");
   if (name === "pip" || name === "pip3") return first === "install";
   if (name === "python" || name === "python3") {
     return first === "-m" && (

--- a/src/security/policy.ts
+++ b/src/security/policy.ts
@@ -671,7 +671,7 @@ function isAllowedBuildCommand(program: string, args: string[]): boolean {
   if (name === "npm") return ["install", "ci", "i"].includes(first ?? "");
   if (name === "pnpm" || name === "yarn" || name === "bun") return ["install", "i", "ci"].includes(first ?? "")
     || (name === "yarn" && args.length === 0)
-    || (first === "hardhat" && second === "compile")
+    || (first === "hardhat" && (second === "compile" || second === "typechain"))
     || (first === "blueprint" && second === "build");
   if (name === "pip" || name === "pip3") return first === "install";
   if (name === "python" || name === "python3") {
@@ -696,7 +696,7 @@ function isAllowedBuildCommand(program: string, args: string[]): boolean {
   if (name === "scarb") return ["build", "fetch", "check", "metadata"].includes(scarbSubcommand(args) ?? "");
   if (name === "blueprint") return first === "build";
   if (name === "func-js" || name === "tolk-js" || name === "tact") return args.length > 0 && !isToolInfoArgs(args);
-  if (name === "npx") return (first === "hardhat" && second === "compile") || (first === "blueprint" && second === "build");
+  if (name === "npx") return (first === "hardhat" && (second === "compile" || second === "typechain")) || (first === "blueprint" && second === "build");
   return false;
 }
 

--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -1258,6 +1258,7 @@ function sandboxEnv(workspace: string, tmpDir: string, cacheDir?: string, comman
     GOCACHE: path.join(pkgCache, "go-build-cache"),
     GOMODCACHE: path.join(pkgCache, "go-mod-cache"),
     NPM_CONFIG_CACHE: path.join(pkgCache, "npm-cache"),
+    YARN_GLOBAL_FOLDER: path.join(pkgCache, "yarn-berry"),
   };
   out.PATH = sandboxToolPath(process.env.PATH);
   if (network === "enabled") {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2442,19 +2442,19 @@ async function runLaunch(c: Ctx): Promise<void> {
     || stringValue(materialBoundary?.material_fingerprint);
   if (currentMaterialFingerprint) spec.materialFingerprint = currentMaterialFingerprint;
   if (spec.verb === "run") {
-    if (spec.sourcePaths.length > 0) {
+    const prepared = latestPreparedWorkspace(runs);
+    if (prepared && !runBodyHasMaterialOverride(body)) {
+      applyProjectPrepareDefaults(spec, project, runs);
+      spec.pipeline = true;
+      applyPreparedWorkspaceToSpec(spec, prepared);
+    } else if (spec.sourcePaths.length > 0) {
       applyProjectSourceDefaults(spec, project);
       if (!spec.pipeline) spec.pipeline = false;
     } else {
       applyProjectPrepareDefaults(spec, project, runs);
       spec.pipeline = true;
-      const prepared = latestPreparedWorkspace(runs);
       if (prepared) {
-        spec.dir = undefined;
-        spec.sourcePaths = [prepared.workspaceDir];
-        spec.buildRoot = prepared.workspaceDir;
-        spec.clue = undefined;
-        if (!spec.scopeNote && prepared.scopeNote) spec.scopeNote = prepared.scopeNote;
+        applyPreparedWorkspaceToSpec(spec, prepared);
       } else if (spec.clue && spec.sourcePaths.length === 0) {
         resetPipelineCoverageForUnknownInventory(spec);
       }
@@ -2688,6 +2688,11 @@ function runBodyHasConfigOverride(body: Record<string, unknown>, key: string): b
   const overrides = objectValue(body.overrides);
   const config = objectValue(overrides?.config);
   return config?.[key] !== undefined;
+}
+
+function runBodyHasMaterialOverride(body: Record<string, unknown>): boolean {
+  const overrides = objectValue(body.overrides);
+  return overrides?.sourcePaths !== undefined || overrides?.buildRoot !== undefined || overrides?.corpusPaths !== undefined;
 }
 
 function resumeInterruptedCoverageBatch(spec: LaunchSpec, progress: Coverage, runs: Array<Record<string, unknown>>): void {
@@ -3261,11 +3266,17 @@ function applyPreparedWorkspaceIfNeeded(spec: LaunchSpec, runs: Array<Record<str
         : "this project has no source paths and no prepared workspace yet. Run Prepare first, or configure source paths.",
     };
   }
+  applyPreparedWorkspaceToSpec(spec, prepared);
+  return { ok: true };
+}
+
+function applyPreparedWorkspaceToSpec(spec: LaunchSpec, prepared: { workspaceDir: string; manifestPath: string; scopeNote?: string }): void {
   spec.dir = undefined;
   spec.sourcePaths = [prepared.workspaceDir];
   spec.buildRoot = prepared.workspaceDir;
+  spec.corpusPaths = [];
+  spec.clue = undefined;
   if (!spec.scopeNote && prepared.scopeNote) spec.scopeNote = prepared.scopeNote;
-  return { ok: true };
 }
 
 function latestPreparedWorkspace(runs: Array<Record<string, unknown>>): { workspaceDir: string; manifestPath: string; scopeNote?: string } | undefined {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -29,6 +29,7 @@ import { loadScopeInventory, saveScopeInventory } from "../agent/scope-store.js"
 import { deriveScopeNote } from "../scope-note.js";
 import { confirmSelectorsForFinding } from "../util/confirm-selector.js";
 import { phaseInputFingerprint } from "../util/material-fingerprint.js";
+import { reconcileLegacyPreparedMaterialFingerprints } from "../util/prepared-material-fingerprint.js";
 import { isResumeSettledDecision, isSubmissionReadyDecision, needsSubmissionReadinessWork } from "../util/submission-readiness.js";
 import { isSandboxBackend, type SandboxBackend } from "../security/sandbox.js";
 import { normalizeRunGroupManifest, normalizeWorkItemInput } from "../evaluation/contracts.js";
@@ -750,6 +751,21 @@ export function startUiServer(options: UiServerOptions = {}): ReturnType<typeof 
   ]);
   const artifactReconciled = reconcileSuccessfulArtifactRuns(store);
   if (artifactReconciled > 0) console.log(`[flounder ui] reconciled ${artifactReconciled} completed run artifact${artifactReconciled === 1 ? "" : "s"}`);
+  const materialFingerprintMigration = reconcileLegacyPreparedMaterialFingerprints(
+    store.listRuns(),
+    (runId, expected, replacement) => {
+      const current = store.getRun(runId);
+      if (stringValue(current?.material_fingerprint) !== expected) return false;
+      store.updateRunMaterialFingerprint(runId, replacement);
+      return true;
+    },
+  ).then((changed) => {
+    if (changed > 0) console.log(`[flounder ui] repaired ${changed} legacy prepared-material fingerprint${changed === 1 ? "" : "s"}`);
+    return changed;
+  }).catch((error) => {
+    console.warn(`[flounder ui] prepared-material fingerprint repair skipped: ${String(error instanceof Error ? error.message : error)}`);
+    return 0;
+  });
   const plane = new ControlPlane();
   reconcileTerminalRunGroupItems(store, plane);
   for (const group of store.listRunGroups(10_000, 0)) {
@@ -779,6 +795,7 @@ export function startUiServer(options: UiServerOptions = {}): ReturnType<typeof 
       // .then(run) (not Promise.resolve(run())) so a SYNCHRONOUS throw in a handler becomes a
       // rejection we can turn into a 500 — never an uncaught exception that kills the server.
       Promise.resolve()
+        .then(() => materialFingerprintMigration)
         .then(() => r.handler({ req, res, params, url, store, plane, out, maintainerMode }))
         .catch((error) => {
           if (!res.headersSent) sendJson(res, 500, { error: String(error instanceof Error ? error.message : error) });

--- a/src/util/prepared-material-fingerprint.ts
+++ b/src/util/prepared-material-fingerprint.ts
@@ -19,11 +19,6 @@ export async function preparedWorkspaceMaterialFingerprint(workspaceDir: string,
   return workspaceFingerprint(preparedSource, preparedCorpus);
 }
 
-async function legacyPreparedWorkspaceMaterialFingerprint(workspaceDir: string): Promise<string> {
-  const preparedSource = await loadSource([workspaceDir]);
-  return workspaceFingerprint(preparedSource, []);
-}
-
 export async function reconcileLegacyPreparedMaterialFingerprints(
   runs: PreparedMaterialRunRow[],
   replace: (runId: number, expected: string, replacement: string) => boolean,
@@ -36,20 +31,16 @@ export async function reconcileLegacyPreparedMaterialFingerprints(
     const storedFingerprint = stringValue(prepare.material_fingerprint);
     const prepareStartedAt = stringValue(prepare.started_at);
     if (!Number.isFinite(prepareId) || !Number.isFinite(projectId) || prepare.kind !== "prepare" || prepare.status !== "done" || !runDir || !storedFingerprint) continue;
-    const hasDifferentLaterResult = runs.some((run) => Number(run.project_id) === projectId
-      && run.kind !== "prepare"
-      && Boolean(stringValue(run.material_fingerprint))
-      && stringValue(run.material_fingerprint) !== storedFingerprint
-      && Boolean(stringValue(run.started_at) && prepareStartedAt && stringValue(run.started_at) >= prepareStartedAt));
-    if (!hasDifferentLaterResult) continue;
-
     const workspaceDir = path.join(path.resolve(runDir), "prepare", "workspace");
     if (!existsSync(workspaceDir)) continue;
-    const legacy = await legacyPreparedWorkspaceMaterialFingerprint(workspaceDir);
-    if (legacy !== storedFingerprint) continue;
     const canonical = await preparedWorkspaceMaterialFingerprint(workspaceDir, []);
-    if (canonical === legacy) continue;
-    if (replace(prepareId, legacy, canonical)) changed += 1;
+    if (canonical === storedFingerprint) continue;
+    const hasCanonicalLaterResult = runs.some((run) => Number(run.project_id) === projectId
+      && run.kind !== "prepare"
+      && stringValue(run.material_fingerprint) === canonical
+      && Boolean(stringValue(run.started_at) && prepareStartedAt && stringValue(run.started_at) >= prepareStartedAt));
+    if (!hasCanonicalLaterResult) continue;
+    if (replace(prepareId, storedFingerprint, canonical)) changed += 1;
   }
   return changed;
 }

--- a/src/util/prepared-material-fingerprint.ts
+++ b/src/util/prepared-material-fingerprint.ts
@@ -1,0 +1,67 @@
+import path from "node:path";
+import { existsSync } from "node:fs";
+import { loadCorpus, loadSource } from "../ingest/source.js";
+import { materialFingerprint } from "./material-fingerprint.js";
+
+export interface PreparedMaterialRunRow extends Record<string, unknown> {
+  id?: unknown;
+  project_id?: unknown;
+  kind?: unknown;
+  status?: unknown;
+  run_dir?: unknown;
+  material_fingerprint?: unknown;
+  started_at?: unknown;
+}
+
+export async function preparedWorkspaceMaterialFingerprint(workspaceDir: string, corpusPaths: string[]): Promise<string> {
+  const preparedSource = await loadSource([workspaceDir], { publicRoot: workspaceDir });
+  const preparedCorpus = corpusPaths.length > 0 ? await loadCorpus(corpusPaths) : [];
+  return workspaceFingerprint(preparedSource, preparedCorpus);
+}
+
+async function legacyPreparedWorkspaceMaterialFingerprint(workspaceDir: string): Promise<string> {
+  const preparedSource = await loadSource([workspaceDir]);
+  return workspaceFingerprint(preparedSource, []);
+}
+
+export async function reconcileLegacyPreparedMaterialFingerprints(
+  runs: PreparedMaterialRunRow[],
+  replace: (runId: number, expected: string, replacement: string) => boolean,
+): Promise<number> {
+  let changed = 0;
+  for (const prepare of runs) {
+    const prepareId = Number(prepare.id);
+    const projectId = Number(prepare.project_id);
+    const runDir = stringValue(prepare.run_dir);
+    const storedFingerprint = stringValue(prepare.material_fingerprint);
+    const prepareStartedAt = stringValue(prepare.started_at);
+    if (!Number.isFinite(prepareId) || !Number.isFinite(projectId) || prepare.kind !== "prepare" || prepare.status !== "done" || !runDir || !storedFingerprint) continue;
+    const hasDifferentLaterResult = runs.some((run) => Number(run.project_id) === projectId
+      && run.kind !== "prepare"
+      && Boolean(stringValue(run.material_fingerprint))
+      && stringValue(run.material_fingerprint) !== storedFingerprint
+      && Boolean(stringValue(run.started_at) && prepareStartedAt && stringValue(run.started_at) >= prepareStartedAt));
+    if (!hasDifferentLaterResult) continue;
+
+    const workspaceDir = path.join(path.resolve(runDir), "prepare", "workspace");
+    if (!existsSync(workspaceDir)) continue;
+    const legacy = await legacyPreparedWorkspaceMaterialFingerprint(workspaceDir);
+    if (legacy !== storedFingerprint) continue;
+    const canonical = await preparedWorkspaceMaterialFingerprint(workspaceDir, []);
+    if (canonical === legacy) continue;
+    if (replace(prepareId, legacy, canonical)) changed += 1;
+  }
+  return changed;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function workspaceFingerprint(source: Awaited<ReturnType<typeof loadSource>>, corpus: Awaited<ReturnType<typeof loadCorpus>>): string {
+  return materialFingerprint([
+    { label: "source", docs: source },
+    { label: "build", docs: source },
+    { label: "corpus", docs: corpus },
+  ]);
+}

--- a/tests/agent.test.mjs
+++ b/tests/agent.test.mjs
@@ -2237,6 +2237,40 @@ test("resuming requeues legacy audited scopes whose durable outcome is incomplet
   }
 });
 
+test("resuming reconciles complete durable outcomes that a legacy release left pending", async () => {
+  const dir = await tempDir();
+  try {
+    const cfg = defaultConfig();
+    cfg.targetName = "legacy-complete-coverage";
+    cfg.sourcePaths = [fixtures];
+    cfg.outputDir = path.join(dir, "runs");
+    cfg.auditDeep = true;
+    cfg.auditMaxScopes = 1;
+    cfg.auditDigSamples = 1;
+    cfg.auditDigMaxSamples = 1;
+    cfg.auditSynthesize = false;
+    cfg.auditChallengeDischarges = false;
+    cfg.auditRefute = false;
+
+    await runAudit(cfg, { llm: new OutcomeOnlySynthesisLlmClient() });
+    const historyDir = path.join(cfg.outputDir, "history", cfg.targetName);
+    const scopesPath = path.join(historyDir, "scopes.json");
+    const legacyScopes = JSON.parse(await readFile(scopesPath, "utf8"));
+    legacyScopes.find((scope) => scope.id === "S1").status = "pending";
+    await writeFile(scopesPath, JSON.stringify(legacyScopes), "utf8");
+
+    cfg.auditMaxScopes = 0;
+    const { runDir, scopeCoverage } = await runAudit(cfg, { llm: new OutcomeOnlySynthesisLlmClient() });
+    assert.deepEqual(scopeCoverage, { total: 2, audited: 1, pending: 1, deferred: 0 });
+    const repairedScopes = JSON.parse(await readFile(scopesPath, "utf8"));
+    assert.equal(repairedScopes.find((scope) => scope.id === "S1").status, "audited");
+    const events = (await readFile(path.join(runDir, "events.jsonl"), "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+    assert.deepEqual(events.find((event) => event.kind === "audit_scope_coverage_reconciled")?.scopes, ["S1"]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("pinned region audits persist the same scope outcome contract", async () => {
   const dir = await tempDir();
   try {

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -320,6 +320,71 @@ test("api: project run defaults leave map/dig turns unbounded and use standard s
   });
 });
 
+test("api: project run prefers the current prepared workspace over stored source paths", async () => {
+  await withServer(async (base, out) => {
+    const json = (r) => r.json();
+    const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    const created = await json(await post("/api/projects", {
+      name: "prepared-material-over-source-config",
+      sourcePaths: ["./contracts"],
+      buildRoot: ".",
+      corpusPaths: ["README.md"],
+      config: { prepareClue: "official deployed source and docs" },
+    }));
+    const runDir = path.join(out, "prepared-material-over-source-config-prepare");
+    const workspace = path.join(runDir, "prepare", "workspace");
+    await mkdir(path.join(workspace, "contracts"), { recursive: true });
+    await writeFile(path.join(workspace, "contracts", "Target.sol"), "contract Target {}\n");
+    await writeFile(
+      path.join(workspace, "prepare_manifest.json"),
+      JSON.stringify({
+        clue: "official deployed source and docs",
+        posture: "blind",
+        scope_declaration: "Prepared source snapshot only.",
+        real_target: {
+          requires_confirmation: false,
+          mode: "source-only",
+          ground_truth: [],
+          confirm_guidance: { required: false, not_required_reason: "source-only fixture" },
+        },
+        components: [],
+      }),
+    );
+
+    const store = MetadataStore.openForOutput(out);
+    try {
+      const prepareRun = store.startRun({ projectId: created.id, kind: "prepare", runDir, provider: "openai-codex", model: "gpt-5.5" });
+      store.finishRun(prepareRun, "done");
+    } finally {
+      store.close();
+    }
+
+    const launched = await json(await post(`/api/projects/${created.uuid}/runs`, { verb: "run" }));
+    assert.equal(launched.queued, true);
+    const job = (await json(await fetch(base + "/api/jobs/" + launched.jobId))).job;
+    const spec = JSON.parse(job.spec_json);
+
+    assert.equal(spec.pipeline, true);
+    assert.equal(spec.dir, undefined);
+    assert.deepEqual(spec.sourcePaths, [workspace]);
+    assert.equal(spec.buildRoot, workspace);
+    assert.deepEqual(spec.corpusPaths, []);
+    assert.equal(spec.clue, undefined);
+
+    const explicit = await json(await post(`/api/projects/${created.uuid}/runs`, {
+      verb: "run",
+      overrides: { sourcePaths: ["./explicit"], buildRoot: "./explicit", corpusPaths: ["docs.md"] },
+    }));
+    assert.equal(explicit.queued, true);
+    const explicitJob = (await json(await fetch(base + "/api/jobs/" + explicit.jobId))).job;
+    const explicitSpec = JSON.parse(explicitJob.spec_json);
+    assert.equal(explicitSpec.pipeline, false);
+    assert.deepEqual(explicitSpec.sourcePaths, ["./explicit"]);
+    assert.equal(explicitSpec.buildRoot, "./explicit");
+    assert.deepEqual(explicitSpec.corpusPaths, ["docs.md"]);
+  });
+});
+
 test("api: explicit standard coverage leaves map/dig turns unbounded while capping the batch", async () => {
   await withServer(async (base) => {
     const json = (r) => r.json();

--- a/tests/coverage-loop.test.mjs
+++ b/tests/coverage-loop.test.mjs
@@ -14,6 +14,7 @@ import {
   nextScopeOutcomeSample,
   readScratchScopeOutcome,
   scopeOutcomeNeedsAnotherSample,
+  scopeOutcomeNeedsCoverage,
 } from "../dist/agent/scope-outcomes.js";
 import { newSession } from "../dist/agent/tools.js";
 
@@ -85,6 +86,24 @@ test("scope outcome separates coverage evidence from findings and fails closed o
   assert.equal(blocked.outcome.coverageComplete, false);
   assert.match(blocked.errors.join(" "), /cannot be true while blockers remain/);
   assert.equal(scopeOutcomeNeedsAnotherSample([blocked.outcome]), false, "sampling cannot repair an external resource blocker");
+});
+
+test("resolved region coverage does not stay pending only because synthesis has unresolved edges", () => {
+  const outcome = {
+    scopeId: "S1",
+    sample: 1,
+    coverageComplete: true,
+    obligations: [
+      { id: "O1", statement: "the missing binding is established", status: "unmet", evidence: "confirmed by cmd1" },
+    ],
+    compositionEdges: [
+      { id: "E1", kind: "binding", description: "the input reaches the sink without the required binding", status: "unresolved", from: "input", to: "sink" },
+    ],
+    blockers: [],
+  };
+
+  assert.equal(scopeOutcomeNeedsAnotherSample([outcome]), true, "an adaptive sample may still investigate the unresolved edge");
+  assert.equal(scopeOutcomeNeedsCoverage(outcome), false, "the persisted region handoff is complete even though synthesis still has a lead");
 });
 
 test("invalid composition status cannot be normalized into observed evidence", () => {

--- a/tests/material-fingerprint.test.mjs
+++ b/tests/material-fingerprint.test.mjs
@@ -60,7 +60,7 @@ test("prepare and audit fingerprint the same staged workspace identically", asyn
   }
 });
 
-test("legacy prepared workspace fingerprints are backfilled only after exact verification", async () => {
+test("prepared workspace fingerprints are backfilled only after an exact canonical result", async () => {
   const runDir = await mkdtemp(path.join(os.tmpdir(), "flounder-legacy-prepare-run-"));
   const workspace = path.join(runDir, "prepare", "workspace");
   try {
@@ -78,8 +78,10 @@ test("legacy prepared workspace fingerprints are backfilled only after exact ver
     const runs = [
       { id: 1, project_id: 7, kind: "prepare", status: "done", run_dir: runDir, material_fingerprint: legacyFingerprint, started_at: "2026-01-01T00:00:00.000Z" },
       { id: 2, project_id: 7, kind: "run", status: "done", run_dir: path.join(runDir, "audit"), material_fingerprint: canonicalFingerprint, started_at: "2026-01-01T00:01:00.000Z" },
-      { id: 3, project_id: 8, kind: "prepare", status: "done", run_dir: runDir, material_fingerprint: "sha256:not-legacy", started_at: "2026-01-01T00:00:00.000Z" },
+      { id: 3, project_id: 8, kind: "prepare", status: "done", run_dir: runDir, material_fingerprint: "sha256:included-external-corpus", started_at: "2026-01-01T00:00:00.000Z" },
       { id: 4, project_id: 8, kind: "run", status: "done", run_dir: path.join(runDir, "other"), material_fingerprint: canonicalFingerprint, started_at: "2026-01-01T00:01:00.000Z" },
+      { id: 5, project_id: 9, kind: "prepare", status: "done", run_dir: runDir, material_fingerprint: "sha256:unverified", started_at: "2026-01-01T00:00:00.000Z" },
+      { id: 6, project_id: 9, kind: "run", status: "done", run_dir: path.join(runDir, "unrelated"), material_fingerprint: "sha256:different", started_at: "2026-01-01T00:01:00.000Z" },
     ];
     const replacements = [];
     const changed = await reconcileLegacyPreparedMaterialFingerprints(runs, (runId, expected, replacement) => {
@@ -87,8 +89,11 @@ test("legacy prepared workspace fingerprints are backfilled only after exact ver
       return true;
     });
 
-    assert.equal(changed, 1);
-    assert.deepEqual(replacements, [{ runId: 1, expected: legacyFingerprint, replacement: canonicalFingerprint }]);
+    assert.equal(changed, 2);
+    assert.deepEqual(replacements, [
+      { runId: 1, expected: legacyFingerprint, replacement: canonicalFingerprint },
+      { runId: 3, expected: "sha256:included-external-corpus", replacement: canonicalFingerprint },
+    ]);
   } finally {
     await rm(runDir, { recursive: true, force: true });
   }

--- a/tests/material-fingerprint.test.mjs
+++ b/tests/material-fingerprint.test.mjs
@@ -3,9 +3,9 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { preparedWorkspaceMaterialFingerprint } from "../dist/agent/acquire.js";
 import { loadSource } from "../dist/ingest/source.js";
 import { materialFingerprint, phaseInputFingerprint } from "../dist/util/material-fingerprint.js";
+import { preparedWorkspaceMaterialFingerprint, reconcileLegacyPreparedMaterialFingerprints } from "../dist/util/prepared-material-fingerprint.js";
 
 test("material fingerprints are traversal-order independent but content and namespace sensitive", () => {
   const sourceA = { path: "src/a.ts", kind: "source", content: "export const a = 1;" };
@@ -57,5 +57,39 @@ test("prepare and audit fingerprint the same staged workspace identically", asyn
     assert.equal(prepareFingerprint, auditFingerprint);
   } finally {
     await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("legacy prepared workspace fingerprints are backfilled only after exact verification", async () => {
+  const runDir = await mkdtemp(path.join(os.tmpdir(), "flounder-legacy-prepare-run-"));
+  const workspace = path.join(runDir, "prepare", "workspace");
+  try {
+    await mkdir(path.join(workspace, "src"), { recursive: true });
+    await writeFile(path.join(workspace, "src", "Target.sol"), "contract Target {}\n");
+    const legacySource = await loadSource([workspace]);
+    const legacyFingerprint = materialFingerprint([
+      { label: "source", docs: legacySource },
+      { label: "build", docs: legacySource },
+      { label: "corpus", docs: [] },
+    ]);
+    const canonicalFingerprint = await preparedWorkspaceMaterialFingerprint(workspace, []);
+    assert.notEqual(legacyFingerprint, canonicalFingerprint);
+
+    const runs = [
+      { id: 1, project_id: 7, kind: "prepare", status: "done", run_dir: runDir, material_fingerprint: legacyFingerprint, started_at: "2026-01-01T00:00:00.000Z" },
+      { id: 2, project_id: 7, kind: "run", status: "done", run_dir: path.join(runDir, "audit"), material_fingerprint: canonicalFingerprint, started_at: "2026-01-01T00:01:00.000Z" },
+      { id: 3, project_id: 8, kind: "prepare", status: "done", run_dir: runDir, material_fingerprint: "sha256:not-legacy", started_at: "2026-01-01T00:00:00.000Z" },
+      { id: 4, project_id: 8, kind: "run", status: "done", run_dir: path.join(runDir, "other"), material_fingerprint: canonicalFingerprint, started_at: "2026-01-01T00:01:00.000Z" },
+    ];
+    const replacements = [];
+    const changed = await reconcileLegacyPreparedMaterialFingerprints(runs, (runId, expected, replacement) => {
+      replacements.push({ runId, expected, replacement });
+      return true;
+    });
+
+    assert.equal(changed, 1);
+    assert.deepEqual(replacements, [{ runId: 1, expected: legacyFingerprint, replacement: canonicalFingerprint }]);
+  } finally {
+    await rm(runDir, { recursive: true, force: true });
   }
 });

--- a/tests/material-fingerprint.test.mjs
+++ b/tests/material-fingerprint.test.mjs
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
+import { preparedWorkspaceMaterialFingerprint } from "../dist/agent/acquire.js";
+import { loadSource } from "../dist/ingest/source.js";
 import { materialFingerprint, phaseInputFingerprint } from "../dist/util/material-fingerprint.js";
 
 test("material fingerprints are traversal-order independent but content and namespace sensitive", () => {
@@ -32,4 +37,25 @@ test("phase input fingerprints normalize object key order while preserving value
 
   assert.equal(first, reordered);
   assert.notEqual(first, changed);
+});
+
+test("prepare and audit fingerprint the same staged workspace identically", async () => {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "flounder-material-workspace-"));
+  try {
+    await mkdir(path.join(workspace, "src"), { recursive: true });
+    await writeFile(path.join(workspace, "src", "Target.sol"), "contract Target {}\n");
+
+    const prepareFingerprint = await preparedWorkspaceMaterialFingerprint(workspace, []);
+    const auditSource = await loadSource([workspace], { publicRoot: workspace });
+    const auditBuild = await loadSource([workspace], { publicRoot: workspace });
+    const auditFingerprint = materialFingerprint([
+      { label: "source", docs: auditSource },
+      { label: "build", docs: auditBuild },
+      { label: "corpus", docs: [] },
+    ]);
+
+    assert.equal(prepareFingerprint, auditFingerprint);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
 });

--- a/tests/sandbox.test.mjs
+++ b/tests/sandbox.test.mjs
@@ -418,6 +418,7 @@ test("sandbox Apple container backend maps Flounder isolation options to contain
     assert.match(result.stdout, /\[--cpus\]\[1.25\]/);
     assert.match(result.stdout, /\[--env\]\[HOME=\/workspace\]/);
     assert.match(result.stdout, /\[--env\]\[SCARB_CACHE=\/cache\/scarb-cache\]/);
+    assert.match(result.stdout, /\[--env\]\[YARN_GLOBAL_FOLDER=\/cache\/yarn-berry\]/);
     assert.match(result.stdout, /\[flounder-sandbox:latest\]\[node\]\[--test\]/);
   } finally {
     process.env.PATH = oldPath;

--- a/tests/security-policy.test.mjs
+++ b/tests/security-policy.test.mjs
@@ -26,6 +26,9 @@ test("agent bash allows build/dependency commands (the build phase) across ecosy
     cmd("blueprint", "build", "--all"),
     cmd("npx", "blueprint", "build", "--all"),
     cmd("yarn", "blueprint", "build", "--all"),
+    cmd("yarn", "hardhat", "compile"),
+    cmd("pnpm", "hardhat", "compile"),
+    cmd("bun", "hardhat", "compile"),
     cmd("func-js", "contracts/pool.fc"),
     cmd("tolk-js", "contracts/router.tolk"),
     cmd("tact", "--config", "tact.config.json"),
@@ -50,6 +53,7 @@ test("a build command is NOT confirmation-eligible (build cannot mint a finding)
   assert.equal(isAgentConfirmCommand(cmd("scarb", "--offline", "build")), false);
   assert.equal(isAgentConfirmCommand(cmd("env", "SCARB_CACHE=./.scarb-cache", "scarb", "fetch")), false);
   assert.equal(isAgentConfirmCommand(cmd("blueprint", "build", "--all")), false);
+  assert.equal(isAgentConfirmCommand(cmd("yarn", "hardhat", "compile")), false);
   assert.equal(isAgentConfirmCommand(cmd("func-js", "contracts/pool.fc")), false);
   assert.equal(isAgentConfirmCommand(cmd("forge", "inspect", "src/Vault.sol:Vault", "storage-layout")), false);
   assert.equal(isAgentBuildCommand(cmd("func-js")), false);

--- a/tests/security-policy.test.mjs
+++ b/tests/security-policy.test.mjs
@@ -12,6 +12,7 @@ test("agent bash allows build/dependency commands (the build phase) across ecosy
     cmd("npm", "install"),
     cmd("go", "mod", "download"),
     cmd("forge", "build"),
+    cmd("forge", "inspect", "src/Vault.sol:Vault", "storage-layout"),
     cmd("pip", "install", "-r", "requirements.txt"),
     cmd("python3", "-m", "venv", ".venv"),
     cmd("python3", "-m", "pip", "install", "-r", "requirements.txt"),
@@ -50,6 +51,7 @@ test("a build command is NOT confirmation-eligible (build cannot mint a finding)
   assert.equal(isAgentConfirmCommand(cmd("env", "SCARB_CACHE=./.scarb-cache", "scarb", "fetch")), false);
   assert.equal(isAgentConfirmCommand(cmd("blueprint", "build", "--all")), false);
   assert.equal(isAgentConfirmCommand(cmd("func-js", "contracts/pool.fc")), false);
+  assert.equal(isAgentConfirmCommand(cmd("forge", "inspect", "src/Vault.sol:Vault", "storage-layout")), false);
   assert.equal(isAgentBuildCommand(cmd("func-js")), false);
   assert.equal(isAgentConfirmCommand(cmd("tolk-js", "contracts/router.tolk")), false);
   assert.equal(isAgentConfirmCommand(cmd("tact", "--config", "tact.config.json")), false);
@@ -77,6 +79,8 @@ test("a build command is NOT confirmation-eligible (build cannot mint a finding)
 test("a build command still cannot smuggle a remote/mainnet target in its argv", () => {
   assert.equal(analyzeAgentBashCommandSafety(cmd("cargo", "build", "--target-dir", "https://evil.example/x")).blocked, true);
   assert.equal(analyzeAgentBashCommandSafety(cmd("forge", "build", "--fork-url", "https://mainnet.example")).blocked, true);
+  assert.equal(analyzeAgentBashCommandSafety(cmd("forge", "inspect", "src/Vault.sol:Vault", "storage-layout", "--root", "../outside")).blocked, true);
+  assert.equal(analyzeAgentBashCommandSafety(cmd("forge", "inspect", "src/Vault.sol:Vault", "storage-layout", "--rpc-url", "https://mainnet.example")).blocked, true);
   assert.equal(analyzeAgentBashCommandSafety(cmd("cmake", "-S", "https://evil.example/project", "-B", "build")).blocked, true);
   assert.equal(analyzeAgentBashCommandSafety(cmd("cmake", "-P", "script.cmake")).blocked, true);
 });

--- a/tests/security-policy.test.mjs
+++ b/tests/security-policy.test.mjs
@@ -27,8 +27,10 @@ test("agent bash allows build/dependency commands (the build phase) across ecosy
     cmd("npx", "blueprint", "build", "--all"),
     cmd("yarn", "blueprint", "build", "--all"),
     cmd("yarn", "hardhat", "compile"),
+    cmd("yarn", "hardhat", "typechain"),
     cmd("pnpm", "hardhat", "compile"),
     cmd("bun", "hardhat", "compile"),
+    cmd("npx", "hardhat", "typechain"),
     cmd("func-js", "contracts/pool.fc"),
     cmd("tolk-js", "contracts/router.tolk"),
     cmd("tact", "--config", "tact.config.json"),
@@ -54,6 +56,7 @@ test("a build command is NOT confirmation-eligible (build cannot mint a finding)
   assert.equal(isAgentConfirmCommand(cmd("env", "SCARB_CACHE=./.scarb-cache", "scarb", "fetch")), false);
   assert.equal(isAgentConfirmCommand(cmd("blueprint", "build", "--all")), false);
   assert.equal(isAgentConfirmCommand(cmd("yarn", "hardhat", "compile")), false);
+  assert.equal(isAgentConfirmCommand(cmd("yarn", "hardhat", "typechain")), false);
   assert.equal(isAgentConfirmCommand(cmd("func-js", "contracts/pool.fc")), false);
   assert.equal(isAgentConfirmCommand(cmd("forge", "inspect", "src/Vault.sol:Vault", "storage-layout")), false);
   assert.equal(isAgentBuildCommand(cmd("func-js")), false);


### PR DESCRIPTION
## Summary

- align prepared-material fingerprints across prepare and downstream audit phases, including a conservative legacy backfill
- preserve the prepared workspace as the canonical pipeline input and reconcile completed scope coverage
- support safe Forge inspection, package-manager Hardhat builds, Hardhat TypeChain generation, and Yarn Berry cache reuse in isolated sandboxes

## Root cause

Prepared source handoff and fingerprint calculation could diverge between phases, causing valid prepared materials and completed scope outcomes to appear stale or incomplete. Isolated JavaScript audit workspaces also lacked several package-manager-specific build and cache operations needed by real Hardhat projects.

## Validation

- `npm run verify`
- 462 tests passed
- TypeScript and UI checks passed
- production UI build passed
- API catalog contract passed
- database upgrade contract passed
- mock audit passed
- public-surface scan passed

## Notes

- No host-execution fallback is enabled.
- Existing command safety and local-only confirmation boundaries remain intact.
