### PR TITLE
Refresh imported provider credentials on explicit login

### DIFF
--- a/src/provider-auth.ts
+++ b/src/provider-auth.ts
@@ -126,7 +126,7 @@ export async function assertProviderAuthenticated(provider: string): Promise<voi
 
 export async function loginProvider(provider: string): Promise<void> {
   const normalized = provider.trim();
-  const importedFrom = await importDefaultPiAuth(normalized, providerAuthPath());
+  const importedFrom = await importDefaultPiAuth(normalized, providerAuthPath(), { overwrite: true });
   if (importedFrom) {
     console.log(`${normalized} credentials imported from existing pi auth (${importedFrom}) into ${providerAuthPath()}.`);
     return;
@@ -193,7 +193,11 @@ async function hasStoredAuth(provider: string, authPath: string): Promise<boolea
   return Boolean(auth[provider]);
 }
 
-async function importDefaultPiAuth(provider: string, authPath: string): Promise<string | undefined> {
+async function importDefaultPiAuth(
+  provider: string,
+  authPath: string,
+  options: { overwrite?: boolean } = {},
+): Promise<string | undefined> {
   if (process.env.FLOUNDER_DISABLE_PI_AUTH_IMPORT === "1") return undefined;
   const piAuthPath = defaultPiAuthPath();
   if (piAuthPath === authPath || !existsSync(piAuthPath)) return undefined;
@@ -203,7 +207,7 @@ async function importDefaultPiAuth(provider: string, authPath: string): Promise<
 
   await mkdir(dirname(authPath), { recursive: true });
   const auth = await readAuthFile(authPath);
-  if (!auth[provider]) {
+  if (options.overwrite || !auth[provider]) {
     auth[provider] = entry;
     await writeFile(authPath, JSON.stringify(auth, null, 2), { encoding: "utf8", mode: 0o600 });
     await chmod(authPath, 0o600).catch(() => undefined);

--- a/tests/provider-auth.test.mjs
+++ b/tests/provider-auth.test.mjs
@@ -3,7 +3,7 @@ import test from "node:test";
 import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { providerAuthPath, providerAuthStatus } from "../dist/provider-auth.js";
+import { loginProvider, providerAuthPath, providerAuthStatus } from "../dist/provider-auth.js";
 
 test("provider auth imports an existing pi provider credential into the Flounder agent dir", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "flounder-provider-auth-"));
@@ -27,6 +27,41 @@ test("provider auth imports an existing pi provider credential into the Flounder
     const copied = JSON.parse(await readFile(authPath, "utf8"));
     assert.deepEqual(copied, { "openai-codex": credential });
     assert.equal((await stat(authPath)).mode & 0o777, 0o600);
+  } finally {
+    restoreEnv("FLOUNDER_AGENT_DIR", oldFlounderAgentDir);
+    restoreEnv("PI_AGENT_DIR", oldPiAgentDir);
+  }
+});
+
+test("explicit provider login refreshes an existing Flounder credential from pi auth", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "flounder-provider-auth-refresh-"));
+  const flounderAgent = path.join(root, "flounder-agent");
+  const piAgent = path.join(root, "pi-agent");
+  await mkdir(flounderAgent, { recursive: true });
+  await mkdir(piAgent, { recursive: true });
+  const staleCredential = { type: "oauth", access: "stale", refresh: "stale" };
+  const freshCredential = { type: "oauth", access: "fresh", refresh: "fresh" };
+  const unrelatedCredential = { type: "oauth", subject: "keep-me" };
+  await writeFile(
+    path.join(flounderAgent, "auth.json"),
+    JSON.stringify({ "openai-codex": staleCredential, anthropic: unrelatedCredential }),
+    "utf8",
+  );
+  await writeFile(path.join(piAgent, "auth.json"), JSON.stringify({ "openai-codex": freshCredential }), "utf8");
+
+  const oldFlounderAgentDir = process.env.FLOUNDER_AGENT_DIR;
+  const oldPiAgentDir = process.env.PI_AGENT_DIR;
+  process.env.FLOUNDER_AGENT_DIR = flounderAgent;
+  process.env.PI_AGENT_DIR = piAgent;
+  try {
+    await loginProvider("openai-codex");
+
+    const copied = JSON.parse(await readFile(providerAuthPath(), "utf8"));
+    assert.deepEqual(copied, {
+      "openai-codex": freshCredential,
+      anthropic: unrelatedCredential,
+    });
+    assert.equal((await stat(providerAuthPath())).mode & 0o777, 0o600);
   } finally {
     restoreEnv("FLOUNDER_AGENT_DIR", oldFlounderAgentDir);
     restoreEnv("PI_AGENT_DIR", oldPiAgentDir);


### PR DESCRIPTION
## Summary

- refresh an existing Flounder provider credential when `daemon provider login` imports the corresponding pi credential
- preserve credentials for unrelated providers and the auth file's `0600` mode
- add a regression test covering stale-to-fresh credential replacement

## Root cause

The import helper skipped its write whenever the destination already contained that provider, but still returned the pi auth path. Explicit login therefore reported a successful import while leaving an invalidated token unchanged.

## User impact

Operators can use the documented provider login command to refresh a daemon credential instead of seeing every subsequent model session fail with an invalid-token error.

## Validation

- regression test fails against the old behavior and passes with the fix
- `node --test tests/provider-auth.test.mjs`
- full suite with the supported Node 24 runtime: 497/497 passing
- `npm run check:public`
- `git diff --check`
