### PR TITLE
Preserve sandbox image toolchain paths

### DIFF
--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -558,7 +558,7 @@ async function runOciSandboxProcess(input: ProcessRunInput): Promise<{ stdout: s
   }
   if (input.options.memoryMb !== undefined) dockerArgs.push("--memory", `${Math.max(64, Math.floor(input.options.memoryMb))}m`);
   if (input.options.cpus !== undefined) dockerArgs.push("--cpus", String(Math.max(0.1, input.options.cpus)));
-  for (const [key, value] of Object.entries(sandboxEnv("/workspace", "/workspace/.tmp", input.cacheDir ? "/cache" : undefined, input.command, input.options.network))) {
+  for (const [key, value] of Object.entries(containerSandboxEnv("/workspace", "/workspace/.tmp", input.cacheDir ? "/cache" : undefined, input.command, input.options.network))) {
     if (value !== undefined) dockerArgs.push("--env", `${key}=${value}`);
   }
   dockerArgs.push(input.options.image, input.command.program, ...input.command.args);
@@ -619,7 +619,7 @@ async function runAppleContainerSandboxProcess(input: ProcessRunInput): Promise<
   const memoryMb = input.options.memoryMb ?? defaultAppleContainerMemoryMb();
   containerArgs.push("--memory", `${Math.max(64, Math.floor(memoryMb))}M`);
   if (input.options.cpus !== undefined) containerArgs.push("--cpus", String(Math.max(0.1, input.options.cpus)));
-  for (const [key, value] of Object.entries(sandboxEnv("/workspace", "/workspace/.tmp", input.cacheDir ? "/cache" : undefined, input.command, input.options.network))) {
+  for (const [key, value] of Object.entries(containerSandboxEnv("/workspace", "/workspace/.tmp", input.cacheDir ? "/cache" : undefined, input.command, input.options.network))) {
     if (value !== undefined) containerArgs.push("--env", `${key}=${value}`);
   }
   containerArgs.push(input.options.image, input.command.program, ...input.command.args);
@@ -1502,6 +1502,14 @@ function sandboxEnv(workspace: string, tmpDir: string, cacheDir?: string, comman
   }
   if (process.env.LANG !== undefined) out.LANG = process.env.LANG;
   if (process.env.LC_ALL !== undefined) out.LC_ALL = process.env.LC_ALL;
+  return out;
+}
+
+function containerSandboxEnv(workspace: string, tmpDir: string, cacheDir?: string, command?: ReproductionCommand, network: SandboxNetworkMode = "none"): NodeJS.ProcessEnv {
+  const out = sandboxEnv(workspace, tmpDir, cacheDir, command, network);
+  // Container images own their toolchain PATH. Injecting the daemon host's PATH
+  // can select unrelated distro binaries ahead of a pinned image toolchain.
+  delete out.PATH;
   return out;
 }
 

--- a/tests/sandbox.test.mjs
+++ b/tests/sandbox.test.mjs
@@ -442,6 +442,7 @@ test("sandbox auto prefers Apple container on Apple silicon when the backend is 
       assert.equal(result.exitCode, 0);
       assert.match(result.stdout, /^ARGS:/);
       assert.match(result.stdout, /\[--network\]\[flounder-sealed\]\[--no-dns\]/);
+      assert.doesNotMatch(result.stdout, /\[--env\]\[PATH=/, "container runs must preserve the image-defined PATH");
       assert.match(result.stdout, /\[flounder-sandbox:auto-apple\]\[node\]\[--test\]/);
     });
   } finally {
@@ -477,6 +478,7 @@ test("sandbox auto falls back to Docker on Apple silicon when Apple sealed netwo
       assert.equal(result.exitCode, 0);
       assert.match(result.stdout, /^DOCKER_ARGS:/);
       assert.match(result.stdout, /\[--network\]\[none\]/);
+      assert.doesNotMatch(result.stdout, /\[--env\]\[PATH=/, "container runs must preserve the image-defined PATH");
       assert.match(result.stdout, /\[flounder-sandbox:auto-docker\]\[node\]\[--test\]/);
     });
   } finally {
@@ -520,6 +522,7 @@ test("sandbox Apple container backend maps Flounder isolation options to contain
     assert.match(result.stdout, /\[--env\]\[HOME=\/workspace\]/);
     assert.match(result.stdout, /\[--env\]\[SCARB_CACHE=\/cache\/scarb-cache\]/);
     assert.match(result.stdout, /\[--env\]\[YARN_GLOBAL_FOLDER=\/cache\/yarn-berry\]/);
+    assert.doesNotMatch(result.stdout, /\[--env\]\[PATH=/, "container runs must preserve the image-defined PATH");
     assert.match(result.stdout, /\[flounder-sandbox:latest\]\[node\]\[--test\]/);
   } finally {
     process.env.PATH = oldPath;


### PR DESCRIPTION
## What changed

- Preserve each OCI or Apple container image's own `PATH` instead of injecting the daemon host's `PATH`.
- Keep host-backend tool discovery unchanged.
- Add regression coverage for explicit Apple container execution, automatic Apple selection, and automatic Docker fallback.

## Why

Flounder was correctly selecting a target-specific Rust 1.86 sandbox image, but then overwrote its `PATH` with the daemon host's directory order. When `/usr/bin` appeared before `/usr/local/bin`, the container executed Debian's Rust 1.75 binaries instead of the image's pinned Rust 1.86 toolchain. Toolchain preflight then blocked otherwise valid confirmations.

Container images now retain the toolchain path they define and validate at build time.

## Impact

Target-specific sandbox images reliably expose their pinned compilers and package managers. This removes host-dependent toolchain drift for both Apple container and Docker-backed OCI runs without weakening sandbox isolation or changing host execution behavior.

## Validation

- `npm run check`
- `npm test`
- `npm run check:public`
- `node --test tests/sandbox.test.mjs` (30/30)
- End-to-end `runSandboxCommand` against `flounder-sandbox:rust-1.86.0` returned `rustc 1.86.0`
- Control reproduction with a host-style `PATH` returned Rust 1.75 before the fix
