### PR TITLE
Scale Apple sandbox memory to the host

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1337,7 +1337,7 @@ Shared options:
   --allow-host-execution  trusted-local opt-in only: let auto fall back to host execution when no sandbox backend is available
   --prepare-network <m>   none|enabled; dependency warm-up/build commands default to enabled
   --confirm-network <m>   none|enabled; open-world prepare/confirm bash commands default to enabled
-  --sandbox-memory-mb <n> memory limit for OCI sandbox commands
+  --sandbox-memory-mb <n> memory limit for container sandbox commands
   --sandbox-cpus <n>      CPU limit for OCI sandbox commands
   --no-refute / --no-appeal  skip the independent-refutation / one-appeal passes on confirmed findings
   --server <url>          control plane the CLI drives (default --server > FLOUNDER_SERVER > config 'server' > http://127.0.0.1:4500)

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -176,7 +176,7 @@ const sharedParams = {
   sandboxAllowHostFallback: Type.Optional(Type.Boolean({ description: "Trusted-local opt-in for host fallback when OCI is unavailable." })),
   sandboxPrepareNetwork: Type.Optional(Type.String({ description: "none|enabled for prepare/build warm-up commands." })),
   sandboxConfirmNetwork: Type.Optional(Type.String({ description: "none|enabled for open-world confirm commands." })),
-  sandboxMemoryMb: Type.Optional(Type.Number({ description: "Memory limit for OCI sandbox commands." })),
+  sandboxMemoryMb: Type.Optional(Type.Number({ description: "Memory limit for container sandbox commands." })),
   sandboxCpus: Type.Optional(Type.Number({ description: "CPU limit for OCI sandbox commands." })),
 };
 

--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { copyFile, lstat, mkdir, open, readdir, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
+import { totalmem } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { analyzeReproductionCommandSafety } from "./policy.js";
@@ -28,6 +29,8 @@ export const DEFAULT_SANDBOX_IMAGE = "flounder-sandbox:latest";
 const APPLE_CONTAINER_SEALED_NETWORK = "flounder-sealed";
 const APPLE_CONTAINER_NETWORK_DNS = ["1.1.1.1", "8.8.8.8"] as const;
 const CACHE_TEMP_PREFIX = ".flounder-cache-";
+const APPLE_CONTAINER_DEFAULT_MEMORY_CAP_MB = 8192;
+const APPLE_CONTAINER_DEFAULT_MEMORY_FLOOR_MB = 1024;
 
 export interface SandboxExecutionOptions {
   backend?: SandboxBackend;
@@ -307,6 +310,20 @@ export function autoPrefersAppleContainer(platform = process.platform, arch = pr
   return platform === "darwin" && arch === "arm64";
 }
 
+/**
+ * Apple container otherwise defaults each Linux VM to 1 GiB, which is too small
+ * to link many real Rust/Solana test targets. Reserve one quarter of host memory
+ * for a command, bounded so concurrent audit streams remain practical.
+ */
+export function defaultAppleContainerMemoryMb(hostMemoryBytes = totalmem()): number {
+  const hostMemoryMb = Math.floor(hostMemoryBytes / (1024 * 1024));
+  if (!Number.isFinite(hostMemoryMb) || hostMemoryMb <= 0) return APPLE_CONTAINER_DEFAULT_MEMORY_FLOOR_MB;
+  return Math.max(
+    APPLE_CONTAINER_DEFAULT_MEMORY_FLOOR_MB,
+    Math.min(APPLE_CONTAINER_DEFAULT_MEMORY_CAP_MB, Math.floor(hostMemoryMb / 4)),
+  );
+}
+
 export async function checkSandboxReadiness(input: SandboxExecutionOptions = {}): Promise<SandboxReadiness> {
   const options = normalizeSandboxExecutionOptions(input);
   if (options.backend === "host") {
@@ -553,7 +570,8 @@ async function runAppleContainerSandboxProcess(input: ProcessRunInput): Promise<
   if (typeof process.getuid === "function" && typeof process.getgid === "function") {
     containerArgs.push("--user", `${process.getuid()}:${process.getgid()}`);
   }
-  if (input.options.memoryMb !== undefined) containerArgs.push("--memory", `${Math.max(64, Math.floor(input.options.memoryMb))}M`);
+  const memoryMb = input.options.memoryMb ?? defaultAppleContainerMemoryMb();
+  containerArgs.push("--memory", `${Math.max(64, Math.floor(memoryMb))}M`);
   if (input.options.cpus !== undefined) containerArgs.push("--cpus", String(Math.max(0.1, input.options.cpus)));
   for (const [key, value] of Object.entries(sandboxEnv("/workspace", "/workspace/.tmp", input.cacheDir ? "/cache" : undefined, input.command, input.options.network))) {
     if (value !== undefined) containerArgs.push("--env", `${key}=${value}`);

--- a/tests/sandbox.test.mjs
+++ b/tests/sandbox.test.mjs
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { defaultConfig, sandboxExecutionOptions, sandboxNetworkForPurpose } from "../dist/config.js";
-import { autoPrefersAppleContainer, checkSandboxReadiness, clearSandboxAvailabilityCache, compactSandboxWorkspace, runSandboxCommand, sandboxToolPath } from "../dist/security/sandbox.js";
+import { autoPrefersAppleContainer, checkSandboxReadiness, clearSandboxAvailabilityCache, compactSandboxWorkspace, defaultAppleContainerMemoryMb, runSandboxCommand, sandboxToolPath } from "../dist/security/sandbox.js";
 
 async function tempDir(prefix) {
   return mkdtemp(path.join(os.tmpdir(), prefix));
@@ -246,6 +246,13 @@ test("sandbox auto preference is limited to Apple silicon macOS", () => {
   assert.equal(autoPrefersAppleContainer("darwin", "arm64"), true);
   assert.equal(autoPrefersAppleContainer("darwin", "x64"), false);
   assert.equal(autoPrefersAppleContainer("linux", "arm64"), false);
+});
+
+test("Apple container memory defaults scale with the host and remain bounded", () => {
+  const gib = 1024 ** 3;
+  assert.equal(defaultAppleContainerMemoryMb(4 * gib), 1024);
+  assert.equal(defaultAppleContainerMemoryMb(16 * gib), 4096);
+  assert.equal(defaultAppleContainerMemoryMb(64 * gib), 8192);
 });
 
 test("sandbox refuses implicit host fallback when the OCI image is unavailable", async () => {
@@ -502,6 +509,7 @@ test("sandbox Apple container backend pins DNS only for network-enabled runs", a
     assert.equal(result.exitCode, 0);
     assert.match(result.stdout, /\[--dns\]\[1\.1\.1\.1\]/);
     assert.match(result.stdout, /\[--dns\]\[8\.8\.8\.8\]/);
+    assert.match(result.stdout, new RegExp(`\\[--memory\\]\\[${defaultAppleContainerMemoryMb()}M\\]`));
     assert.doesNotMatch(result.stdout, /\[--no-dns\]/);
     assert.doesNotMatch(result.stdout, /\[--network\]\[flounder-sealed\]/);
     assert.match(result.stdout, /\[flounder-sandbox:cairo\]\[scarb\]\[build\]/);


### PR DESCRIPTION
## Summary

- give Apple container commands a host-aware memory default instead of the runtime's fixed 1 GiB VM default
- reserve one quarter of host memory per command, bounded from 1 GiB to 8 GiB so concurrent audit streams remain practical
- preserve explicit `--sandbox-memory-mb` overrides
- describe the memory option accurately for all container sandbox backends

## Root cause

Large Rust and Solana confirmation targets could compile successfully and then fail at the final link with `ld terminated with signal 9 [Killed]`. The Apple container runtime was starting every unspecified sandbox command with only 1 GiB, even on a host with enough memory. This appeared to users as an unexplained target build failure.

## Verification

- `npm run build`
- focused Apple container memory and option-mapping tests (3 passed)
- `node --test --test-concurrency=1 tests/*.test.mjs` (477 passed)
- `npm run check:public`
