### PR TITLE
fix(ui): prevent dashboard snapshot stream starvation

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -26,6 +26,7 @@ import { THINKING_LEVELS } from "../config.js";
 import { projectHistoryDir } from "../trace/history.js";
 import { positiveIntegerId } from "../util/ids.js";
 import { DAEMON_PROTOCOL_VERSION } from "./protocol.js";
+import { SharedSnapshotStream } from "./shared-snapshot-stream.js";
 import { loadScopeInventory, saveScopeInventory } from "../agent/scope-store.js";
 import { deriveScopeNote } from "../scope-note.js";
 import { confirmSelectorsForFinding } from "../util/confirm-selector.js";
@@ -5780,20 +5781,33 @@ function runHasDisplayWeight(run: Record<string, unknown>): boolean {
   return false;
 }
 
+type LiveSnapshot = {
+  projects: Array<Record<string, unknown>>;
+  active: Array<Record<string, unknown>>;
+};
+
+const projectSnapshotStreams = new WeakMap<MetadataStore, SharedSnapshotStream<LiveSnapshot>>();
+
+function sharedProjectSnapshotStream(store: MetadataStore, plane: ControlPlane): SharedSnapshotStream<LiveSnapshot> {
+  const existing = projectSnapshotStreams.get(store);
+  if (existing) return existing;
+  const stream = new SharedSnapshotStream(() => {
+    reconcileLostExecutorJobs(store, plane);
+    return {
+      projects: projectSnapshots(store, { limit: PROJECT_STREAM_LIMIT }),
+      active: activeRuns(store, plane),
+    };
+  }, 1200);
+  projectSnapshotStreams.set(store, stream);
+  return stream;
+}
+
 function streamSnapshots(res: ServerResponse, store: MetadataStore, plane: ControlPlane): void {
   res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
-  const timer = setInterval(tick, 1200);
-  res.on("close", () => clearInterval(timer));
-  tick();
-  // A throw here (closed socket, or a transient store read error) must not crash the server.
-  function tick(): void {
-    try {
-      reconcileLostExecutorJobs(store, plane);
-      res.write(`data: ${JSON.stringify({ projects: projectSnapshots(store, { limit: PROJECT_STREAM_LIMIT }), active: activeRuns(store, plane) })}\n\n`);
-    } catch {
-      clearInterval(timer);
-    }
-  }
+  const unsubscribe = sharedProjectSnapshotStream(store, plane).subscribe((snapshot) => {
+    res.write(`data: ${JSON.stringify(snapshot)}\n\n`);
+  });
+  res.on("close", unsubscribe);
 }
 
 // Build a launch spec from the project's stored materials/config + the request body

--- a/src/server/shared-snapshot-stream.ts
+++ b/src/server/shared-snapshot-stream.ts
@@ -1,0 +1,68 @@
+/**
+ * Fan one synchronous snapshot producer out to any number of live consumers.
+ *
+ * Snapshot construction can be expensive and blocks the Node event loop. A
+ * timer per SSE client multiplies that work and, when construction takes longer
+ * than the interval, can starve every other control-plane request. This stream
+ * computes once, shares the result, and waits until the completed computation
+ * before scheduling the next refresh.
+ */
+export class SharedSnapshotStream<T> {
+  private readonly listeners = new Set<(snapshot: T) => void>();
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private latest: T | undefined;
+  private hasLatest = false;
+  private running = false;
+
+  constructor(
+    private readonly build: () => T,
+    private readonly refreshMs: number,
+  ) {}
+
+  subscribe(listener: (snapshot: T) => void): () => void {
+    this.listeners.add(listener);
+    if (this.hasLatest) {
+      this.deliver(listener, this.latest as T);
+    } else if (!this.running && !this.timer) {
+      this.tick();
+    }
+    return () => {
+      this.listeners.delete(listener);
+      if (this.listeners.size === 0) {
+        if (this.timer) clearTimeout(this.timer);
+        this.timer = undefined;
+        this.latest = undefined;
+        this.hasLatest = false;
+      }
+    };
+  }
+
+  private tick(): void {
+    this.timer = undefined;
+    if (this.running || this.listeners.size === 0) return;
+    this.running = true;
+    try {
+      const snapshot = this.build();
+      this.latest = snapshot;
+      this.hasLatest = true;
+      for (const listener of [...this.listeners]) this.deliver(listener, snapshot);
+    } catch {
+      // A transient store read failure must not crash the control plane or
+      // permanently disable updates for every connected dashboard.
+    } finally {
+      this.running = false;
+      if (this.listeners.size > 0) {
+        this.timer = setTimeout(() => this.tick(), Math.max(0, this.refreshMs));
+        this.timer.unref?.();
+      }
+    }
+  }
+
+  private deliver(listener: (snapshot: T) => void, snapshot: T): void {
+    try {
+      listener(snapshot);
+    } catch {
+      this.listeners.delete(listener);
+    }
+  }
+}

--- a/tests/shared-snapshot-stream.test.mjs
+++ b/tests/shared-snapshot-stream.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { SharedSnapshotStream } from "../dist/server/shared-snapshot-stream.js";
+
+test("shared snapshot stream computes once for all subscribers and stops when idle", async () => {
+  let builds = 0;
+  const stream = new SharedSnapshotStream(() => ({ sequence: ++builds }), 20);
+  const first = [];
+  const second = [];
+
+  const unsubscribeFirst = stream.subscribe((snapshot) => first.push(snapshot));
+  const unsubscribeSecond = stream.subscribe((snapshot) => second.push(snapshot));
+
+  assert.equal(builds, 1, "a second subscriber must reuse the current snapshot");
+  assert.deepEqual(first, [{ sequence: 1 }]);
+  assert.deepEqual(second, [{ sequence: 1 }]);
+
+  await delay(55);
+  assert.ok(builds >= 2, "the shared producer should continue refreshing");
+  assert.equal(first.length, builds);
+  assert.deepEqual(second, first, "all subscribers should receive the same shared snapshots");
+
+  unsubscribeFirst();
+  unsubscribeSecond();
+  const stoppedAt = builds;
+  await delay(50);
+  assert.equal(builds, stoppedAt, "the producer should stop when no subscribers remain");
+
+  const resumed = [];
+  const unsubscribeResumed = stream.subscribe((snapshot) => resumed.push(snapshot));
+  assert.equal(builds, stoppedAt + 1, "a new subscriber should restart with a fresh snapshot");
+  assert.deepEqual(resumed, [{ sequence: stoppedAt + 1 }]);
+  unsubscribeResumed();
+});


### PR DESCRIPTION
## Summary

- share one project snapshot producer across all dashboard SSE clients
- schedule each refresh only after the previous synchronous snapshot build completes
- stop idle producers and restart with a fresh snapshot on reconnect
- isolate listener failures so one closed client cannot disable updates for others

## Problem

The dashboard previously created a separate 1.2-second snapshot timer for every SSE connection. When snapshot construction takes longer than that interval, multiple open dashboard connections can continuously occupy the Node event loop and delay unrelated control-plane APIs.

## Verification

- npm run check
- targeted API and shared-stream tests
- sequential regression tests for API, daemon flow, harness experiments, and run groups
- public-surface scan
- manual two-client SSE regression check confirmed unrelated API requests remain responsive
