### PR TITLE
Reject control-plane protocol drift

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -25,6 +25,7 @@ import { type LaunchSpec, ActivityBus, type Activity, type ReportFindingSpec, ty
 import { THINKING_LEVELS } from "../config.js";
 import { projectHistoryDir } from "../trace/history.js";
 import { positiveIntegerId } from "../util/ids.js";
+import { DAEMON_PROTOCOL_VERSION } from "./protocol.js";
 import { loadScopeInventory, saveScopeInventory } from "../agent/scope-store.js";
 import { deriveScopeNote } from "../scope-note.js";
 import { confirmSelectorsForFinding } from "../util/confirm-selector.js";
@@ -4939,9 +4940,15 @@ function authorizedDaemonOwnedRun(c: Ctx, daemon: Record<string, unknown>, runId
 async function daemonRegister(c: Ctx): Promise<void> {
   const daemon = daemonAuth(c);
   if (!daemon) return;
-  const body = (await readBody(c.req)) as { name?: string; capabilities?: unknown; workspace?: string };
+  const body = (await readBody(c.req)) as { name?: string; protocolVersion?: unknown; capabilities?: unknown; workspace?: string };
+  if (body.protocolVersion !== DAEMON_PROTOCOL_VERSION) {
+    return sendJson(c.res, 409, {
+      error: `daemon protocol mismatch: server requires ${DAEMON_PROTOCOL_VERSION}, daemon reported ${String(body.protocolVersion ?? "missing")}`,
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+    });
+  }
   c.store.touchDaemon(Number(daemon.id), body.capabilities, body.workspace);
-  sendJson(c.res, 200, { ok: true, daemonId: Number(daemon.id), name: daemon.name });
+  sendJson(c.res, 200, { ok: true, daemonId: Number(daemon.id), name: daemon.name, protocolVersion: DAEMON_PROTOCOL_VERSION });
 }
 
 async function daemonHeartbeat(c: Ctx): Promise<void> {

--- a/src/server/daemon.ts
+++ b/src/server/daemon.ts
@@ -24,6 +24,7 @@ import { assertProviderAuthenticated, knownRuntimeProviders, providerAuthStatus 
 import { buildDefaultSandboxImage, checkSandboxReadiness, DEFAULT_SANDBOX_IMAGE, isDefaultSandboxImage, sandboxToolPath, type SandboxImageBuildResult, type SandboxReadiness } from "../security/sandbox.js";
 import { RunLogger } from "../trace/logger.js";
 import { positiveIntegerId } from "../util/ids.js";
+import { DAEMON_PROTOCOL_VERSION } from "./protocol.js";
 
 export interface DaemonOptions {
   server: string;
@@ -53,8 +54,12 @@ export async function runDaemon(opts: DaemonOptions): Promise<void> {
     void post(base, headers, "/api/daemon/heartbeat", { instanceId, activeJobIds: [...inflight.keys()] });
   };
 
-  const reg = await fetch(base + "/api/daemon/register", { method: "POST", headers, body: JSON.stringify({ name: opts.name ?? "daemon", capabilities: await daemonCapabilities(), workspace }) }).catch(() => null);
+  const reg = await fetch(base + "/api/daemon/register", { method: "POST", headers, body: JSON.stringify({ name: opts.name ?? "daemon", protocolVersion: DAEMON_PROTOCOL_VERSION, capabilities: await daemonCapabilities(), workspace }) }).catch(() => null);
   if (!reg || !reg.ok) throw new Error(`daemon: could not register with ${base} (status ${reg ? reg.status : "no response"}) — check --server and --token`);
+  const registration = (await reg.json().catch(() => ({}))) as { protocolVersion?: unknown };
+  if (registration.protocolVersion !== DAEMON_PROTOCOL_VERSION) {
+    throw new Error(`daemon: control-plane protocol mismatch (daemon=${DAEMON_PROTOCOL_VERSION}, server=${String(registration.protocolVersion ?? "missing")}) — update and restart both the server and daemon from the same Flounder release`);
+  }
   console.log(`[flounder daemon] connected to ${base}  (out=${out}, workspace=${workspace}, concurrency=${maxConcurrent})`);
   // Historical terminal artifacts live on the executor, not the control plane.
   // Replay them best-effort after registration; failures never block new work and

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1,0 +1,4 @@
+// Version the control-plane <-> execution-plane contract independently from the
+// package release. Increment this whenever a daemon could otherwise accept a job
+// whose meaning or required fields differ across server and daemon versions.
+export const DAEMON_PROTOCOL_VERSION = 1;

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -7,6 +7,7 @@ import { startUiServer } from "../dist/server/app.js";
 import { MetadataStore } from "../dist/db/store.js";
 import { loadScopeInventory, saveScopeInventory } from "../dist/agent/scope-store.js";
 import { projectHistoryDir } from "../dist/trace/history.js";
+import { DAEMON_PROTOCOL_VERSION } from "../dist/server/protocol.js";
 
 // The whole workflow is a REST API an agent can self-learn (GET /api) and drive without
 // the UI. This pins the catalog + a project CRUD round-trip over real HTTP.
@@ -5301,6 +5302,7 @@ test("api: daemon lists return provider-auth summaries by default", async () => 
       method: "POST",
       headers: { "content-type": "application/json", authorization: `Bearer ${created.token}` },
       body: JSON.stringify({
+        protocolVersion: DAEMON_PROTOCOL_VERSION,
         workspace: "/tmp/flounder-worker",
         capabilities: {
           providers: [

--- a/tests/daemon-flow.test.mjs
+++ b/tests/daemon-flow.test.mjs
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 import { startUiServer } from "../dist/server/app.js";
 import { daemonJobTerminalState, ensureDaemonDirectories, loadVerifyArtifactReplay } from "../dist/server/daemon.js";
 import { MetadataStore } from "../dist/db/store.js";
+import { DAEMON_PROTOCOL_VERSION } from "../dist/server/protocol.js";
 
 const execFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "..");
@@ -48,8 +49,12 @@ async function withServer(out, fn) {
 
 const j = (r) => r.json();
 const ui = (base, method, p, body) => fetch(base + p, { method, ...(body ? { headers: { "content-type": "application/json" }, body: JSON.stringify(body) } : {}) });
-const asDaemon = (base, token, method, p, body) =>
-  fetch(base + p, { method, headers: { authorization: `Bearer ${token}`, ...(body ? { "content-type": "application/json" } : {}) }, ...(body ? { body: JSON.stringify(body) } : {}) });
+const asDaemon = (base, token, method, p, body) => {
+  const requestBody = p === "/api/daemon/register" && body
+    ? { ...body, protocolVersion: DAEMON_PROTOCOL_VERSION }
+    : body;
+  return fetch(base + p, { method, headers: { authorization: `Bearer ${token}`, ...(requestBody ? { "content-type": "application/json" } : {}) }, ...(requestBody ? { body: JSON.stringify(requestBody) } : {}) });
+};
 
 test("daemon: job terminal state reflects every persisted run phase", () => {
   assert.equal(daemonJobTerminalState(["done"]), "done");
@@ -307,6 +312,28 @@ test("daemon: register requires a valid bearer token", async () => {
     assert.equal((await j(ok)).ok, true);
     // claim/run/activity/status all reject an unknown token too
     assert.equal((await fetch(base + "/api/daemon/claim", { method: "POST" })).status, 401);
+  });
+});
+
+test("daemon: register rejects control-plane protocol drift", async () => {
+  await withServerAndToken(async ({ base, token }) => {
+    const register = (protocolVersion) => fetch(base + "/api/daemon/register", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ name: "versioned", ...(protocolVersion === undefined ? {} : { protocolVersion }), capabilities: {} }),
+    });
+
+    const missing = await register(undefined);
+    assert.equal(missing.status, 409);
+    assert.match((await j(missing)).error, /reported missing/);
+
+    const stale = await register(DAEMON_PROTOCOL_VERSION - 1);
+    assert.equal(stale.status, 409);
+    assert.match((await j(stale)).error, /protocol mismatch/);
+
+    const current = await register(DAEMON_PROTOCOL_VERSION);
+    assert.equal(current.status, 200);
+    assert.equal((await j(current)).protocolVersion, DAEMON_PROTOCOL_VERSION);
   });
 });
 

--- a/tests/harness-experiments-api.test.mjs
+++ b/tests/harness-experiments-api.test.mjs
@@ -4,12 +4,13 @@ import { mkdtemp } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { startUiServer } from "../dist/server/app.js";
+import { DAEMON_PROTOCOL_VERSION } from "../dist/server/protocol.js";
 
 const json = (response) => response.json();
 const request = (base, method, route, body, token) => fetch(base + route, {
   method,
   headers: { "content-type": "application/json", ...(token ? { authorization: `Bearer ${token}` } : {}) },
-  ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  ...(body !== undefined ? { body: JSON.stringify(route === "/api/daemon/register" ? { ...body, protocolVersion: DAEMON_PROTOCOL_VERSION } : body) } : {}),
 });
 
 function item(itemKey, expectedOutcome) {

--- a/tests/run-groups-api.test.mjs
+++ b/tests/run-groups-api.test.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { startUiServer } from "../dist/server/app.js";
 import { MetadataStore } from "../dist/db/store.js";
+import { DAEMON_PROTOCOL_VERSION } from "../dist/server/protocol.js";
 
 async function withServer(fn) {
   const out = await mkdtemp(path.join(os.tmpdir(), "flounder-run-groups-"));
@@ -22,7 +23,7 @@ const json = (response) => response.json();
 const request = (base, method, route, body, token) => fetch(base + route, {
   method,
   headers: { "content-type": "application/json", ...(token ? { authorization: `Bearer ${token}` } : {}) },
-  ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  ...(body !== undefined ? { body: JSON.stringify(route === "/api/daemon/register" ? { ...body, protocolVersion: DAEMON_PROTOCOL_VERSION } : body) } : {}),
 });
 
 function item(itemKey, expectedOutcome, target) {


### PR DESCRIPTION
## Summary

- version the control-plane to daemon job contract
- reject missing or mismatched protocol versions during daemon registration
- make new daemons reject old control planes that do not acknowledge the protocol version

This prevents mixed-version deployments from silently dropping newer job fields such as configured engagement context.

## Verification

- npm run check
- Node 24: daemon-flow.test.mjs (20/20)
- Node 24: run-groups-api.test.mjs (4/4)
- Node 24: harness-experiments-api.test.mjs (1/1)
- Node 24: targeted daemon-list API test
- npm run check:public

Node 25.8.1 currently crashes in the unchanged baseline with a native InternalCallbackScope assertion; the same tests pass on Node 24.13.0.