### PR TITLE
Fail confirm runs with incomplete decision coverage

### DIFF
--- a/src/agent/confirm.ts
+++ b/src/agent/confirm.ts
@@ -264,6 +264,29 @@ export async function runConfirm(
   await logger.artifact("confirm_decision.json", rows);
   if (impactInventory) await logger.artifact(IMPACT_INVENTORY_FILE, impactInventory);
   await logger.artifact("confirm_transcript.json", { stoppedReason: result.stoppedReason, steps: result.steps });
+  if (!options.signal?.aborted) {
+    try {
+      assertCompleteConfirmDecisionCoverage(priorFindings, rows);
+    } catch (error) {
+      const missing = missingConfirmDecisionFindingIds(priorFindings, rows);
+      await logger.event("audit_confirm_incomplete", {
+        findings: priorFindings.length,
+        covered: priorFindings.length - missing.length,
+        missing: missing.length,
+        missingFindingIds: missing.slice(0, 20),
+      });
+      recorder.confirmDecisions(rows, path.join(logger.runDir, "confirm_decision.json"));
+      recorder.stage("confirm", {
+        status: "error",
+        findings: priorFindings.length,
+        rows: rows.length,
+        missingFindingIds: missing.length,
+        at: new Date().toISOString(),
+      });
+      recorder.finish("error");
+      throw error;
+    }
+  }
   await logger.artifact(
     "confirm_report.md",
     renderConfirmReport({
@@ -569,6 +592,35 @@ export interface ConfirmDecisionRow {
   patchedSuccessPatterns?: string[];
   // Set by the framework when this row is the merge of several rows a single fix neutralized.
   mergedFrom?: string[];
+}
+
+export function assertCompleteConfirmDecisionCoverage(
+  findings: Array<{ id?: unknown }>,
+  rows: Array<{ members?: unknown }>,
+): void {
+  const missing = missingConfirmDecisionFindingIds(findings, rows);
+  if (missing.length === 0) return;
+  const preview = missing.slice(0, 10).join(", ");
+  const suffix = missing.length > 10 ? `, and ${missing.length - 10} more` : "";
+  throw new Error(
+    `flounder confirm: decision sheet omitted ${missing.length} selected finding id(s): ${preview}${suffix}; every selected finding must appear in a decision members array`,
+  );
+}
+
+function missingConfirmDecisionFindingIds(
+  findings: Array<{ id?: unknown }>,
+  rows: Array<{ members?: unknown }>,
+): string[] {
+  const covered = new Set(
+    rows.flatMap((row) => Array.isArray(row.members) ? row.members : [])
+      .filter((member): member is string => typeof member === "string")
+      .map((member) => member.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  return findings
+    .map((finding) => typeof finding.id === "string" ? finding.id.trim() : "")
+    .filter(Boolean)
+    .filter((id) => !covered.has(id.toLowerCase()));
 }
 
 function mergeSettledRows(rows: ConfirmDecisionRow[]): ConfirmDecisionRow[] {

--- a/tests/confirm-resume.test.mjs
+++ b/tests/confirm-resume.test.mjs
@@ -3,7 +3,7 @@ import test from "node:test";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { enforceBountySubmitReadiness, loadSettledFromPriorConfirm } from "../dist/agent/confirm.js";
+import { assertCompleteConfirmDecisionCoverage, enforceBountySubmitReadiness, loadSettledFromPriorConfirm } from "../dist/agent/confirm.js";
 import { publicPath } from "../dist/util/paths.js";
 
 // `flounder confirm` auto-resumes a prior interrupted confirm of the same input run: it finds
@@ -93,6 +93,26 @@ test("confirm resume: aggregate input carries settled rows from prior subset con
 
   const settled = await loadSettledFromPriorConfirm(out, "tgt", inputA, path.join(out, "tgt-confirm-cur"), [inputA, inputB]);
   assert.deepEqual(settled.map((r) => r.bug).sort(), ["Bug A newer", "Bug B"]);
+});
+
+test("confirm completion rejects a decision sheet that omits selected finding ids", () => {
+  const findings = [
+    { id: "finding-a" },
+    { id: "finding-b" },
+    { id: "finding-c" },
+  ];
+
+  assert.doesNotThrow(() => assertCompleteConfirmDecisionCoverage(findings, [
+    { members: ["finding-a", "finding-b"] },
+    { members: ["finding-c"] },
+  ]));
+
+  assert.throws(
+    () => assertCompleteConfirmDecisionCoverage(findings, [
+      { members: ["finding-a", "finding-b"] },
+    ]),
+    /decision sheet omitted 1 selected finding id.*finding-c/,
+  );
 });
 
 test("confirm bounty submit readiness requires impact inventory and closed gates", () => {


### PR DESCRIPTION
## Summary

- add a deterministic Confirm completion gate that requires every selected finding ID to appear in a decision row's `members`
- persist partial decision evidence, emit an `audit_confirm_incomplete` event, and mark the run as errored instead of falsely completing
- add a regression test for grouped complete coverage and omitted IDs

## Root cause

Confirm instructed the model to cover every selected finding, but the framework validated only row shape and submission readiness. A model could therefore emit `done` with a partial `confirm_decision.json`, and the run would be recorded as successfully completed while some selected findings had no decision.

## Impact

Confirm now fails closed when the final decision sheet is incomplete. Finished partial rows remain durable for retry, but downstream report and submission workflows cannot mistake partial adjudication for a completed Confirm phase.

## Validation

- `npm run check`
- `npm run build`
- `node --test tests/*.test.mjs` — 496 passed on the repository-pinned Node 24.13.0
- `npm run check:api-catalog:dist`
- `npm run check:public:commit`