### PR TITLE
fix(daemon): preserve terminal job handoff

### DIFF
--- a/src/server/daemon.ts
+++ b/src/server/daemon.ts
@@ -37,6 +37,96 @@ export interface DaemonOptions {
 
 type Activity = { kind: string; delta?: string; tool?: string; step?: number; streamId?: string };
 
+type DaemonJob = { id: number; project: string; spec: LaunchSpec };
+const TERMINAL_RETRY_INITIAL_DELAY_MS = 250;
+const TERMINAL_RETRY_MAX_DELAY_MS = 5_000;
+const TERMINAL_REQUEST_TIMEOUT_MS = 10_000;
+const TERMINAL_RETRY_LOG_INTERVAL = 12;
+
+export function createSerializedClaimLoop<T>(options: {
+  maxConcurrent: number;
+  activeCount: () => number;
+  claim: () => Promise<T | undefined>;
+  start: (job: T) => void;
+}): () => Promise<void> {
+  let running: Promise<void> | undefined;
+  let requested = false;
+
+  const trigger = (): Promise<void> => {
+    requested = true;
+    if (running) return running;
+
+    const current = (async () => {
+      do {
+        requested = false;
+        while (options.activeCount() < options.maxConcurrent) {
+          const job = await options.claim();
+          if (!job) break;
+          options.start(job);
+        }
+      } while (requested && options.activeCount() < options.maxConcurrent);
+    })().finally(() => {
+      if (running === current) running = undefined;
+      if (requested) void trigger();
+    });
+    running = current;
+    return current;
+  };
+
+  return trigger;
+}
+
+export async function requestUntilAccepted(
+  method: "POST" | "PATCH",
+  base: string,
+  headers: Record<string, string>,
+  requestPath: string,
+  body: unknown,
+  options: {
+    fetchImpl?: typeof fetch;
+    sleep?: (delayMs: number) => Promise<void>;
+    initialDelayMs?: number;
+    maxDelayMs?: number;
+    requestTimeoutMs?: number;
+    onRetry?: (attempt: number, status: number | undefined) => void;
+  } = {},
+): Promise<void> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const sleep = options.sleep ?? ((delayMs: number) => new Promise<void>((resolve) => setTimeout(resolve, delayMs)));
+  const maxDelayMs = Math.max(1, options.maxDelayMs ?? TERMINAL_RETRY_MAX_DELAY_MS);
+  const requestTimeoutMs = Math.max(1, options.requestTimeoutMs ?? TERMINAL_REQUEST_TIMEOUT_MS);
+  let delayMs = Math.max(1, options.initialDelayMs ?? TERMINAL_RETRY_INITIAL_DELAY_MS);
+  let attempt = 0;
+
+  for (;;) {
+    attempt += 1;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
+    const response = await fetchImpl(base + requestPath, {
+      method,
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    }).catch(() => null).finally(() => clearTimeout(timeout));
+    if (response?.ok) return;
+    options.onRetry?.(attempt, response?.status);
+    await sleep(delayMs);
+    delayMs = Math.min(maxDelayMs, delayMs * 2);
+  }
+}
+
+export async function completeDaemonJobHandoff(options: {
+  flushRunState: () => Promise<void>;
+  deliverJobState: () => Promise<void>;
+  release: () => void;
+  scheduleClaim: () => void;
+}): Promise<void> {
+  await options.flushRunState();
+  await options.deliverJobState();
+  options.release();
+  options.scheduleClaim();
+}
+
 let defaultSandboxBuild: Promise<SandboxImageBuildResult> | undefined;
 
 export async function runDaemon(opts: DaemonOptions): Promise<void> {
@@ -70,17 +160,7 @@ export async function runDaemon(opts: DaemonOptions): Promise<void> {
   setInterval(heartbeat, 10_000);
   heartbeat();
 
-  const claimLoop = async (): Promise<void> => {
-    while (inflight.size < maxConcurrent) {
-      const res = await fetch(base + "/api/daemon/claim", { method: "POST", headers }).catch(() => null);
-      if (!res || !res.ok) return;
-      const data = (await res.json().catch(() => ({}))) as { job?: { id: number; project: string; spec: LaunchSpec } };
-      if (!data.job) return;
-      void runJob(data.job);
-    }
-  };
-
-  const runJob = async (job: { id: number; project: string; spec: LaunchSpec }): Promise<void> => {
+  const runJob = async (job: DaemonJob): Promise<void> => {
     const abort = new AbortController();
     inflight.set(job.id, abort);
     heartbeat();
@@ -99,6 +179,8 @@ export async function runDaemon(opts: DaemonOptions): Promise<void> {
       sink.flush();
       await tracker?.flush();
     };
+    let terminal: "done" | "error" | "canceled";
+    let terminalError: string | undefined;
     try {
       const cfg = specToConfig(spec, out, workspace);
       if (spec.mockLlm) {
@@ -150,22 +232,45 @@ export async function runDaemon(opts: DaemonOptions): Promise<void> {
           if (verifyTempDir) await rm(verifyTempDir, { recursive: true, force: true });
         }
       }
-      await flushTracker();
-      const terminal = daemonJobTerminalState(trackers.map((item) => item.terminalState()), abort.signal.aborted);
-      await post(base, headers, `/api/daemon/jobs/${job.id}/status`, {
-        status: terminal,
-        ...(terminal === "error" ? { error: trackers.find((item) => item.terminalState() === "error")?.errorSummary() ?? "one or more run phases finished with status error" } : {}),
-      });
+      terminal = daemonJobTerminalState(trackers.map((item) => item.terminalState()), abort.signal.aborted);
+      if (terminal === "error") terminalError = trackers.find((item) => item.terminalState() === "error")?.errorSummary() ?? "one or more run phases finished with status error";
     } catch (error) {
-      await flushTracker();
-      await post(base, headers, `/api/daemon/jobs/${job.id}/status`, { status: abort.signal.aborted ? "canceled" : "error", error: error instanceof Error ? error.message.slice(0, 500) : String(error) });
-    } finally {
-      inflight.delete(job.id);
-      runScopeTargets.delete(job.id);
-      heartbeat();
-      void claimLoop();
+      terminal = abort.signal.aborted ? "canceled" : "error";
+      terminalError = error instanceof Error ? error.message.slice(0, 500) : String(error);
     }
+
+    await completeDaemonJobHandoff({
+      flushRunState: flushTracker,
+      deliverJobState: () => requestUntilAccepted("POST", base, headers, `/api/daemon/jobs/${job.id}/status`, {
+        status: terminal,
+        ...(terminalError ? { error: terminalError } : {}),
+      }, {
+        onRetry: (attempt, status) => {
+          if (attempt === 1 || attempt % TERMINAL_RETRY_LOG_INTERVAL === 0) {
+            console.warn(`[flounder daemon] terminal handoff for job ${job.id} failed${status ? ` (HTTP ${status})` : ""}; retaining the job and retrying`);
+          }
+        },
+      }),
+      release: () => {
+        inflight.delete(job.id);
+        runScopeTargets.delete(job.id);
+        heartbeat();
+      },
+      scheduleClaim: () => { void claimLoop(); },
+    });
   };
+
+  const claimLoop = createSerializedClaimLoop<DaemonJob>({
+    maxConcurrent,
+    activeCount: () => inflight.size,
+    claim: async () => {
+      const res = await fetch(base + "/api/daemon/claim", { method: "POST", headers }).catch(() => null);
+      if (!res?.ok) return undefined;
+      const data = (await res.json().catch(() => ({}))) as { job?: DaemonJob };
+      return data.job;
+    },
+    start: (job) => { void runJob(job); },
+  });
 
   // SSE: dispatch nudges (re-claim) + cancels. Reconnect with backoff; also claim on connect.
   for (;;) {
@@ -651,7 +756,15 @@ class RemoteTracker implements RunTracker {
 
   finish(status: RunStatus, coverage?: Coverage, findingsTotal?: number): void {
     this.finalStatus = status;
-    this.enqueue(() => (this.runId ? this.req("PATCH", `/api/daemon/runs/${this.runId}`, { finish: { status, coverage, findingsTotal } }) : Promise.resolve()));
+    this.chain = this.chain.then(() => (this.runId
+      ? requestUntilAccepted("PATCH", this.base, this.headers, `/api/daemon/runs/${this.runId}`, { finish: { status, coverage, findingsTotal } }, {
+        onRetry: (attempt, responseStatus) => {
+          if (attempt === 1 || attempt % TERMINAL_RETRY_LOG_INTERVAL === 0) {
+            console.warn(`[flounder daemon] terminal run update for ${this.targetName} failed${responseStatus ? ` (HTTP ${responseStatus})` : ""}; retaining the job and retrying`);
+          }
+        },
+      })
+      : Promise.resolve()));
   }
 
   terminalState(): RunStatus | undefined {

--- a/tests/daemon-flow.test.mjs
+++ b/tests/daemon-flow.test.mjs
@@ -6,7 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { startUiServer } from "../dist/server/app.js";
-import { daemonJobTerminalState, ensureDaemonDirectories, loadVerifyArtifactReplay } from "../dist/server/daemon.js";
+import { completeDaemonJobHandoff, createSerializedClaimLoop, daemonJobTerminalState, ensureDaemonDirectories, loadVerifyArtifactReplay, requestUntilAccepted } from "../dist/server/daemon.js";
 import { MetadataStore } from "../dist/db/store.js";
 import { DAEMON_PROTOCOL_VERSION } from "../dist/server/protocol.js";
 
@@ -61,6 +61,95 @@ test("daemon: job terminal state reflects every persisted run phase", () => {
   assert.equal(daemonJobTerminalState(["done", "error", "done"]), "error");
   assert.equal(daemonJobTerminalState(["done", "killed"]), "canceled");
   assert.equal(daemonJobTerminalState(["done"], true), "canceled");
+});
+
+test("daemon: concurrent claim nudges share one drain and respect executor capacity", async () => {
+  const queued = [1, 2, 3];
+  const active = new Set();
+  let releaseFirstClaim;
+  let claimCalls = 0;
+  const firstClaim = new Promise((resolve) => { releaseFirstClaim = resolve; });
+  const claimLoop = createSerializedClaimLoop({
+    maxConcurrent: 2,
+    activeCount: () => active.size,
+    claim: async () => {
+      claimCalls += 1;
+      if (claimCalls === 1) await firstClaim;
+      return queued.shift();
+    },
+    start: (job) => { active.add(job); },
+  });
+
+  const drains = [claimLoop(), claimLoop(), claimLoop()];
+  releaseFirstClaim();
+  await Promise.all(drains);
+
+  assert.deepEqual([...active], [1, 2]);
+  assert.deepEqual(queued, [3]);
+  assert.equal(claimCalls, 2);
+});
+
+test("daemon: terminal handoff retries transport and HTTP failures until accepted", async () => {
+  const responses = [new Error("connection reset"), new Response(null, { status: 503 }), new Response(null, { status: 200 })];
+  const waits = [];
+  const retries = [];
+  const requests = [];
+
+  await requestUntilAccepted("POST", "http://127.0.0.1:4500", { authorization: "Bearer test" }, "/api/daemon/jobs/7/status", { status: "done" }, {
+    initialDelayMs: 2,
+    maxDelayMs: 4,
+    fetchImpl: async (url, init) => {
+      requests.push({ url, init });
+      const response = responses.shift();
+      if (response instanceof Error) throw response;
+      return response;
+    },
+    sleep: async (delayMs) => { waits.push(delayMs); },
+    onRetry: (attempt, status) => { retries.push({ attempt, status }); },
+  });
+
+  assert.equal(requests.length, 3);
+  assert.deepEqual(waits, [2, 4]);
+  assert.deepEqual(retries, [{ attempt: 1, status: undefined }, { attempt: 2, status: 503 }]);
+  assert.equal(requests[0].url, "http://127.0.0.1:4500/api/daemon/jobs/7/status");
+  assert.equal(requests[0].init.method, "POST");
+  assert.equal(requests[0].init.body, JSON.stringify({ status: "done" }));
+});
+
+test("daemon: terminal handoff retains capacity until run and job state are accepted", async () => {
+  const deferred = () => {
+    let resolve;
+    const promise = new Promise((accept) => { resolve = accept; });
+    return { promise, resolve };
+  };
+  const tick = () => new Promise((resolve) => setImmediate(resolve));
+  const runState = deferred();
+  const jobState = deferred();
+  const events = [];
+
+  const handoff = completeDaemonJobHandoff({
+    flushRunState: async () => {
+      events.push("run:start");
+      await runState.promise;
+      events.push("run:accepted");
+    },
+    deliverJobState: async () => {
+      events.push("job:start");
+      await jobState.promise;
+      events.push("job:accepted");
+    },
+    release: () => { events.push("capacity:released"); },
+    scheduleClaim: () => { events.push("claim:scheduled"); },
+  });
+
+  await tick();
+  assert.deepEqual(events, ["run:start"]);
+  runState.resolve();
+  await tick();
+  assert.deepEqual(events, ["run:start", "run:accepted", "job:start"]);
+  jobState.resolve();
+  await handoff;
+  assert.deepEqual(events, ["run:start", "run:accepted", "job:start", "job:accepted", "capacity:released", "claim:scheduled"]);
 });
 
 test("daemon: startup creates the reported product home and workspace directories", async () => {


### PR DESCRIPTION
## Summary

- Make daemon completion a durable handoff: flush terminal run state, deliver terminal job state, then release executor capacity.
- Retry terminal run and job updates with bounded exponential backoff instead of silently dropping transport or HTTP failures.
- Serialize claim-loop wakeups so simultaneous polling and stream nudges cannot exceed the configured daemon job concurrency.
- Add regression tests for retry behavior, claim capacity, and handoff ordering.

## Root cause

The daemon previously treated terminal status delivery as best effort and removed a job from its local inflight set unconditionally. If the final request was lost, the next heartbeat reported an online executor without that job, so control-plane reconciliation canceled it as `executor no longer holds this job`. Claim-loop wakeups could also overlap and race past the configured capacity.

## Test Coverage

- `npm run check`
- `npm run check:public`
- Focused daemon regression suite: 4/4 passed
- Production build completed successfully
- Full `npm test` on this branch: 381/385 tests passed; four test-file workers hit a native Node 24 `InternalCallbackScope::Close` assertion. The exact same four files fail with the same native assertion on the unmodified `origin/main` baseline (378/382 passed), while those files pass 125/125 when isolated. This is a pre-existing, load-sensitive runner failure rather than a JavaScript assertion regression.

## Pre-Landing Review

No correctness, race, or test gaps remained after independent review. Scope check is clean: two files changed, both directly related to daemon handoff behavior.

## Design Review

No frontend files changed; design review was not applicable.

## Test plan

- [x] Build server and UI assets
- [x] Type-check server and UI
- [x] Run daemon handoff and concurrency regression tests
- [x] Run public-surface scan
- [x] Compare the native full-suite crash against an unmodified baseline
