### PR TITLE
fix(storage): compact inspection workspaces

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile } from "node:fs/promises";
+import { mkdir, readFile, rm } from "node:fs/promises";
 import path from "node:path";
 import { sandboxExecutionOptions, sandboxNetworkForPurpose, type AuditorConfig } from "../config.js";
 import { analyzeAgentBashCommandSafety, analyzeConfirmBashCommandSafety, isAgentBuildCommand, isAgentConfirmCommand, isAgentInspectionCommand, isAgentWorkspaceSetupCommand, openWorldCommandNeedsNetwork } from "../security/policy.js";
@@ -400,15 +400,30 @@ const bashTool: AgentTool = {
     const commandWorkspace = sourceReadBoundaryActive(ctx) && isAgentInspectionCommand(normalized.command)
       ? await prepareInspectionWorkspace(ctx, workspace, runId)
       : workspace;
-    const result = await runSandboxCommand(
-      normalized.command,
-      commandWorkspace.absolute,
-      ctx.cfg.reproductionMaxLogBytes,
-      ctx.cfg.sourcePaths,
-      ctx.session.buildCacheDir,
-      sandboxExecutionOptions(ctx.cfg, commandNetwork),
-      ctx.signal,
-    );
+    let result: ReproductionCommandResult;
+    try {
+      result = await runSandboxCommand(
+        normalized.command,
+        commandWorkspace.absolute,
+        ctx.cfg.reproductionMaxLogBytes,
+        ctx.cfg.sourcePaths,
+        ctx.session.buildCacheDir,
+        sandboxExecutionOptions(ctx.cfg, commandNetwork),
+        ctx.signal,
+      );
+    } finally {
+      if (commandWorkspace.absolute !== workspace.absolute) {
+        try {
+          await rm(commandWorkspace.absolute, { recursive: true, force: true });
+        } catch (error) {
+          await ctx.logger.event("audit_command_workspace_cleanup_failed", {
+            runId,
+            error: error instanceof Error ? error.message : String(error),
+            ...activityStreamMeta(ctx),
+          });
+        }
+      }
+    }
     const exitMatched = result.exitCode === result.expectedExitCode && !result.timedOut;
     const isConfirm = normalized.purpose === "confirm";
     const eligibleByType = isAgentConfirmCommand(normalized.command);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import { runDaemon } from "./server/daemon.js";
 import { isSandboxBackend } from "./security/sandbox.js";
 import { knownRuntimeProviders, loginProvider, printProviderCheck, providerAuthStatus } from "./provider-auth.js";
 import { absolutizeRunGroupManifest, normalizeRunGroupManifest } from "./evaluation/contracts.js";
+import { compactHistoricalInspectionWorkspaces, readStoredRunsForCompaction } from "./storage/compact.js";
 
 async function main(argv: string[]): Promise<void> {
   const [cmd, ...rest] = argv;
@@ -27,6 +28,11 @@ async function main(argv: string[]): Promise<void> {
 
   if (cmd === "history") {
     await runHistoryCommand(rest);
+    return;
+  }
+
+  if (cmd === "storage") {
+    await runStorageCommand(rest);
     return;
   }
 
@@ -1031,6 +1037,54 @@ async function runHistoryCommand(args: string[]): Promise<void> {
   console.log(`[history] runs=${manifest.aggregate.totalRuns} materials=${manifest.aggregate.materialsTotal} findings=${manifest.aggregate.findingsTotal}`);
 }
 
+async function runStorageCommand(args: string[]): Promise<void> {
+  const [subcommand, ...rest] = args;
+  if (subcommand === "help" || subcommand === "--help" || subcommand === "-h") {
+    printStorageHelp();
+    return;
+  }
+  if (subcommand !== "compact") {
+    throw new Error("Unknown storage command. Use: flounder storage compact [--apply] [--out <dir>]");
+  }
+  const out = resolveOut(rest);
+  const result = await compactHistoricalInspectionWorkspaces({
+    outputDir: out,
+    runs: readStoredRunsForCompaction(out),
+    apply: rest.includes("--apply"),
+  });
+  console.log(`[storage] mode=${result.apply ? "apply" : "dry-run"} terminal_runs=${result.terminalRunDirs} candidates=${result.candidateDirectories}`);
+  console.log(`[storage] reclaimable=${formatByteSize(result.reclaimableBytes)} removed=${formatByteSize(result.removedBytes)} (${result.removedDirectories} directories)`);
+  if (result.skippedRunningRunDirs > 0) console.log(`[storage] skipped_running=${result.skippedRunningRunDirs}`);
+  if (result.skippedUnsafeRunDirs > 0) console.log(`[storage] skipped_unsafe=${result.skippedUnsafeRunDirs}`);
+  if (result.missingRunDirs > 0) console.log(`[storage] missing_run_dirs=${result.missingRunDirs}`);
+  if (!result.apply && result.candidateDirectories > 0) {
+    console.log("[storage] No files removed. Review this preview, then re-run with --apply to remove only terminal per-command source views.");
+  }
+}
+
+function printStorageHelp(): void {
+  console.log(`flounder storage compact — reclaim historical per-command inspection copies.
+
+Usage:
+  flounder storage compact [--out <dir>]          preview reclaimable space (default)
+  flounder storage compact [--out <dir>] --apply  remove terminal-run inspection copies
+
+The command never touches running runs, report artifacts, transcripts, findings, or PoC files.
+It only removes paired *-source-view-cmdN directories created as disposable read-only input
+for one inspection command. Paths outside the configured output root and symlinks are skipped.`);
+}
+
+function formatByteSize(bytes: number): string {
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  let value = Math.max(0, bytes);
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(unit === 0 ? 0 : 2)} ${units[unit]}`;
+}
+
 // Read/write views over the control-plane server state. These are product resources, not
 // database commands: project inventory, global run history, global findings, daemon registry,
 // and daemon connection tokens.
@@ -1264,6 +1318,7 @@ Usage:
   flounder continue --project <uuid|name>                                         finish the stored project pipeline round (same as the UI Continue button)
   flounder group create|start|status|pause|cancel|retry|report                    durable evaluation, replay, and multi-target work groups
   flounder history import-run --target <name> --run <dir>
+  flounder storage compact [--apply]                                             preview or remove terminal per-command inspection copies
   flounder server project list                                                   list tracked projects
   flounder server run list [--project <name>]                                    list run history globally or for one project
   flounder server finding list [--project <name>] [--status <s>] [--tracking <s>] list findings globally or for one project

--- a/src/storage/compact.ts
+++ b/src/storage/compact.ts
@@ -1,0 +1,148 @@
+import "../db/sqlite-quiet.js";
+import { createRequire } from "node:module";
+import { lstat, readdir, rm } from "node:fs/promises";
+import path from "node:path";
+
+const { DatabaseSync } = createRequire(import.meta.url)("node:sqlite") as typeof import("node:sqlite");
+
+export interface StoredRunForCompaction {
+  run_dir?: unknown;
+  status?: unknown;
+}
+
+export interface InspectionWorkspaceCompactionResult {
+  apply: boolean;
+  terminalRunDirs: number;
+  candidateDirectories: number;
+  reclaimableBytes: number;
+  removedDirectories: number;
+  removedBytes: number;
+  skippedRunningRunDirs: number;
+  skippedUnsafeRunDirs: number;
+  missingRunDirs: number;
+}
+
+const INSPECTION_PHASE_DIRECTORIES = ["audit", "confirm", "report", "reproduction"] as const;
+const SOURCE_VIEW_SUFFIX = /-source-view-cmd[1-9]\d*$/;
+
+/** Read the compaction worklist without migrations, journal changes, or other DB writes. */
+export function readStoredRunsForCompaction(outputDir: string): StoredRunForCompaction[] {
+  const db = new DatabaseSync(path.join(outputDir, "flounder.db"), { readOnly: true, timeout: 5000 });
+  try {
+    return db.prepare("SELECT run_dir, status FROM run WHERE run_dir IS NOT NULL AND run_dir <> ''").all() as StoredRunForCompaction[];
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Find or remove historical per-command source views for terminal runs.
+ *
+ * These directories are read-only copies created solely to enforce a narrow
+ * source boundary for one inspection command. The command result is persisted
+ * elsewhere, so the copy is rebuildable and is not audit evidence. Running runs,
+ * paths outside the configured output root, symlinks, and unpaired lookalikes are
+ * never touched. Dry-run is the default at the CLI layer.
+ */
+export async function compactHistoricalInspectionWorkspaces(input: {
+  outputDir: string;
+  runs: StoredRunForCompaction[];
+  apply?: boolean;
+}): Promise<InspectionWorkspaceCompactionResult> {
+  const outputRoot = path.resolve(input.outputDir);
+  const statusesByDir = new Map<string, Set<string>>();
+  let skippedUnsafeRunDirs = 0;
+
+  for (const run of input.runs) {
+    if (typeof run.run_dir !== "string" || run.run_dir.trim() === "") continue;
+    const runDir = path.resolve(run.run_dir);
+    if (!isStrictDescendant(outputRoot, runDir)) {
+      skippedUnsafeRunDirs += 1;
+      continue;
+    }
+    const statuses = statusesByDir.get(runDir) ?? new Set<string>();
+    statuses.add(String(run.status ?? ""));
+    statusesByDir.set(runDir, statuses);
+  }
+
+  const result: InspectionWorkspaceCompactionResult = {
+    apply: input.apply === true,
+    terminalRunDirs: 0,
+    candidateDirectories: 0,
+    reclaimableBytes: 0,
+    removedDirectories: 0,
+    removedBytes: 0,
+    skippedRunningRunDirs: 0,
+    skippedUnsafeRunDirs,
+    missingRunDirs: 0,
+  };
+
+  for (const [runDir, statuses] of statusesByDir) {
+    if (statuses.has("running")) {
+      result.skippedRunningRunDirs += 1;
+      continue;
+    }
+    const runInfo = await safeLstat(runDir);
+    if (!runInfo) {
+      result.missingRunDirs += 1;
+      continue;
+    }
+    if (!runInfo.isDirectory() || runInfo.isSymbolicLink()) {
+      result.skippedUnsafeRunDirs += 1;
+      continue;
+    }
+    result.terminalRunDirs += 1;
+
+    for (const phase of INSPECTION_PHASE_DIRECTORIES) {
+      const phaseDir = path.join(runDir, phase);
+      let entries: import("node:fs").Dirent[];
+      try {
+        entries = await readdir(phaseDir, { withFileTypes: true });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw error;
+      }
+      for (const entry of entries) {
+        if (!entry.isDirectory() || !SOURCE_VIEW_SUFFIX.test(entry.name)) continue;
+        const baseName = entry.name.replace(SOURCE_VIEW_SUFFIX, "");
+        const baseInfo = await safeLstat(path.join(phaseDir, baseName));
+        if (!baseInfo?.isDirectory() || baseInfo.isSymbolicLink()) continue;
+
+        const candidate = path.join(phaseDir, entry.name);
+        const bytes = await treeSizeWithoutFollowingSymlinks(candidate);
+        result.candidateDirectories += 1;
+        result.reclaimableBytes += bytes;
+        if (input.apply === true) {
+          await rm(candidate, { recursive: true, force: true });
+          result.removedDirectories += 1;
+          result.removedBytes += bytes;
+        }
+      }
+    }
+  }
+  return result;
+}
+
+function isStrictDescendant(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative !== "" && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+async function safeLstat(target: string): Promise<import("node:fs").Stats | undefined> {
+  try {
+    return await lstat(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+async function treeSizeWithoutFollowingSymlinks(target: string): Promise<number> {
+  const info = await safeLstat(target);
+  if (!info) return 0;
+  if (!info.isDirectory() || info.isSymbolicLink()) return info.size;
+  let total = info.size;
+  const entries = await readdir(target, { withFileTypes: true });
+  for (const entry of entries) total += await treeSizeWithoutFollowingSymlinks(path.join(target, entry.name));
+  return total;
+}

--- a/tests/agent.test.mjs
+++ b/tests/agent.test.mjs
@@ -3500,6 +3500,11 @@ test("buildRoot: the sandbox copies the buildable root, while the model reads on
     const inspect = await tool("bash").run({ cmd: "find crate -type f -print", purpose: "inspect" }, toolCtx);
     assert.match(inspect.observation, /crate\/src\/lib\.rs/);
     assert.doesNotMatch(inspect.observation, /AuditFindings|KNOWN ANSWER/);
+    await assert.rejects(
+      stat(path.join(logger.runDir, "audit", "workspace-source-view-cmd1")),
+      /ENOENT/,
+      "the per-command source view must be removed after the inspection result is captured",
+    );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/cli-help.test.mjs
+++ b/tests/cli-help.test.mjs
@@ -41,3 +41,10 @@ test("cli continue has command-specific help", async () => {
   assert.match(stdout, /verb:"run"/);
   assert.match(stdout, /--coverage <mode>/);
 });
+
+test("cli storage compaction is dry-run first and documents its evidence boundary", async () => {
+  const { stdout } = await execFileAsync(process.execPath, [path.join(root, "dist/cli.js"), "storage", "--help"], { cwd: root });
+  assert.match(stdout, /storage compact.*preview reclaimable space/);
+  assert.match(stdout, /--apply.*remove terminal-run inspection copies/);
+  assert.match(stdout, /never touches running runs, report artifacts, transcripts, findings, or PoC files/);
+});

--- a/tests/storage.test.mjs
+++ b/tests/storage.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { compactHistoricalInspectionWorkspaces } from "../dist/storage/compact.js";
+
+test("historical storage compaction previews and removes only terminal paired source views", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "flounder-storage-"));
+  const out = path.join(root, "out");
+  const terminal = path.join(out, "terminal-run");
+  const running = path.join(out, "running-run");
+  const outside = path.join(root, "outside-run");
+  try {
+    for (const runDir of [terminal, running, outside]) {
+      await mkdir(path.join(runDir, "audit", "workspace"), { recursive: true });
+      await mkdir(path.join(runDir, "audit", "workspace-source-view-cmd1"), { recursive: true });
+      await writeFile(path.join(runDir, "audit", "workspace", "source.rs"), "durable source\n");
+      await writeFile(path.join(runDir, "audit", "workspace-source-view-cmd1", "source.rs"), "disposable copy\n");
+    }
+    await writeFile(path.join(terminal, "report.md"), "durable evidence\n");
+    await mkdir(path.join(terminal, "audit", "orphan-source-view-cmd2"), { recursive: true });
+    await writeFile(path.join(terminal, "audit", "orphan-source-view-cmd2", "keep.txt"), "unpaired lookalike\n");
+    const outsideEvidence = path.join(root, "outside-evidence.txt");
+    await writeFile(outsideEvidence, "must survive\n");
+    await symlink(outsideEvidence, path.join(terminal, "audit", "workspace-source-view-cmd1", "outside-link"));
+
+    const runs = [
+      { run_dir: terminal, status: "done" },
+      { run_dir: running, status: "running" },
+      { run_dir: outside, status: "done" },
+    ];
+    const preview = await compactHistoricalInspectionWorkspaces({ outputDir: out, runs });
+    assert.equal(preview.apply, false);
+    assert.equal(preview.candidateDirectories, 1);
+    assert.equal(preview.removedDirectories, 0);
+    assert.equal(preview.skippedRunningRunDirs, 1);
+    assert.equal(preview.skippedUnsafeRunDirs, 1);
+    assert.ok(preview.reclaimableBytes > 0);
+    assert.ok((await stat(path.join(terminal, "audit", "workspace-source-view-cmd1"))).isDirectory());
+
+    const applied = await compactHistoricalInspectionWorkspaces({ outputDir: out, runs, apply: true });
+    assert.equal(applied.candidateDirectories, 1);
+    assert.equal(applied.removedDirectories, 1);
+    assert.equal(applied.removedBytes, applied.reclaimableBytes);
+    await assert.rejects(stat(path.join(terminal, "audit", "workspace-source-view-cmd1")), /ENOENT/);
+    assert.equal(await readFile(path.join(terminal, "report.md"), "utf8"), "durable evidence\n");
+    assert.equal(await readFile(path.join(terminal, "audit", "workspace", "source.rs"), "utf8"), "durable source\n");
+    assert.equal(await readFile(path.join(terminal, "audit", "orphan-source-view-cmd2", "keep.txt"), "utf8"), "unpaired lookalike\n");
+    assert.ok((await stat(path.join(running, "audit", "workspace-source-view-cmd1"))).isDirectory());
+    assert.ok((await stat(path.join(outside, "audit", "workspace-source-view-cmd1"))).isDirectory());
+    assert.equal(await readFile(outsideEvidence, "utf8"), "must survive\n");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- remove narrow source-view copies immediately after each read-only inspection command
- add flounder storage compact as a dry-run-first historical backfill
- require --apply before removing terminal-run source views
- skip running runs, paths outside the output root, symlinks, and unpaired lookalike directories
- preserve reports, transcripts, findings, PoCs, and primary workspaces

## Evidence

A real dry run over 419 terminal runs found 5,363 paired disposable source views totaling 183.71 GiB. No files were removed during validation.

## Verification

- npm run check
- npm run check:public
- Node 24.13.0: agent + storage tests (95/95 passed)
- Node 24.13.0: CLI/storage tests (6/6 passed)
- live dry run: 419 terminal runs, 5,363 candidates, 183.71 GiB reclaimable, 0 removed

The full parallel suite reached 366 passing tests, but four existing HTTP/SQLite test processes aborted in Node with InternalCallbackScope::Close; the same native runtime failure is outside this change. Relevant suites pass independently.