### PR TITLE
Add constrained Confirm adjudication

### DIFF
--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -14,7 +14,7 @@ import { createRequire } from "node:module";
 import { randomBytes, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { enforceSubmissionReadiness, needsSubmissionReadinessWork } from "../util/submission-readiness.js";
+import { enforceSubmissionReadiness, isSubmissionReadyDecision, needsSubmissionReadinessWork } from "../util/submission-readiness.js";
 import { canonicalFindingKey } from "../util/finding-identity.js";
 import { phaseInputFingerprint } from "../util/material-fingerprint.js";
 import type {
@@ -150,6 +150,23 @@ export interface ConfirmRow {
   reproCommandId?: string | undefined;
   reportMarkdown?: string | undefined;
 }
+
+export interface ConfirmDecisionAdjudicationInput {
+  recommendation: "submit-candidate" | "drop";
+  rationale: string;
+  evidenceDecisionId?: number | undefined;
+  submissionConfidence?: "low" | "medium" | "high" | undefined;
+  gateEvidence?: {
+    scope: string;
+    liveImpact: string;
+    knownIssue: string;
+    payout: string;
+  } | undefined;
+}
+
+export type ConfirmDecisionAdjudicationResult =
+  | { ok: true; decision: Record<string, unknown> }
+  | { ok: false; error: string };
 
 export interface Coverage {
   total: number;
@@ -444,6 +461,8 @@ CREATE TABLE IF NOT EXISTS confirm_decision(
   human_gates TEXT,
   engagement_profile_json TEXT,
   adjudication_json TEXT,
+  operator_adjudication_json TEXT,
+  adjudicated_at TEXT,
   merged_from_json TEXT,
   repro_command_id TEXT,
   report_markdown TEXT,
@@ -622,6 +641,8 @@ const ADDITIVE_COLUMNS = [
   ["confirm_decision", "human_gates", "ALTER TABLE confirm_decision ADD COLUMN human_gates TEXT"],
   ["confirm_decision", "engagement_profile_json", "ALTER TABLE confirm_decision ADD COLUMN engagement_profile_json TEXT"],
   ["confirm_decision", "adjudication_json", "ALTER TABLE confirm_decision ADD COLUMN adjudication_json TEXT"],
+  ["confirm_decision", "operator_adjudication_json", "ALTER TABLE confirm_decision ADD COLUMN operator_adjudication_json TEXT"],
+  ["confirm_decision", "adjudicated_at", "ALTER TABLE confirm_decision ADD COLUMN adjudicated_at TEXT"],
   ["confirm_decision", "merged_from_json", "ALTER TABLE confirm_decision ADD COLUMN merged_from_json TEXT"],
   ["confirm_decision", "repro_command_id", "ALTER TABLE confirm_decision ADD COLUMN repro_command_id TEXT"],
   ["confirm_decision", "severity", "ALTER TABLE confirm_decision ADD COLUMN severity TEXT"],
@@ -661,6 +682,14 @@ function confirmMemberKeys(member: string): string[] {
   const embedded = cleaned.match(/\b(k[0-9a-z]+)\b/i)?.[1];
   if (embedded) add(embedded);
   return [...keys];
+}
+
+function decisionMemberKeySet(row: Record<string, unknown>): Set<string> {
+  const keys = new Set<string>();
+  for (const member of parseJsonArray(row.members_json)) {
+    for (const key of confirmMemberKeys(String(member))) keys.add(key);
+  }
+  return keys;
 }
 
 const SEVERITY_RANK: Record<string, number> = {
@@ -2816,6 +2845,143 @@ export class MetadataStore {
     return this.db.prepare("SELECT * FROM confirm_decision WHERE id = ?").get(id) as Record<string, unknown> | undefined;
   }
 
+  /** Resolve operator-only submission gates without weakening execution confirmation.
+   * A submit-candidate may reuse evidence only from the same project, material snapshot,
+   * and canonical bug membership. The original machine decision is retained as an audit trail. */
+  adjudicateConfirmDecision(id: number, input: ConfirmDecisionAdjudicationInput): ConfirmDecisionAdjudicationResult {
+    const target = this.getConfirmDecision(id);
+    if (!target) return { ok: false, error: "no such confirm decision" };
+    const rationale = input.rationale.trim();
+    if (!rationale) return { ok: false, error: "rationale is required" };
+    if (input.recommendation !== "submit-candidate" && input.recommendation !== "drop") {
+      return { ok: false, error: "recommendation must be submit-candidate or drop" };
+    }
+
+    return this.transaction(() => {
+      const ts = now();
+      const originalAdjudication = target.adjudication_json ? jsonParseOrNull(String(target.adjudication_json)) : undefined;
+      const operatorRecord: Record<string, unknown> = {
+        recommendation: input.recommendation,
+        rationale,
+        reviewed_at: ts,
+        original: {
+          recommendation: target.recommendation ?? null,
+          submission_confidence: target.submission_confidence ?? null,
+          evidence_level: target.evidence_level ?? null,
+          human_gates: target.human_gates ?? null,
+          adjudication: originalAdjudication ?? null,
+        },
+      };
+
+      if (input.recommendation === "drop") {
+        this.db.prepare(
+          `UPDATE confirm_decision
+              SET recommendation = 'drop', submission_confidence = 'low',
+                  operator_adjudication_json = ?, adjudicated_at = ?
+            WHERE id = ?`,
+        ).run(JSON.stringify(operatorRecord), ts, id);
+        return { ok: true, decision: this.getConfirmDecision(id)! };
+      }
+
+      if (target.reproduced !== "yes") {
+        return { ok: false, error: "submit-candidate requires a reproduced confirm decision" };
+      }
+      const gates = input.gateEvidence;
+      if (!gates || [gates.scope, gates.liveImpact, gates.knownIssue, gates.payout].some((value) => !value?.trim())) {
+        return { ok: false, error: "submit-candidate requires evidence for scope, liveImpact, knownIssue, and payout" };
+      }
+
+      const evidence = input.evidenceDecisionId == null ? target : this.getConfirmDecision(input.evidenceDecisionId);
+      if (!evidence) return { ok: false, error: "no such evidence confirm decision" };
+      if (Number(evidence.project_id) !== Number(target.project_id)) {
+        return { ok: false, error: "evidence confirm decision belongs to a different project" };
+      }
+      const targetKeys = decisionMemberKeySet(target);
+      const evidenceKeys = decisionMemberKeySet(evidence);
+      if (targetKeys.size === 0 || targetKeys.size !== evidenceKeys.size || ![...targetKeys].every((key) => evidenceKeys.has(key))) {
+        return { ok: false, error: "evidence confirm decision does not cover the same canonical bug" };
+      }
+      if (evidence.reproduced !== "yes" || !isRealTargetEvidenceLevel(String(evidence.evidence_level ?? ""))) {
+        return { ok: false, error: "evidence confirm decision is not real-target or local-fork reproduced" };
+      }
+      if (!String(evidence.repro_evidence ?? "").trim() || !String(evidence.repro_command_id ?? "").trim()) {
+        return { ok: false, error: "evidence confirm decision lacks executable reproduction provenance" };
+      }
+
+      const targetRun = target.run_id == null ? undefined : this.getRun(Number(target.run_id));
+      const evidenceRun = evidence.run_id == null ? undefined : this.getRun(Number(evidence.run_id));
+      const targetMaterial = String(targetRun?.material_fingerprint ?? "").trim();
+      const evidenceMaterial = String(evidenceRun?.material_fingerprint ?? "").trim();
+      if (!targetMaterial || !evidenceMaterial || targetMaterial !== evidenceMaterial) {
+        return { ok: false, error: "evidence confirm decision has missing or different prepared material" };
+      }
+
+      const payout = isRecord(originalAdjudication) ? originalAdjudication.payout_estimate : undefined;
+      const payoutRecord = payout && typeof payout === "object" && !Array.isArray(payout)
+        ? payout as Record<string, unknown>
+        : {};
+      const finalAdjudication = {
+        gates: [
+          { id: "scope", status: "pass", evidence: gates.scope.trim() },
+          { id: "live_impact", status: "pass", evidence: gates.liveImpact.trim() },
+          { id: "known_issue", status: "pass", evidence: gates.knownIssue.trim() },
+          { id: "payout", status: "pass", evidence: gates.payout.trim() },
+        ],
+        scope_status: "pass",
+        live_impact_status: "pass",
+        known_issue_status: "pass",
+        payout_status: "pass",
+        payout_estimate: {
+          ...payoutRecord,
+          status: "estimated",
+          basis: gates.payout.trim(),
+        },
+        operator_review: {
+          reviewed_at: ts,
+          rationale,
+          evidence_decision_id: Number(evidence.id),
+        },
+      };
+      const submissionConfidence = input.submissionConfidence ?? "medium";
+      const candidate = {
+        ...target,
+        recommendation: "submit-candidate",
+        evidence_level: evidence.evidence_level,
+        submission_confidence: submissionConfidence,
+        repro_evidence: evidence.repro_evidence,
+        repro_command_id: evidence.repro_command_id,
+        corroboration: evidence.corroboration ?? target.corroboration,
+        human_gates: null,
+        adjudication_json: JSON.stringify(finalAdjudication),
+      };
+      if (!isSubmissionReadyDecision(candidate, { requireImpactInventory: false })) {
+        return { ok: false, error: "operator adjudication did not satisfy submission readiness" };
+      }
+
+      operatorRecord.evidence_decision_id = Number(evidence.id);
+      operatorRecord.material_fingerprint = targetMaterial;
+      operatorRecord.gate_evidence = gates;
+      this.db.prepare(
+        `UPDATE confirm_decision
+            SET recommendation = 'submit-candidate', evidence_level = ?, submission_confidence = ?,
+                repro_evidence = ?, repro_command_id = ?, corroboration = ?, human_gates = NULL,
+                adjudication_json = ?, operator_adjudication_json = ?, adjudicated_at = ?
+          WHERE id = ?`,
+      ).run(
+        String(evidence.evidence_level),
+        submissionConfidence,
+        String(evidence.repro_evidence),
+        String(evidence.repro_command_id),
+        sqlText(evidence.corroboration ?? target.corroboration),
+        JSON.stringify(finalAdjudication),
+        JSON.stringify(operatorRecord),
+        ts,
+        id,
+      );
+      return { ok: true, decision: this.getConfirmDecision(id)! };
+    });
+  }
+
   /** Persist the final submission report for one real-target decision. Finding-level reports
    * remain independent evidence summaries; this is the decision-level submission package. */
   setConfirmDecisionReport(projectId: number, decisionId: number, markdown: string): boolean {
@@ -3445,11 +3611,12 @@ export class MetadataStore {
 
   // --- internals ------------------------------------------------------------
 
-  private transaction(fn: () => void, mode: "deferred" | "immediate" = "deferred"): void {
+  private transaction<T>(fn: () => T, mode: "deferred" | "immediate" = "deferred"): T {
     this.db.exec(mode === "immediate" ? "BEGIN IMMEDIATE" : "BEGIN");
     try {
-      fn();
+      const result = fn();
       this.db.exec("COMMIT");
+      return result;
     } catch (error) {
       this.db.exec("ROLLBACK");
       throw error;

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -376,6 +376,19 @@ const ROUTES: Route[] = [
     handler: confirmDecisionReport,
   }),
   route({
+    method: "POST", path: "/api/confirm-decisions/:id/adjudicate",
+    summary: "Record a constrained operator decision for Confirm submission gates. A submit-candidate requires same-project, same-material, same-bug real-target execution evidence and explicit evidence for every bounty gate.",
+    params: { id: "confirm decision id" },
+    body: {
+      recommendation: "'submit-candidate' | 'drop'",
+      rationale: "string — required operator rationale",
+      evidenceDecisionId: "number? — corroborating Confirm row with real-target execution evidence",
+      submissionConfidence: "'low' | 'medium' | 'high'? (default medium)",
+      gateEvidence: "{ scope, liveImpact, knownIssue, payout } — non-empty evidence strings required for submit-candidate",
+    },
+    handler: confirmDecisionAdjudicate,
+  }),
+  route({
     method: "GET", path: "/api/projects/:uuid/confirm-decisions",
     summary: "List current-material confirm decisions (one per distinct bug). Filter ?reproduced=yes for bugs reproduced on the real target; pass ?includeStale=true to inspect decisions from older prepared material snapshots.",
     params: { uuid: "project UUID" },
@@ -3503,6 +3516,8 @@ function confirmDecisionDisplayRow(row: Record<string, unknown>): Record<string,
   if (engagementProfile) out.engagement_profile = engagementProfile;
   const adjudication = safeParse(row.adjudication_json);
   if (adjudication) out.adjudication = adjudication;
+  const operatorAdjudication = safeParse(row.operator_adjudication_json);
+  if (operatorAdjudication) out.operator_adjudication = operatorAdjudication;
   out.has_report = decisionHasFormalReport(row);
   return out;
 }
@@ -3602,6 +3617,50 @@ function confirmDecisionReport(c: Ctx): void {
     markdown: stored || renderDecisionReportMarkdown(row, linkedFindings),
     source: stored ? "db" : "generated",
   });
+}
+
+async function confirmDecisionAdjudicate(c: Ctx): Promise<void> {
+  const body = (await readBody(c.req)) as {
+    recommendation?: unknown;
+    rationale?: unknown;
+    evidenceDecisionId?: unknown;
+    submissionConfidence?: unknown;
+    gateEvidence?: unknown;
+  };
+  if (body.recommendation !== "submit-candidate" && body.recommendation !== "drop") {
+    return sendJson(c.res, 400, { error: "recommendation must be submit-candidate or drop" });
+  }
+  if (typeof body.rationale !== "string" || !body.rationale.trim()) {
+    return sendJson(c.res, 400, { error: "rationale is required" });
+  }
+  if (body.submissionConfidence !== undefined && !["low", "medium", "high"].includes(String(body.submissionConfidence))) {
+    return sendJson(c.res, 400, { error: "submissionConfidence must be low, medium, or high" });
+  }
+  if (body.evidenceDecisionId !== undefined && (!Number.isInteger(body.evidenceDecisionId) || Number(body.evidenceDecisionId) <= 0)) {
+    return sendJson(c.res, 400, { error: "evidenceDecisionId must be a positive integer" });
+  }
+  const gates = body.gateEvidence && typeof body.gateEvidence === "object" && !Array.isArray(body.gateEvidence)
+    ? body.gateEvidence as Record<string, unknown>
+    : undefined;
+  const gateEvidence = gates && ["scope", "liveImpact", "knownIssue", "payout"].every((key) => typeof gates[key] === "string")
+    ? {
+      scope: String(gates.scope),
+      liveImpact: String(gates.liveImpact),
+      knownIssue: String(gates.knownIssue),
+      payout: String(gates.payout),
+    }
+    : undefined;
+  const result = c.store.adjudicateConfirmDecision(Number(c.params.id), {
+    recommendation: body.recommendation,
+    rationale: body.rationale,
+    evidenceDecisionId: body.evidenceDecisionId === undefined ? undefined : Number(body.evidenceDecisionId),
+    submissionConfidence: body.submissionConfidence as "low" | "medium" | "high" | undefined,
+    gateEvidence,
+  });
+  if (!result.ok) {
+    return sendJson(c.res, result.error === "no such confirm decision" ? 404 : 409, { error: result.error });
+  }
+  sendJson(c.res, 200, { decision: confirmDecisionDisplayRow(result.decision) });
 }
 
 function renderFindingReportMarkdown(row: Record<string, unknown>, decisions: Array<Record<string, unknown>> = []): string {

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -34,6 +34,7 @@ test("api: GET /api is a self-describing catalog of every resource + operation",
       "PATCH /api/projects/:uuid", "DELETE /api/projects/:uuid",
       "POST /api/projects/:uuid/runs", "GET /api/projects/:uuid/findings",
       "GET /api/findings/:id/lifecycle", "POST /api/findings/:id/retry",
+      "POST /api/confirm-decisions/:id/adjudicate",
       "GET /api/projects/:uuid/scopes", "GET /api/projects/:uuid/backlog", "GET /api/projects/:uuid/confirm-decisions",
       "PATCH /api/backlog/:id",
       "GET /api/providers", "POST /api/providers", "GET /api/providers/:id",
@@ -2154,6 +2155,206 @@ test("api: report launch queues only reproduced real-target findings that were n
     const conflictRecovered = await post(`/api/projects/${created.uuid}/runs`, { verb: "report", findingIds: [conflicted.id] });
     assert.equal(conflictRecovered.status, 200);
     assert.ok((await conflictRecovered.json()).jobId);
+  });
+});
+
+test("api: operator adjudication requires correlated real-target evidence before report", async () => {
+  await withServer(async (base, out) => {
+    const post = (url, body) => fetch(base + url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const created = await (await post("/api/projects", { name: "operator-adjudication", sourcePaths: ["./src"] })).json();
+    const store = MetadataStore.openForOutput(out);
+    let findingId;
+    let evidenceDecisionId;
+    let targetDecisionId;
+    try {
+      const auditRun = store.startRun({
+        projectId: created.id,
+        kind: "audit",
+        runDir: path.join(out, "operator-adjudication-audit"),
+        materialFingerprint: "sha256:operator-adjudication",
+      });
+      store.upsertFindings(created.id, auditRun, [{
+        findingKey: "koperatorgate",
+        title: "Delegated role is inert",
+        location: "contracts/Access.sol:42",
+        severity: "low",
+        status: "confirmed-differential",
+      }, {
+        findingKey: "kunrelatedgate",
+        title: "Unrelated confirmed behavior",
+        location: "contracts/Other.sol:10",
+        severity: "low",
+        status: "confirmed-executable",
+      }]);
+      findingId = Number(store.queryFindings(created.id, { search: "Delegated role is inert" })[0].id);
+      store.finishRun(auditRun, "done");
+
+      const evidenceRun = store.startRun({
+        projectId: created.id,
+        kind: "confirm",
+        runDir: path.join(out, "operator-adjudication-evidence"),
+        materialFingerprint: "sha256:operator-adjudication",
+      });
+      store.upsertConfirmDecisions(created.id, evidenceRun, [{
+        bug: "Fork reproduction with incomplete engagement context",
+        reproduced: "yes",
+        recommendation: "needs-human",
+        members: ["koperatorgate"],
+        evidenceLevel: "local-fork-reproduced",
+        reproEvidence: "cmd-fork changed three role bits through the deployed proxy on a pinned local fork",
+        reproCommandId: "cmd-fork",
+        humanGates: "Known-issue review is pending.",
+        engagementProfile: { policy_kind: "source_review", required_gates: ["scope"] },
+      }]);
+      evidenceDecisionId = Number(store.listConfirmDecisions(created.id)[0].id);
+      store.finishRun(evidenceRun, "done");
+
+      const targetRun = store.startRun({
+        projectId: created.id,
+        kind: "confirm",
+        runDir: path.join(out, "operator-adjudication-policy"),
+        materialFingerprint: "sha256:operator-adjudication",
+      });
+      store.upsertConfirmDecisions(created.id, targetRun, [{
+        bug: "Delegated role is inert",
+        reproduced: "yes",
+        recommendation: "needs-human",
+        members: ["koperatorgate"],
+        evidenceLevel: "source-only-local-confirmed",
+        reproEvidence: "The exact deployed runtime was executed locally; live RPC was unavailable.",
+        reproCommandId: "cmd-local",
+        humanGates: "Live impact, novelty, and payout remain pending.",
+        engagementProfile: {
+          policy_kind: "bug_bounty",
+          platform: "Example bounty",
+          required_gates: ["scope", "live_impact", "known_issue", "payout"],
+        },
+        adjudication: {
+          gates: [
+            { id: "scope", status: "pass" },
+            { id: "live_impact", status: "unknown" },
+            { id: "known_issue", status: "needs-human" },
+            { id: "payout", status: "unknown" },
+          ],
+          payout_estimate: { status: "unknown", eligible_min_usd: 500, eligible_max_usd: 1000 },
+        },
+      }]);
+      targetDecisionId = Number(store.listConfirmDecisions(created.id).find((row) => Number(row.run_id) === targetRun).id);
+      store.finishRun(targetRun, "done");
+
+      const unrelatedRun = store.startRun({
+        projectId: created.id,
+        kind: "confirm",
+        runDir: path.join(out, "operator-adjudication-unrelated"),
+        materialFingerprint: "sha256:operator-adjudication",
+      });
+      store.upsertConfirmDecisions(created.id, unrelatedRun, [{
+        bug: "Unrelated same-project reproduction",
+        reproduced: "yes",
+        recommendation: "needs-human",
+        members: ["kunrelatedgate"],
+        evidenceLevel: "local-fork-reproduced",
+        reproEvidence: "cmd-unrelated reproduced another bug on a pinned local fork",
+        reproCommandId: "cmd-unrelated",
+      }]);
+      store.finishRun(unrelatedRun, "done");
+    } finally {
+      store.close();
+    }
+
+    const missingRationale = await post(`/api/confirm-decisions/${targetDecisionId}/adjudicate`, {
+      recommendation: "submit-candidate",
+      rationale: "",
+    });
+    assert.equal(missingRationale.status, 400);
+
+    const missingGateEvidence = await post(`/api/confirm-decisions/${targetDecisionId}/adjudicate`, {
+      recommendation: "submit-candidate",
+      rationale: "Reviewed the external submission gates.",
+      evidenceDecisionId,
+      gateEvidence: { scope: "In scope", liveImpact: "Live fork passed", knownIssue: "No disclosure found", payout: "" },
+    });
+    assert.equal(missingGateEvidence.status, 409);
+
+    const other = await (await post("/api/projects", { name: "operator-adjudication-other", sourcePaths: ["./src"] })).json();
+    const otherStore = MetadataStore.openForOutput(out);
+    let otherDecisionId;
+    try {
+      const otherRun = otherStore.startRun({
+        projectId: other.id,
+        kind: "confirm",
+        runDir: path.join(out, "operator-adjudication-other-confirm"),
+        materialFingerprint: "sha256:operator-adjudication",
+      });
+      otherStore.upsertConfirmDecisions(other.id, otherRun, [{
+        bug: "Unrelated reproduced bug",
+        reproduced: "yes",
+        recommendation: "needs-human",
+        members: ["koperatorgate"],
+        evidenceLevel: "local-fork-reproduced",
+        reproEvidence: "cmd-other reproduced an unrelated effect on a local fork",
+        reproCommandId: "cmd-other",
+      }]);
+      otherDecisionId = Number(otherStore.listConfirmDecisions(other.id)[0].id);
+      otherStore.finishRun(otherRun, "done");
+    } finally {
+      otherStore.close();
+    }
+    const crossProject = await post(`/api/confirm-decisions/${targetDecisionId}/adjudicate`, {
+      recommendation: "submit-candidate",
+      rationale: "Reviewed the external submission gates.",
+      evidenceDecisionId: otherDecisionId,
+      gateEvidence: { scope: "In scope", liveImpact: "Live fork passed", knownIssue: "No disclosure found", payout: "Reward tier applies" },
+    });
+    assert.equal(crossProject.status, 409);
+    assert.match((await crossProject.json()).error, /different project/);
+
+    const decisions = await (await fetch(base + `/api/projects/${created.uuid}/confirm-decisions?includeStale=true`)).json();
+    const unrelatedDecisionId = decisions.confirmDecisions.find((row) => row.bug === "Unrelated same-project reproduction").id;
+    const differentBug = await post(`/api/confirm-decisions/${targetDecisionId}/adjudicate`, {
+      recommendation: "submit-candidate",
+      rationale: "Reviewed the external submission gates.",
+      evidenceDecisionId: unrelatedDecisionId,
+      gateEvidence: { scope: "In scope", liveImpact: "Live fork passed", knownIssue: "No disclosure found", payout: "Reward tier applies" },
+    });
+    assert.equal(differentBug.status, 409);
+    assert.match((await differentBug.json()).error, /same canonical bug/);
+
+    const adjudicated = await post(`/api/confirm-decisions/${targetDecisionId}/adjudicate`, {
+      recommendation: "submit-candidate",
+      rationale: "The same-material fork evidence and external bounty checks settle every submission gate.",
+      evidenceDecisionId,
+      submissionConfidence: "medium",
+      gateEvidence: {
+        scope: "The affected source path is in the pinned bounty scope.",
+        liveImpact: "The pinned local fork exercised the deployed proxy and changed three role bits.",
+        knownIssue: "Bounded public searches found no matching disclosure or fix.",
+        payout: "The published Low tier is eligible for an estimated $500-$1,000 award.",
+      },
+    });
+    assert.equal(adjudicated.status, 200);
+    const decision = (await adjudicated.json()).decision;
+    assert.equal(decision.recommendation, "submit-candidate");
+    assert.equal(decision.evidence_level, "local-fork-reproduced");
+    assert.equal(decision.repro_command_id, "cmd-fork");
+    assert.equal(decision.human_gates, null);
+    assert.equal(decision.engagement_profile.policy_kind, "bug_bounty");
+    assert.equal(decision.adjudication.known_issue_status, "pass");
+    assert.equal(decision.operator_adjudication.evidence_decision_id, evidenceDecisionId);
+    assert.equal(decision.operator_adjudication.original.recommendation, "needs-human");
+
+    const report = await post(`/api/projects/${created.uuid}/runs`, { verb: "report", findingIds: [findingId] });
+    assert.equal(report.status, 200);
+    const job = (await (await fetch(base + `/api/jobs/${(await report.json()).jobId}`)).json()).job;
+    const spec = JSON.parse(job.spec_json);
+    assert.equal(spec.reportFindings.length, 1);
+    assert.equal(spec.reportFindings[0].decisionId, targetDecisionId);
+    assert.equal(spec.reportFindings[0].evidenceLevel, "local-fork-reproduced");
+    assert.equal(spec.reportFindings[0].decisions[0].engagement_profile.policy_kind, "bug_bounty");
   });
 });
 


### PR DESCRIPTION
## Summary
- add an operator API for resolving Confirm submission gates
- require same-project, same-material, same-bug real-target execution evidence before promoting a submit candidate
- preserve the machine decision and operator rationale as a durable audit trail
- expose adjudication in the API and cover report handoff with regression tests

## Validation
- `npm run verify`
- 463 tests passed
- API catalog contract passed
- database upgrade contract passed (`v0.3.1` to current)
- mock audit passed
- public-surface scan passed