### PR TITLE
Make blocked Confirm retries actionable

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -307,7 +307,7 @@ const ROUTES: Route[] = [
       maxScopes: "number? — one-off scope cap for this run, or the custom target when scopeCoverageMode=custom", mapSteps: "number? — one-off map turn cap", mapSamples: "number? — independent Map inventories to union without dropping singleton scopes", digSteps: "number? — one-off per-scope dig turn cap",
       maxSteps: "number? — one-off global turn cap", digSamples: "number? — minimum independent samples per scope", digMaxSamples: "number? — adaptive per-scope sample ceiling", adaptiveDig: "boolean? — add bounded samples only for incomplete/uncertain outcomes", eagerPrepare: "boolean? — warm the build before Dig and surface repairable resource blockers", digConcurrency: "number? — one-off parallel scopes", verifyConcurrency: "number? — one-off parallel Verify findings (isolated workspaces)",
       findingId: "number? — confirm/report: reproduce or report one selected finding",
-      findingIds: "number[]? — confirm/report: reproduce selected pending audit-confirmed findings, or generate/regenerate formal reports for selected reproduced findings. Report without selection only generates missing reports.",
+      findingIds: "number[]? — confirm/report: reproduce selected pending or explicitly reopened audit-confirmed findings, or generate/regenerate formal reports for selected reproduced findings. Report without selection only generates missing reports.",
       inputRunDir: "string? — confirm: the finished run dir to reproduce",
       clue: "string? — prepare: the tx / address / project / link to acquire from",
       posture: "string? — prepare: 'blind' | 'informed'", matchDeployed: "boolean? — prepare: prove staged source matches the live deployment (default true)", endpoint: "string? — prepare: read-only access hint (e.g. RPC URL)",
@@ -2553,7 +2553,14 @@ async function runLaunch(c: Ctx): Promise<void> {
   if (spec.verb === "confirm" && !spec.inputRunDir && !(spec.inputRunDirs && spec.inputRunDirs.length > 0)) {
     const findingIds = selectedFindingIds(body);
     if (findingIds.length > 0) {
-      const selected = findingIds.map((id) => ({ id, row: c.store.getConfirmable(Number(project.id), id) }));
+      const retryContext = new Map(c.store.confirmableContext(Number(project.id)).map((row) => [Number(row.id), row]));
+      const selected = findingIds.map((id) => {
+        const pending = c.store.getConfirmable(Number(project.id), id);
+        const reopened = !pending && c.store.hasFindingPhaseRetry(Number(project.id), "finding", id, "confirm")
+          ? retryContext.get(id)
+          : undefined;
+        return { id, row: pending ?? reopened, reopened: Boolean(reopened) };
+      });
       const trackingBlocked = selected
         .filter((entry) => findingTrackingBlocksProgress(c.store.getFinding(entry.id)))
         .map((entry) => entry.id);
@@ -2567,7 +2574,7 @@ async function runLaunch(c: Ctx): Promise<void> {
         return sendJson(c.res, 400, { error: `finding ${reviewBlocked.join(", ")} did not pass independent review` });
       }
       const missing = selected.filter((entry) => !entry.row || !confirmableRunDir(entry.row as unknown as Record<string, unknown>)).map((entry) => entry.id);
-      if (missing.length > 0) return sendJson(c.res, 400, { error: `finding ${missing.join(", ")} is not pending confirm for this project, or has no source run dir` });
+      if (missing.length > 0) return sendJson(c.res, 400, { error: `finding ${missing.join(", ")} is not pending or explicitly reopened for Confirm in this project, or has no source run dir` });
       const stale = selected.filter((entry) => entry.row && !rowBelongsToCurrentMaterial(entry.row as unknown as Record<string, unknown>, currentResultRunIds, materialBoundary)).map((entry) => entry.id);
       if (stale.length > 0 && body.allowMaterialDrift !== true) {
         return sendJson(c.res, 409, {
@@ -2582,6 +2589,9 @@ async function runLaunch(c: Ctx): Promise<void> {
       spec.inputRunDir = spec.inputRunDirs[0];
       spec.confirmKeys = rows.flatMap((row) => confirmSelectorsForFinding(row as unknown as { id?: unknown; finding_key?: unknown }));
       spec.confirmFindings = confirmFindingSeeds(c.store, Number(project.id), rows);
+      // A focused retry is an explicit request to replace the old blocked decision. Without
+      // fresh mode runConfirm may load that decision from a prior artifact and treat it as settled.
+      if (selected.some((entry) => entry.reopened)) spec.fresh = true;
     } else {
       const currentDecisions = currentConfirmDecisions(c.store.listConfirmDecisions(Number(project.id)).filter((row) => rowBelongsToCurrentMaterial(row, currentResultRunIds, materialBoundary)));
       const pending = confirmWorkRows(c.store, Number(project.id), currentResultRunIds, materialBoundary, currentDecisions);
@@ -2618,9 +2628,21 @@ async function runLaunch(c: Ctx): Promise<void> {
     });
   }
   if (spec.verb === "prepare" || (spec.verb === "run" && spec.pipeline && spec.clue) || (isScopeInventoryVerb(spec.verb) && !scopeView.hasInventory)) await resetCurrentScopeProjection(c, project);
+  const blockingJob = activeProjectJob(c.store, spec.target);
   const jobId = c.store.enqueueJob(spec.target, spec, daemonId);
   c.plane.nudge();
-  sendJson(c.res, 200, { jobId, verb: spec.verb, queued: true, daemons: c.plane.daemonCount(daemonId), daemonId });
+  sendJson(c.res, 200, {
+    jobId,
+    verb: spec.verb,
+    queued: true,
+    daemons: c.plane.daemonCount(daemonId),
+    daemonId,
+    ...(blockingJob ? {
+      queueReason: "project-run-active",
+      blockingJobId: Number(blockingJob.id),
+      message: `Another run for this project is still in progress (job ${Number(blockingJob.id)}). This job will start automatically when it finishes.`,
+    } : {}),
+  });
 }
 
 function applyProjectPrepareDefaults(spec: LaunchSpec, project: Record<string, unknown>, runs: Array<Record<string, unknown>>): void {
@@ -3357,9 +3379,20 @@ async function launch(c: Ctx): Promise<void> {
   if (!c.store.getProject(target)) {
     c.store.upsertProject({ name: target, sourcePaths: spec.sourcePaths, ...(spec.buildRoot ? { buildRoot: spec.buildRoot } : {}), corpusPaths: spec.corpusPaths ?? [], config: launchDisplayConfig(spec) });
   }
+  const blockingJob = activeProjectJob(c.store, target);
   const jobId = c.store.enqueueJob(target, spec);
   c.plane.nudge();
-  sendJson(c.res, 200, { jobId, verb: spec.verb, queued: true, daemons: c.plane.daemonCount() });
+  sendJson(c.res, 200, {
+    jobId,
+    verb: spec.verb,
+    queued: true,
+    daemons: c.plane.daemonCount(),
+    ...(blockingJob ? {
+      queueReason: "project-run-active",
+      blockingJobId: Number(blockingJob.id),
+      message: `Another run for this project is still in progress (job ${Number(blockingJob.id)}). This job will start automatically when it finishes.`,
+    } : {}),
+  });
 }
 
 // Coerce a /api/launch body into a clean LaunchSpec (drop non-finite/wrong-typed values; no
@@ -5357,11 +5390,17 @@ function daemonRecentlySeen(store: MetadataStore, daemonId: number): boolean {
 
 // In-flight jobs across all daemons, shaped for the dashboard's "active" list.
 function activeRuns(store: MetadataStore, plane?: ControlPlane): Array<Record<string, unknown>> {
-  return store.runningJobs().map((job) => {
+  const jobs = store.runningJobs();
+  const activeByProject = new Map<string, Record<string, unknown>>();
+  for (const job of jobs) {
+    if ((job.status === "dispatched" || job.status === "running") && typeof job.project === "string") activeByProject.set(job.project, job);
+  }
+  return jobs.map((job) => {
     const spec = safeParse(job.spec_json) as { verb?: string } | null;
     const daemonId = typeof job.daemon_id === "number" ? job.daemon_id : undefined;
     const onlineDaemons = daemonId !== undefined && plane ? (plane.hasDaemonSignal(daemonId) ? Math.max(1, plane.daemonCount(daemonId)) : 0) : undefined;
-    const blockedReason = daemonId !== undefined && onlineDaemons === 0 ? "selected-daemon-offline" : undefined;
+    const blockingJob = job.status === "queued" && typeof job.project === "string" ? activeByProject.get(job.project) : undefined;
+    const blockedReason = blockingJob ? "project-run-active" : daemonId !== undefined && onlineDaemons === 0 ? "selected-daemon-offline" : undefined;
     const lastActivityAt = typeof job.run_id === "number" ? latestRunActivityAt(store, plane, Number(job.run_id)) : undefined;
     const activity = runInactivity(lastActivityAt);
     const updatedAt = maxIsoTimestamp(String(job.updated_at ?? ""), lastActivityAt);
@@ -5378,8 +5417,13 @@ function activeRuns(store: MetadataStore, plane?: ControlPlane): Array<Record<st
       daemonId: daemonId ?? null,
       ...(onlineDaemons !== undefined ? { onlineDaemons } : {}),
       ...(blockedReason ? { blockedReason } : {}),
+      ...(blockingJob ? { blockingJobId: Number(blockingJob.id) } : {}),
     };
   });
+}
+
+function activeProjectJob(store: MetadataStore, project: string): Record<string, unknown> | undefined {
+  return store.runningJobs().find((job) => job.project === project && (job.status === "dispatched" || job.status === "running"));
 }
 
 function latestRunActivityAt(store: MetadataStore, plane: ControlPlane | undefined, runId: number): string | undefined {

--- a/src/server/ui/src/App.tsx
+++ b/src/server/ui/src/App.tsx
@@ -125,6 +125,9 @@ interface LaunchResult {
   verb?: string;
   queued?: boolean;
   daemons?: number;
+  queueReason?: string;
+  blockingJobId?: number;
+  message?: string;
 }
 
 const ONLINE_MS = 90_000;
@@ -1993,10 +1996,13 @@ export function App() {
         ...((action === "confirm" || action === "report") && selected ? { findingIds: selected.map((finding) => finding.id) } : {}),
       })) as LaunchResult;
       const waiting = (result.daemons ?? 0) === 0;
+      const waitingForProject = result.queueReason === "project-run-active";
       const label = action === "verify" ? "verify" : action === "map-expand" ? "expand map" : opensNextCoverage ? "run" : verb;
       setToast({
-        tone: waiting ? "warning" : "success",
-        message: waiting
+        tone: waiting || waitingForProject ? "warning" : "success",
+        message: waitingForProject
+          ? result.message ?? `${label} queued behind another run for this project and will start automatically when it finishes.`
+          : waiting
           ? `${label} queued, but no online daemon is connected. Start a daemon to claim the job.`
           : `${label} queued for ${plural(result.daemons ?? 0, "daemon")}.${runHint && (action === "run" || opensNextCoverage) ? ` ${runHint}` : ""}`,
       });
@@ -2303,9 +2309,12 @@ export function App() {
               try {
                 const result = (await api.launchRun(uuid, { verb: "run", pipeline: true })) as LaunchResult;
                 const waiting = (result.daemons ?? 0) === 0;
+                const waitingForProject = result.queueReason === "project-run-active";
                 setToast({
-                  tone: waiting ? "warning" : "success",
-                  message: waiting
+                  tone: waiting || waitingForProject ? "warning" : "success",
+                  message: waitingForProject
+                    ? result.message ?? "run queued behind another run for this project and will start automatically when it finishes."
+                    : waiting
                     ? "run queued, but no online daemon is connected. Start a daemon to claim the job."
                     : `run queued for ${plural(result.daemons ?? 0, "daemon")}.`,
                 });

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -3029,6 +3029,94 @@ test("api: confirm launch carries DB-backed seeds when prior run artifact is mis
   });
 });
 
+test("api: a focused retry can relaunch a reproduced finding whose Confirm phase is blocked", async () => {
+  await withServer(async (base, out) => {
+    const json = (r) => r.json();
+    const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    const created = await json(await post("/api/projects", { name: "focused-reproduced-confirm-retry", sourcePaths: ["src"] }));
+    const auditRunDir = path.join(out, "focused-reproduced-confirm-audit");
+    let findingId;
+    const store = MetadataStore.openForOutput(out);
+    try {
+      const auditRunId = store.startRun({ projectId: created.id, kind: "audit", runDir: auditRunDir });
+      store.upsertFindings(created.id, auditRunId, [{
+        findingKey: "kretryreproduced",
+        title: "Real-target evidence still needs one automated follow-up",
+        location: "src/Target.sol:19",
+        severity: "high",
+        status: "confirmed-executable",
+        confidence: 0.93,
+      }]);
+      store.finishRun(auditRunId, "done");
+      findingId = Number(store.listFindings(created.id)[0].id);
+
+      const confirmRunId = store.startRun({ projectId: created.id, kind: "confirm", runDir: path.join(out, "focused-reproduced-confirm-old") });
+      store.upsertConfirmDecisions(created.id, confirmRunId, [{
+        bug: "Reproduced but not submission-ready",
+        reproduced: "yes",
+        recommendation: "needs-human",
+        members: ["kretryreproduced"],
+        humanGates: "Deployment equivalence and local-fork impact remain to be checked.",
+      }]);
+      store.recordFindingPhaseAttempt(created.id, confirmRunId, {
+        subjectType: "finding",
+        subjectId: findingId,
+        phase: "confirm",
+        inputFingerprint: "sha256:old-confirm-input",
+        state: "blocked",
+        outcome: "yes",
+        blocker: "Deployment equivalence and local-fork impact remain to be checked.",
+      });
+      store.finishRun(confirmRunId, "done");
+      assert.equal(store.getFinding(findingId).confirm_status, "reproduced");
+    } finally {
+      store.close();
+    }
+
+    const retried = await json(await post(`/api/findings/${findingId}/retry`, { phase: "confirm" }));
+    assert.equal(retried.ok, true);
+
+    const launchedResponse = await post(`/api/projects/${created.uuid}/runs`, { verb: "confirm", findingIds: [findingId] });
+    assert.equal(launchedResponse.status, 200);
+    const launched = await json(launchedResponse);
+    assert.equal(launched.queued, true);
+    const job = (await json(await fetch(base + "/api/jobs/" + launched.jobId))).job;
+    const spec = JSON.parse(job.spec_json);
+    assert.ok(spec.confirmKeys.includes("kretryreproduced"));
+    assert.ok(spec.confirmKeys.includes(`origin:${findingId}:kretryreproduced`));
+    assert.equal(spec.confirmFindings[0].originId, findingId);
+    assert.equal(spec.fresh, true, "a focused retry must not reuse the old blocked decision as settled evidence");
+  });
+});
+
+test("api: queued project work explains that an earlier run is holding the project", async () => {
+  await withServer(async (base, out) => {
+    const json = (r) => r.json();
+    const post = (p, body) => fetch(base + p, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    const created = await json(await post("/api/projects", { name: "explained-project-queue", sourcePaths: ["src"] }));
+    let activeJobId;
+    const store = MetadataStore.openForOutput(out);
+    try {
+      activeJobId = store.enqueueJob(created.name, { verb: "audit" });
+      const runId = store.startRun({ projectId: created.id, kind: "audit", runDir: path.join(out, "explained-project-queue-active") });
+      store.setJobRun(activeJobId, runId);
+    } finally {
+      store.close();
+    }
+
+    const launched = await json(await post(`/api/projects/${created.uuid}/runs`, { verb: "prepare", clue: "refresh public source" }));
+    assert.equal(launched.queued, true);
+    assert.equal(launched.queueReason, "project-run-active");
+    assert.equal(launched.blockingJobId, activeJobId);
+    assert.match(launched.message, /start automatically/i);
+
+    const active = await json(await fetch(base + "/api/active"));
+    const queued = active.active.find((row) => row.jobId === launched.jobId);
+    assert.equal(queued.blockedReason, "project-run-active");
+    assert.equal(queued.blockingJobId, activeJobId);
+  });
+});
+
 test("api: prepare summary normalizes verified deployment evidence", async () => {
   await withServer(async (base, out) => {
     const json = (r) => r.json();


### PR DESCRIPTION
## Summary

- let an explicitly reopened Confirm phase relaunch a finding even when an earlier decision already marked it reproduced
- force focused retries to ignore the prior blocked decision instead of silently treating it as settled
- explain same-project queue serialization in launch responses, active-job state, and the UI toast, including the blocking job ID and automatic-start behavior

## Why

An operator could click Retry on a blocked Confirm phase and then receive `finding is not pending confirm`, because the selected-finding path only accepted `confirm_status IS NULL`. Separately, a job routed to an online daemon could remain queued behind another run for the same project without a user-facing explanation.

## Verification

- `node --test --test-concurrency=1 tests/*.test.mjs` (478 passed)
- `npm run build`
- `npm run check:public`
