### PR TITLE
Clean up sandbox processes when runs stop

### DIFF
--- a/src/agent/pi-session.ts
+++ b/src/agent/pi-session.ts
@@ -190,6 +190,8 @@ export async function runAuditSession(input: {
   if (!model) throw new Error(`audit session: unknown provider/model ${input.cfg.provider}/${input.cfg.auditModel}`);
   if (input.activityStreamId) input.ctx.activityStreamId = input.activityStreamId;
   else delete input.ctx.activityStreamId;
+  if (input.signal) input.ctx.signal = input.signal;
+  else delete input.ctx.signal;
 
   const steps: TranscriptStep[] = [];
   let stepNo = 0;

--- a/src/agent/prepare.ts
+++ b/src/agent/prepare.ts
@@ -61,7 +61,7 @@ export interface ToolVersionCheck {
   reason?: string;
 }
 
-export async function prepareWorkspaceToolchain(input: { workspace: SandboxWorkspace; cfg: AuditorConfig; logger: RunLogger; cacheDir?: string; focusCommand?: ReproductionCommand; focusPaths?: string[]; streamId?: string }): Promise<PrepareReport> {
+export async function prepareWorkspaceToolchain(input: { workspace: SandboxWorkspace; cfg: AuditorConfig; logger: RunLogger; cacheDir?: string; focusCommand?: ReproductionCommand; focusPaths?: string[]; streamId?: string; signal?: AbortSignal }): Promise<PrepareReport> {
   const streamMeta = input.streamId ? { streamId: input.streamId } : {};
   const artifactName = input.streamId ? `audit_prepare-${slug(input.streamId)}.json` : "audit_prepare.json";
   const allPlans = await detectToolchains(input.workspace.absolute);
@@ -105,6 +105,7 @@ export async function prepareWorkspaceToolchain(input: { workspace: SandboxWorks
         input.cfg.sourcePaths,
         input.cacheDir,
         sandboxExecutionOptions(input.cfg, input.cfg.sandboxPrepareNetwork),
+        input.signal,
       );
       const ok = run.exitCode === 0 && !run.timedOut;
       const record: PrepareCommandResult = {
@@ -175,7 +176,13 @@ export function prepareResourceRequests(report: PrepareReport, focusCommand?: Re
 }
 
 async function checkPinnedToolVersions(
-  input: { workspace: SandboxWorkspace; cfg: AuditorConfig; logger: RunLogger; cacheDir?: string },
+  input: {
+    workspace: SandboxWorkspace;
+    cfg: AuditorConfig;
+    logger: RunLogger;
+    cacheDir?: string;
+    signal?: AbortSignal;
+  },
   pins: PinnedToolVersion[],
 ): Promise<ToolVersionCheck[]> {
   const specs = pins.flatMap((pin) => versionCheckSpecs(pin));
@@ -195,6 +202,7 @@ async function checkPinnedToolVersions(
       input.cfg.sourcePaths,
       input.cacheDir,
       sandboxExecutionOptions(input.cfg, "none"),
+      input.signal,
     );
     const combined = `${run.stdout}\n${run.stderr}`.trim();
     const actual = firstVersionLine(combined);

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -143,6 +143,8 @@ export interface ToolContext {
   logger: RunLogger;
   session: AgentSession;
   onCommandRun?: (record: CommandRunRecord) => void;
+  /** Cooperative run cancellation. Active sandbox commands stop with the agent session. */
+  signal?: AbortSignal;
   /** Identity of the concurrent map/dig/verify stream that owns this context. */
   activityStreamId?: string;
 }
@@ -405,6 +407,7 @@ const bashTool: AgentTool = {
       ctx.cfg.sourcePaths,
       ctx.session.buildCacheDir,
       sandboxExecutionOptions(ctx.cfg, commandNetwork),
+      ctx.signal,
     );
     const exitMatched = result.exitCode === result.expectedExitCode && !result.timedOut;
     const isConfirm = normalized.purpose === "confirm";
@@ -902,6 +905,7 @@ async function ensurePrepared(ctx: ToolContext, workspace: SandboxWorkspace, foc
     ...(ctx.session.buildCacheDir ? { cacheDir: ctx.session.buildCacheDir } : {}),
     ...(focusCommand ? { focusCommand } : {}),
     ...(ctx.activityStreamId ? { streamId: ctx.activityStreamId } : {}),
+    ...(ctx.signal ? { signal: ctx.signal } : {}),
   });
   const resourceRequests = prepareResourceRequests(report, focusCommand);
   if (resourceRequests.length > 0) ctx.session.resourceRequests = mergeResourceRequests(ctx.session.resourceRequests ?? [], resourceRequests);

--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -70,6 +70,7 @@ interface ProcessRunInput {
   cacheDir?: string;
   maxLogBytes: number;
   options: SandboxProcessOptions;
+  signal?: AbortSignal;
 }
 
 /**
@@ -198,6 +199,7 @@ export async function runSandboxCommand(
   redactPaths: string[],
   cacheDir?: string,
   executionOptions: SandboxExecutionOptions = {},
+  signal?: AbortSignal,
 ): Promise<ReproductionCommandResult> {
   const cwd = command.cwd ? await resolveWorkspacePathForRead(workspaceAbsolute, command.cwd) : workspaceAbsolute;
   const started = Date.now();
@@ -218,6 +220,7 @@ export async function runSandboxCommand(
     ...(cacheDir ? { cacheDir } : {}),
     maxLogBytes,
     options,
+    ...(signal ? { signal } : {}),
   });
   await persistSandboxToolCaches(workspaceAbsolute, cacheDir);
 
@@ -460,6 +463,7 @@ async function runHostSandboxProcess(input: ProcessRunInput): Promise<{ stdout: 
     env: sandboxEnv(input.workspaceAbsolute, input.tmpDir, input.cacheDir, input.command, input.options.network),
     timeoutMs: input.command.timeoutMs ?? 120_000,
     maxLogBytes: input.maxLogBytes,
+    ...(input.signal ? { signal: input.signal } : {}),
   });
 }
 
@@ -515,7 +519,9 @@ async function runOciSandboxProcess(input: ProcessRunInput): Promise<{ stdout: s
     timeoutMs: input.command.timeoutMs ?? 120_000,
     maxLogBytes: input.maxLogBytes,
     onTimeout: cleanupTimedOutContainer,
+    onAbort: cleanupTimedOutContainer,
     timeoutKillDelayMs: 250,
+    ...(input.signal ? { signal: input.signal } : {}),
   });
   if (result.timedOut) cleanupTimedOutContainer();
   return result;
@@ -566,8 +572,9 @@ async function runAppleContainerSandboxProcess(input: ProcessRunInput): Promise<
     env: containerClientEnv(),
     timeoutMs: input.command.timeoutMs ?? 120_000,
     maxLogBytes: input.maxLogBytes,
+    ...(input.signal ? { signal: input.signal } : {}),
   });
-  if (result.timedOut) {
+  if (result.timedOut || result.aborted) {
     // The Apple CLI may still be unwinding its `container run` XPC session when
     // the timeout fires. Deleting concurrently races that session and can leave
     // the per-container VM running indefinitely, so wait for the client process
@@ -584,19 +591,23 @@ async function runAppleContainerSandboxProcess(input: ProcessRunInput): Promise<
   return result;
 }
 
-async function runSpawnedProcess(input: { program: string; args: string[]; cwd: string; env: NodeJS.ProcessEnv; timeoutMs: number; maxLogBytes: number; onTimeout?: () => void; timeoutKillDelayMs?: number }): Promise<{ stdout: string; stderr: string; exitCode: number | null; timedOut: boolean }> {
+async function runSpawnedProcess(input: { program: string; args: string[]; cwd: string; env: NodeJS.ProcessEnv; timeoutMs: number; maxLogBytes: number; onTimeout?: () => void; onAbort?: () => void; timeoutKillDelayMs?: number; signal?: AbortSignal }): Promise<{ stdout: string; stderr: string; exitCode: number | null; timedOut: boolean; aborted: boolean }> {
   let stdout = "";
   let stderr = "";
   let timedOut = false;
+  let aborted = false;
   let exitCode: number | null = null;
   let terminateTimer: ReturnType<typeof setTimeout> | undefined;
   let killTimer: ReturnType<typeof setTimeout> | undefined;
+  let terminationStarted = false;
   const child = spawn(input.program, input.args, {
     cwd: input.cwd,
     shell: false,
     env: input.env,
   });
   const terminateChild = (): void => {
+    if (terminationStarted) return;
+    terminationStarted = true;
     child.kill("SIGTERM");
     killTimer = setTimeout(() => {
       if (exitCode === null) child.kill("SIGKILL");
@@ -613,6 +624,18 @@ async function runSpawnedProcess(input: { program: string; args: string[]; cwd: 
     if (delay > 0) terminateTimer = setTimeout(terminateChild, delay);
     else terminateChild();
   }, input.timeoutMs);
+  const abortChild = (): void => {
+    if (exitCode !== null || aborted) return;
+    aborted = true;
+    try {
+      input.onAbort?.();
+    } catch (error) {
+      stderr = appendLimited(stderr, error instanceof Error ? error.message : String(error), input.maxLogBytes);
+    }
+    terminateChild();
+  };
+  if (input.signal?.aborted) abortChild();
+  else input.signal?.addEventListener("abort", abortChild, { once: true });
 
   child.stdout?.on("data", (chunk) => {
     stdout = appendLimited(stdout, String(chunk), input.maxLogBytes);
@@ -632,9 +655,10 @@ async function runSpawnedProcess(input: { program: string; args: string[]; cwd: 
     });
   });
   clearTimeout(timer);
+  input.signal?.removeEventListener("abort", abortChild);
   if (terminateTimer) clearTimeout(terminateTimer);
   if (killTimer) clearTimeout(killTimer);
-  return { stdout, stderr, exitCode, timedOut };
+  return { stdout, stderr, exitCode, timedOut, aborted };
 }
 
 /** Case-insensitive literal success-pattern match against combined command output. */

--- a/tests/sandbox.test.mjs
+++ b/tests/sandbox.test.mjs
@@ -540,6 +540,39 @@ test("sandbox Apple container backend force-deletes timed-out containers", async
   }
 });
 
+test("sandbox Apple container backend force-deletes containers when a run is stopped", async () => {
+  const workspace = await tempDir("flounder-sandbox-apple-abort-");
+  const logDir = await tempDir("flounder-sandbox-apple-abort-log-");
+  const logFile = path.join(logDir, "container.log");
+  const fakeBin = await fakeContainerCli({ logFile, runSleepSeconds: 30 });
+  const oldPath = process.env.PATH;
+  const controller = new AbortController();
+  try {
+    process.env.PATH = `${fakeBin}${path.delimiter}${oldPath ?? ""}`;
+    setTimeout(() => controller.abort(), 100);
+    const startedAt = Date.now();
+    const result = await runSandboxCommand(
+      { program: "node", args: ["--test"], timeoutMs: 2_000 },
+      workspace,
+      8000,
+      [],
+      undefined,
+      { backend: "apple-container", image: "flounder-sandbox:abort", network: "enabled" },
+      controller.signal,
+    );
+
+    assert.equal(result.timedOut, false);
+    assert.ok(Date.now() - startedAt < 5_000, "stop should not wait for the command timeout");
+    const cleanupLog = await waitForFileMatch(logFile, /DELETE:flounder-[^\n]+/);
+    assert.equal(cleanupLog.match(/DELETE:flounder-/g)?.length, 1);
+  } finally {
+    process.env.PATH = oldPath;
+    await rm(workspace, { recursive: true, force: true });
+    await rm(logDir, { recursive: true, force: true });
+    await rm(fakeBin, { recursive: true, force: true });
+  }
+});
+
 test("sandbox host backend is explicit and still uses isolated HOME and caches", async () => {
   const workspace = await tempDir("flounder-sandbox-host-");
   const cache = await tempDir("flounder-sandbox-cache-");


### PR DESCRIPTION
## Summary

- thread the run cancellation signal through pi sessions, toolchain preparation, and sandbox commands
- terminate active sandbox client processes when an operator stops a run
- force-delete OCI and Apple containers after cancellation so stopped runs do not leave executors busy
- cover Apple container cancellation with a regression test

## Root cause

Stopping a daemon run aborted the model session, but an active sandbox command did not receive that cancellation signal. The Apple container CLI could therefore keep its per-command VM alive until the command timeout, leaving the executor occupied after the run was already marked killed.

## Verification

- `npm run build`
- `node --test --test-name-pattern='force-deletes containers when a run is stopped|force-deletes timed-out containers' tests/sandbox.test.mjs`
- `node --test --test-concurrency=1 tests/*.test.mjs` (477 passed)
- `npm run check:public`
