### PR TITLE
fix(sandbox): bound Apple container timeout cleanup

### DIFF
--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -29,6 +29,7 @@ export const DEFAULT_SANDBOX_IMAGE = "flounder-sandbox:latest";
 export const DEFAULT_SANDBOX_BUILD_MIN_FREE_DISK_MB = 2048;
 const APPLE_CONTAINER_SEALED_NETWORK = "flounder-sealed";
 const APPLE_CONTAINER_NETWORK_DNS = ["1.1.1.1", "8.8.8.8"] as const;
+const APPLE_CONTAINER_CLEANUP_GRACE_MS = 750;
 const CACHE_TEMP_PREFIX = ".flounder-cache-";
 const APPLE_CONTAINER_DEFAULT_MEMORY_CAP_MB = 8192;
 const APPLE_CONTAINER_DEFAULT_MEMORY_FLOOR_MB = 1024;
@@ -620,6 +621,15 @@ async function runAppleContainerSandboxProcess(input: ProcessRunInput): Promise<
     if (value !== undefined) containerArgs.push("--env", `${key}=${value}`);
   }
   containerArgs.push(input.options.image, input.command.program, ...input.command.args);
+  let cleanupTimer: ReturnType<typeof setTimeout> | undefined;
+  let cleanupPromise: ReturnType<typeof forceRemoveAppleContainer> | undefined;
+  const scheduleCleanup = (): void => {
+    if (cleanupTimer || cleanupPromise) return;
+    cleanupTimer = setTimeout(() => {
+      cleanupTimer = undefined;
+      cleanupPromise = forceRemoveAppleContainer(containerName);
+    }, APPLE_CONTAINER_CLEANUP_GRACE_MS);
+  };
   const result = await runSpawnedProcess({
     program: "container",
     args: containerArgs,
@@ -627,14 +637,20 @@ async function runAppleContainerSandboxProcess(input: ProcessRunInput): Promise<
     env: containerClientEnv(),
     timeoutMs: input.command.timeoutMs ?? 120_000,
     maxLogBytes: input.maxLogBytes,
+    onTimeout: scheduleCleanup,
+    onAbort: scheduleCleanup,
     ...(input.signal ? { signal: input.signal } : {}),
   });
   if (result.timedOut || result.aborted) {
-    // The Apple CLI may still be unwinding its `container run` XPC session when
-    // the timeout fires. Deleting concurrently races that session and can leave
-    // the per-container VM running indefinitely, so wait for the client process
-    // to exit before retrying and observing cleanup.
-    const cleanup = await forceRemoveAppleContainer(containerName);
+    // Give the Apple CLI a bounded opportunity to unwind its `container run`
+    // XPC session. Some releases fail to forward SIGTERM and never exit, so a
+    // delayed force-delete must also be able to release the waiting client.
+    if (cleanupTimer) {
+      clearTimeout(cleanupTimer);
+      cleanupTimer = undefined;
+    }
+    cleanupPromise ??= forceRemoveAppleContainer(containerName);
+    const cleanup = await cleanupPromise;
     if (!cleanup.ok) {
       result.stderr = appendLimited(
         result.stderr,

--- a/tests/sandbox.test.mjs
+++ b/tests/sandbox.test.mjs
@@ -116,11 +116,14 @@ async function fakeContainerCli(options = {}) {
   const dir = await tempDir("flounder-fake-container-bin-");
   const bin = path.join(dir, "container");
   const deleteStateFile = path.join(dir, "delete-count");
+  const runStopFile = path.join(dir, "run-stop");
   await writeFile(bin, `#!/usr/bin/env bash
 LOG_FILE=${JSON.stringify(options.logFile ?? "")}
 RUN_SLEEP_SECONDS=${JSON.stringify(String(options.runSleepSeconds ?? 0))}
+RUN_WAITS_FOR_DELETE=${JSON.stringify(options.runWaitsForDelete ? "1" : "0")}
 DELETE_FAIL_COUNT=${JSON.stringify(String(options.deleteFailCount ?? 0))}
 DELETE_STATE_FILE=${JSON.stringify(deleteStateFile)}
+RUN_STOP_FILE=${JSON.stringify(runStopFile)}
 if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then printf '%s' ${JSON.stringify(options.imageInspectStderr ?? "")} >&2; exit ${options.imageInspectExit ?? 0}; fi
 if [ "$1" = "network" ] && [ "$2" = "inspect" ]; then exit ${options.networkInspectExit ?? 0}; fi
 if [ "$1" = "network" ] && [ "$2" = "create" ]; then exit ${options.networkCreateExit ?? 0}; fi
@@ -131,12 +134,19 @@ if [ "$1" = "delete" ]; then
   DELETE_COUNT=$((DELETE_COUNT + 1))
   printf '%s\\n' "$DELETE_COUNT" > "$DELETE_STATE_FILE"
   if [ "$DELETE_COUNT" -le "$DELETE_FAIL_COUNT" ]; then printf 'transient delete failure\\n' >&2; exit 1; fi
+  if [ "$RUN_WAITS_FOR_DELETE" = "1" ]; then touch "$RUN_STOP_FILE"; fi
   exit ${options.deleteExit ?? 0}
 fi
 if [ "$1" = "run" ]; then
   if [ -n "$LOG_FILE" ]; then printf 'RUN\\n' >> "$LOG_FILE"; fi
   printf 'ARGS:'
   for arg in "$@"; do printf '[%s]' "$arg"; done
+  if [ "$RUN_WAITS_FOR_DELETE" = "1" ]; then
+    trap '' TERM
+    while [ ! -f "$RUN_STOP_FILE" ]; do sleep 0.05; done
+    if [ -n "$LOG_FILE" ]; then printf 'RUN_RELEASED\\n' >> "$LOG_FILE"; fi
+    exit 0
+  fi
   if [ "$RUN_SLEEP_SECONDS" != "0" ]; then exec sleep "$RUN_SLEEP_SECONDS"; fi
   exit 0
 fi
@@ -585,7 +595,7 @@ test("sandbox Apple container backend force-deletes timed-out containers", async
   const workspace = await tempDir("flounder-sandbox-apple-timeout-");
   const logDir = await tempDir("flounder-sandbox-apple-timeout-log-");
   const logFile = path.join(logDir, "container.log");
-  const fakeBin = await fakeContainerCli({ logFile, runSleepSeconds: 5, deleteFailCount: 1 });
+  const fakeBin = await fakeContainerCli({ logFile, runWaitsForDelete: true, deleteFailCount: 1 });
   const oldPath = process.env.PATH;
   try {
     process.env.PATH = `${fakeBin}${path.delimiter}${oldPath ?? ""}`;
@@ -599,7 +609,7 @@ test("sandbox Apple container backend force-deletes timed-out containers", async
     );
 
     assert.equal(result.timedOut, true);
-    const cleanupLog = await waitForFileMatch(logFile, /DELETE:flounder-[^\n]+\nDELETE:flounder-/);
+    const cleanupLog = await waitForFileMatch(logFile, /DELETE:flounder-[^\n]+\nDELETE:flounder-[^\n]+\nRUN_RELEASED/);
     assert.equal(cleanupLog.match(/DELETE:flounder-/g)?.length, 2);
   } finally {
     process.env.PATH = oldPath;


### PR DESCRIPTION
## Summary

- schedule bounded Apple container cleanup as soon as a sandbox command times out or is aborted
- let force-deletion release a `container run` client that does not exit after signal forwarding fails
- retain retry behavior and cleanup diagnostics

## Verification

- TypeScript checks for the server and UI
- `node --test tests/sandbox.test.mjs` (31 passing)
- public-surface scan

The regression test models a container client that ignores termination and only exits after the named container is deleted.
