### PR TITLE
fix(sandbox): guard generated files by capability

### DIFF
--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -184,9 +184,6 @@ export function analyzeSandboxFileSafety(file: ReproductionFile): string | undef
   if (/\b(?:PRIVATE_KEY|MNEMONIC|SECRET|TOKEN|ALCHEMY|INFURA|QUICKNODE|MORALIS|ETHERSCAN|RPC_URL)\b/.test(content)) {
     return `Blocked by flounder guardrail: generated test file ${file.path} must not read secret or RPC environment variables.`;
   }
-  if (/\b(?:sendRawTransaction|broadcast|transferFrom|withdraw|drain)\b/i.test(content) && /\b(?:mainnet|testnet|public\s+rpc|production)\b/i.test(content)) {
-    return `Blocked by flounder guardrail: generated test file ${file.path} combines live-network and value-moving terms.`;
-  }
   return undefined;
 }
 

--- a/tests/sandbox.test.mjs
+++ b/tests/sandbox.test.mjs
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { defaultConfig, sandboxExecutionOptions, sandboxNetworkForPurpose } from "../dist/config.js";
-import { autoPrefersAppleContainer, checkSandboxReadiness, clearSandboxAvailabilityCache, compactSandboxWorkspace, DEFAULT_SANDBOX_BUILD_MIN_FREE_DISK_MB, defaultAppleContainerMemoryMb, runSandboxCommand, sandboxMinFreeDiskMb, sandboxToolPath } from "../dist/security/sandbox.js";
+import { analyzeSandboxFileSafety, autoPrefersAppleContainer, checkSandboxReadiness, clearSandboxAvailabilityCache, compactSandboxWorkspace, DEFAULT_SANDBOX_BUILD_MIN_FREE_DISK_MB, defaultAppleContainerMemoryMb, runSandboxCommand, sandboxMinFreeDiskMb, sandboxToolPath } from "../dist/security/sandbox.js";
 
 async function tempDir(prefix) {
   return mkdtemp(path.join(os.tmpdir(), prefix));
@@ -42,6 +42,26 @@ test("completed sandbox workspaces discard rebuildable output but retain source 
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }
+});
+
+test("sandbox file safety blocks capabilities instead of audit vocabulary", () => {
+  assert.equal(analyzeSandboxFileSafety({
+    path: "tests/local_withdraw.rs",
+    content: "// Reproduce the published mainnet artifact locally.\n#[test] fn withdraw_before_cancel() {}\nconst RPC: &str = \"http://127.0.0.1:8899\";\n",
+  }), undefined);
+
+  assert.match(analyzeSandboxFileSafety({
+    path: "tests/remote.ts",
+    content: "fetch('https://rpc.example.test/mainnet');\n",
+  }), /must not reference remote URLs/);
+  assert.match(analyzeSandboxFileSafety({
+    path: "tests/process.ts",
+    content: "import { execSync } from 'node:child_process';\n",
+  }), /must not spawn subprocesses/);
+  assert.match(analyzeSandboxFileSafety({
+    path: "tests/secret.ts",
+    content: "const rpc = process.env.RPC_URL;\n",
+  }), /must not read secret or RPC environment variables/);
 });
 
 function truncatedElf64() {


### PR DESCRIPTION
## Summary

- remove the prose-only live-network/value-moving keyword conjunction from generated-file safety checks
- continue blocking actual remote URLs, subprocess creation, and secret/RPC environment access
- cover safe local PoCs that mention published mainnet artifacts and withdrawal behavior

## Why

A local-only Solana ProgramTest confirmation was rejected because its source mentioned both a mainnet artifact and a withdraw instruction. Renaming audit evidence to evade vocabulary filters is not a security boundary. Flounder should enforce capabilities at the generated-file and command layers.

## Verification

- npm run check
- npm run check:public
- Node 24.13.0: node --test tests/sandbox.test.mjs (31/31 passed)