### PR TITLE
fix(verify): settle repaired resource requests

### DIFF
--- a/src/agent/audit.ts
+++ b/src/agent/audit.ts
@@ -861,6 +861,9 @@ export async function runAudit(
     }),
   ]);
   let resourceRequests: ResourceRequest[] = mergeResourceRequests(discoveryArtifacts.resourceRequests, session.resourceRequests ?? []);
+  if (auditMode === "verify") {
+    resourceRequests = resolveSatisfiedVerifyResourceRequests(resourceRequests, session.findings);
+  }
   let followupScopes: AuditScope[] = discoveryArtifacts.followupScopes;
   if (followupScopes.length > 0) {
     const merged = mergeFollowupScopes(scopeInventory, followupScopes);
@@ -1424,6 +1427,25 @@ function isConfirmed(status: ConfirmationStatus): boolean {
  * passed command attached to `REFUTED:` proves the mitigation, not the bug. */
 export function isExecutionConfirmedFinding(finding: AgentFinding): boolean {
   return !isRefutedFindingTitle(finding.title) && isConfirmed(finding.confirmationStatus);
+}
+
+/** A failed framework warm-up is a blocker only until the same Verify worker
+ * settles its claim by execution. Keep the failed diagnostic as resolved
+ * provenance, but do not leave the run or project waiting for setup that the
+ * worker already repaired with an isolated harness. Model-authored external
+ * resource requests remain open. */
+export function resolveSatisfiedVerifyResourceRequests(
+  requests: ResourceRequest[],
+  findings: AgentFinding[],
+): ResourceRequest[] {
+  const allClaimsSettledByExecution = findings.length > 0 && findings.every((finding) =>
+    isExecutionConfirmedFinding(finding)
+    || (isRefutedFindingTitle(finding.title) && Boolean(finding.commandRunId)),
+  );
+  if (!allClaimsSettledByExecution) return requests;
+  return requests.map((request) => request.status === "open" && request.id.startsWith("prepare-")
+    ? { ...request, status: "resolved" }
+    : request);
 }
 
 /** Collapse same-claim duplicates from one Verify worker and reject contradictory

--- a/tests/agent.test.mjs
+++ b/tests/agent.test.mjs
@@ -10,7 +10,7 @@ import { ProjectMemory } from "../dist/agent/memory.js";
 import { buildTools, describeAction, ingestFindingsFromScratch, newSession, dedupeFindings, readScratchScopes, isReportFile, scratchHasFindings, scratchHasFindingsArtifact, commandFileArgsForTest, confirmCommandTargetLinkForTest, splitCommandLineForTest } from "../dist/agent/tools.js";
 import { buildRunHealth, mergeFollowupScopes, readScratchCoverageGaps, readScratchFollowupScopes, readScratchResourceRequests } from "../dist/agent/discovery-artifacts.js";
 import { mergeScopeInventory } from "../dist/agent/scope-store.js";
-import { dedupeVerifyInputs, dischargeChallengeFindingTitle, dischargeChallengeScopeOutcomes, normalizeVerifyVerdicts, runAudit, verifyBatchStoppedReason } from "../dist/agent/audit.js";
+import { dedupeVerifyInputs, dischargeChallengeFindingTitle, dischargeChallengeScopeOutcomes, normalizeVerifyVerdicts, resolveSatisfiedVerifyResourceRequests, runAudit, verifyBatchStoppedReason } from "../dist/agent/audit.js";
 import { normalizePrepareManifest, prepareValidationBlockingIssues, readPrepareManifest } from "../dist/agent/acquire.js";
 import { runAuditLoop, isTransientError } from "../dist/agent/loop.js";
 import { MetadataStore } from "../dist/db/store.js";
@@ -669,6 +669,47 @@ test("run health distinguishes blocked, shallow, and coverage-incomplete runs", 
   assert.equal(buildRunHealth({ ...base, infraErrors: 1 }).status, "infra-failed");
   assert.equal(verifyBatchStoppedReason("error", 7, 7), "finished");
   assert.equal(verifyBatchStoppedReason("error", 6, 7), "error");
+});
+
+test("Verify resolves repaired framework prepare requests after an execution verdict", () => {
+  const prepareRequest = {
+    id: "prepare-foundry-sources-aqua-forge-build",
+    status: "open",
+    kind: "toolchain",
+    needed: "Working foundry prepare environment",
+    reason: "forge build failed before the worker created its isolated harness",
+  };
+  const externalRequest = {
+    id: "rpc-archive-node",
+    status: "open",
+    kind: "network",
+    needed: "Archive node",
+    reason: "A real-target fork still needs an endpoint",
+  };
+  const confirmed = {
+    id: "f1",
+    title: "Executable claim",
+    location: "src/Target.sol:1",
+    severity: "high",
+    description: "",
+    evidence: "",
+    exploitSketch: "",
+    fix: "",
+    confidence: 1,
+    confirmationStatus: "confirmed-differential",
+    commandRunId: "cmd14",
+  };
+
+  assert.deepEqual(
+    resolveSatisfiedVerifyResourceRequests([prepareRequest, externalRequest], [confirmed]).map((row) => row.status),
+    ["resolved", "open"],
+  );
+  assert.equal(resolveSatisfiedVerifyResourceRequests([prepareRequest], [
+    { ...confirmed, confirmationStatus: "suspected", commandRunId: undefined },
+  ])[0].status, "open");
+  assert.equal(resolveSatisfiedVerifyResourceRequests([prepareRequest], [
+    { ...confirmed, title: "REFUTED: Executable claim", confirmationStatus: "suspected" },
+  ])[0].status, "resolved");
 });
 
 test("audit sessions settle post-handoff transport errors only after phase-required artifacts exist", () => {


### PR DESCRIPTION
## Summary
- resolve framework-generated prepare resource requests when a Verify worker later settles every claim by execution
- preserve the failed warm-up diagnostic as resolved provenance
- keep model-authored network, credential, artifact, and other external resource requests open

## Why
A transient Foundry warm-up failure could remain as an open project blocker even after the same isolated Verify worker repaired its harness, passed the native PoC, completed differential confirmation, and survived refutation. The run was incorrectly labeled needs-resource and required manual cleanup.

## Verification
- TypeScript checks
- full Node 24 test suite
- focused agent regression suite
- production build
- public-surface scan