### PR TITLE
fix(prepare): allow branch-pinned git clones

### DIFF
--- a/src/security/policy.ts
+++ b/src/security/policy.ts
@@ -471,10 +471,14 @@ function isReadOnlyGitNetworkCommand(args: string[]): boolean {
 function isSafeGitReadOption(arg: string): boolean {
   return arg === "-q"
     || arg === "-v"
+    || arg === "-b"
     || arg === "--quiet"
     || arg === "--verbose"
     || arg === "--progress"
     || arg === "--no-progress"
+    || arg === "--branch"
+    || /^-b[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(arg)
+    || /^--branch=[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(arg)
     || arg === "--depth"
     || /^--depth=[1-9][0-9]*$/.test(arg)
     || arg === "--single-branch"

--- a/tests/security-policy.test.mjs
+++ b/tests/security-policy.test.mjs
@@ -241,6 +241,7 @@ test("open-world egress is granted per command instead of per phase", () => {
     cmd("curl", "-fsSL", "https://example.com/spec.json"),
     cmd("wget", "-q", "https://example.com/spec.json"),
     cmd("git", "clone", "https://github.com/example/project"),
+    cmd("git", "clone", "--branch", "main", "--single-branch", "https://github.com/example/project", "sources/project"),
     cmd("gh", "api", "repos/example/project"),
     cmd("gh", "issue", "view", "123"),
     cmd("solana", "program", "show", "4yBT18tBcWqCDK8p3RMXdmZMjHr3wJM7jM6HVYemEqGh", "--url", "https://api.mainnet-beta.solana.com"),


### PR DESCRIPTION
## What changed

- Allow safe `git clone --branch <ref> --single-branch ...` commands to receive read-only egress during Prepare and Confirm.
- Add a regression case matching the command shape used by the 1inch latest-source Prepare run.

## Root cause

The open-world command policy allowed `git clone` itself but did not recognize the standard `-b` / `--branch` options. As a result, branch-pinned clones were accepted for execution but silently placed in a network-sealed sandbox, where they failed with DNS errors.

## Impact

Prepare can now acquire a specific public branch with the usual safe clone syntax. Egress remains restricted to HTTPS remotes and the existing read-only Git option allowlist; push and unsafe clone configuration remain denied.

## Validation

- `npm test` (491 tests passed)
- `node --test tests/security-policy.test.mjs` (21 tests passed)
- `npm run check:public`
- `git diff --check`
