### PR TITLE
Fix selected Confirm runs with explicit input

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2606,7 +2606,7 @@ async function runLaunch(c: Ctx): Promise<void> {
   // Confirm is finding-grained + resumable, but its distinct-bug consolidation must see the
   // full current confirmed-finding context. The pending rows decide whether there is work to do;
   // the context rows decide what the confirm agent can consolidate against across batches.
-  if (spec.verb === "confirm" && !spec.inputRunDir && !(spec.inputRunDirs && spec.inputRunDirs.length > 0)) {
+  if (spec.verb === "confirm") {
     const findingIds = selectedFindingIds(body);
     if (findingIds.length > 0) {
       const retryContext = new Map(c.store.confirmableContext(Number(project.id)).map((row) => [Number(row.id), row]));
@@ -2648,7 +2648,7 @@ async function runLaunch(c: Ctx): Promise<void> {
       // A focused retry is an explicit request to replace the old blocked decision. Without
       // fresh mode runConfirm may load that decision from a prior artifact and treat it as settled.
       if (selected.some((entry) => entry.reopened)) spec.fresh = true;
-    } else {
+    } else if (!spec.inputRunDir && !(spec.inputRunDirs && spec.inputRunDirs.length > 0)) {
       const currentDecisions = currentConfirmDecisions(c.store.listConfirmDecisions(Number(project.id)).filter((row) => rowBelongsToCurrentMaterial(row, currentResultRunIds, materialBoundary)));
       const pending = confirmWorkRows(c.store, Number(project.id), currentResultRunIds, materialBoundary, currentDecisions);
       if (pending.length === 0) return sendJson(c.res, 400, { error: "nothing to confirm — every audit-confirmed finding already has a real-target decision (use --fresh to redo)" });

--- a/tests/api.test.mjs
+++ b/tests/api.test.mjs
@@ -3072,11 +3072,17 @@ test("api: confirm launch carries DB-backed seeds when prior run artifact is mis
     const explicit = await json(await post(`/api/projects/${created.uuid}/runs`, {
       verb: "confirm",
       findingIds: [readyId],
+      inputRunDir: missingRunDir,
       sandboxConfirmNetwork: "none",
     }));
     const explicitJob = (await json(await fetch(base + "/api/jobs/" + explicit.jobId))).job;
     const explicitSpec = JSON.parse(explicitJob.spec_json);
     assert.equal(explicitSpec.sandboxConfirmNetwork, "none");
+    assert.equal(explicitSpec.inputRunDir, missingRunDir);
+    assert.ok(explicitSpec.confirmKeys.includes("kdbseed"));
+    assert.ok(explicitSpec.confirmKeys.includes(`origin:${readyId}:kdbseed`));
+    assert.equal(explicitSpec.confirmFindings.length, 1);
+    assert.equal(explicitSpec.confirmFindings[0].originId, readyId);
   });
 });
 


### PR DESCRIPTION
## What changed

- Always build the focused Confirm worklist when `findingIds` are supplied.
- Preserve the existing whole-run behavior for explicit input directories when no findings are selected.
- Add an API regression test covering `findingIds` combined with `inputRunDir`.

## Root cause

The project launch handler only translated selected finding IDs into `confirmKeys` and DB-backed finding seeds when no input run directory was already present. Combining both documented inputs skipped that branch, and the transient `findingIds` field was not persisted in the daemon launch spec. Confirm therefore loaded every finding from the input run.

## User impact

Focused confirmation now remains focused even when callers also provide the source run directory, preventing unexpectedly broad and expensive Confirm jobs.

## Validation

- `npm run verify`
- 496 tests passed
- API catalog contract passed
- Database upgrade contract passed
- Mock audit passed
- Public-surface scan passed