### PR TITLE
Retry needs-evidence findings with Verify from start

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -5236,7 +5236,7 @@ function verifyWorklist(store: MetadataStore, projectId: number, currentResultRu
         && store.hasFindingPhaseRetry(projectId, "finding", Number(row.id), "verify")) return true;
       if (status === "suspected" || status === "confirmed-source") return true;
       if (!fromStart || row.confirm_status != null) return false;
-      return status === "confirmed-executable" || status === "confirmed-differential";
+      return status === "needs-evidence" || status === "confirmed-executable" || status === "confirmed-differential";
     })
     .map((row) => {
       const inputFingerprint = findingPhaseFingerprint(store, row, "verify", materialBoundary);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2510,10 +2510,14 @@ async function runLaunch(c: Ctx): Promise<void> {
     spec.verb === "run"
     && spec.pipeline
     && spec.maxScopes === 0
-    && pipelinePostAuditWorkPending(c.store, projectId, currentResultRunIds, materialBoundary, requiresRealTargetConfirmation)
+    && (
+      spec.verifyFromStart
+      || pipelinePostAuditWorkPending(c.store, projectId, currentResultRunIds, materialBoundary, requiresRealTargetConfirmation)
+    )
   ) {
     // Continue the evidence tail directly. Starting runAudit with maxScopes=0 still copies and
     // initializes the target and records a misleading empty Dig run before Verify/Confirm/Report.
+    // An explicit Verify restart is work even when the ordinary pending-work list is settled.
     spec.pipelineStart = "settle";
     spec.maxScopes = 0;
   }
@@ -2766,6 +2770,7 @@ function pipelineRoundComplete(
   materialBoundary: Record<string, unknown> | undefined,
   requiresRealTargetConfirmation: boolean,
 ): boolean {
+  if (spec.verifyFromStart) return false;
   if ((spec.nextActions?.length ?? 0) > 0) return false;
   if (spec.continueCoverage) return false;
   if (spec.maxScopes !== 0) return false;

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -1238,6 +1238,16 @@ test("api: daemon pipeline worklist exposes verify candidates before confirm", a
           confidence: 0.72,
         },
       ], "synthesis");
+      store.upsertFindings(created.id, runId, [
+        {
+          findingKey: "needs-evidence-bug",
+          title: "Proof binding could not be verified with the available toolchain",
+          location: "src/Rollup.sol:52",
+          severity: "high",
+          status: "needs-evidence",
+          confidence: 0.78,
+        },
+      ], "verify");
     } finally {
       store.close();
     }
@@ -1261,7 +1271,10 @@ test("api: daemon pipeline worklist exposes verify candidates before confirm", a
     }));
     assert.equal(restartVerify.phase, "verify");
     assert.equal(restartVerify.verifyFromStart, true);
-    assert.deepEqual(new Set(restartVerify.verifyFindings.map((finding) => finding.finding_key)), new Set(["suspected-bug", "duplicate-suspected-bug", "confirmed-bug"]));
+    assert.deepEqual(
+      new Set(restartVerify.verifyFindings.map((finding) => finding.finding_key)),
+      new Set(["suspected-bug", "duplicate-suspected-bug", "needs-evidence-bug", "confirmed-bug"]),
+    );
 
     const confirm = await json(await fetch(base + "/api/daemon/pipeline-worklist", {
       method: "POST",

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -916,6 +916,51 @@ test("api: standard pipeline continue finishes pending verify work before openin
   });
 });
 
+test("api: Verify from start skips an empty Dig even when the ordinary pipeline round is settled", async () => {
+  await withServer(async (base, out) => {
+    const json = (r) => r.json();
+    const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    const created = await json(await post("/api/projects", {
+      name: "verify-from-start-settled",
+      sourcePaths: ["./src"],
+      config: { scopeCoverageMode: "standard" },
+    }));
+
+    const store = MetadataStore.openForOutput(out);
+    try {
+      store.upsertScopes(created.id, [
+        ...Array.from({ length: 30 }, (_, i) => ({ scopeId: `audited-${i}`, title: `Audited ${i}`, status: "audited", score: 30 - i })),
+      ]);
+      const runId = store.startRun({ projectId: created.id, kind: "run", runDir: path.join(out, "verify-from-start-settled-run") });
+      store.upsertFindings(created.id, runId, [
+        {
+          findingKey: "needs-evidence-retry",
+          title: "Prior verification needs another toolchain",
+          location: "src/A.sol:1",
+          severity: "high",
+          status: "needs-evidence",
+          evidence: "the earlier execution environment could not build the proof",
+        },
+      ], "verify");
+      store.finishRun(runId, "done");
+    } finally {
+      store.close();
+    }
+
+    const pipeline = await json(await post(`/api/projects/${created.uuid}/runs`, {
+      verb: "run",
+      pipeline: true,
+      verifyFromStart: true,
+    }));
+    assert.equal(pipeline.queued, true);
+    const pipelineJob = (await json(await fetch(base + "/api/jobs/" + pipeline.jobId))).job;
+    const pipelineSpec = JSON.parse(pipelineJob.spec_json);
+    assert.equal(pipelineSpec.verifyFromStart, true);
+    assert.equal(pipelineSpec.maxScopes, 0);
+    assert.equal(pipelineSpec.pipelineStart, "settle", "Verify restart must not create a zero-scope Run");
+  });
+});
+
 test("api: blocked confirm decisions stay idempotent until focused retry or explicit coverage continuation", async () => {
   await withServer(async (base, out) => {
     const json = (r) => r.json();


### PR DESCRIPTION
## Summary
- include needs-evidence findings when Verify is explicitly restarted from the beginning
- start an explicit Verify restart at the settle phase so it does not create a misleading zero-scope Dig run
- allow an explicit Verify restart after the ordinary pipeline round is settled
- preserve ordinary Continue behavior so settled blocked work remains idempotent
- cover both lifecycle and launch behavior with API regressions

## Verification
- `npm run check`
- targeted Verify worklist and launch API regressions
- public-surface scan
- affected API/daemon test files: 119/119 passed serially
- parallel full suite before the follow-up commit: 359 functional assertions passed; four Node test workers hit a host `InternalCallbackScope` native crash, and all four affected files passed when rerun serially
