### PR TITLE
fix: automate execution-backed confirm verdicts

### DIFF
--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -1357,7 +1357,10 @@ export class MetadataStore {
             SELECT 1
               FROM confirm_decision
              WHERE confirm_decision.run_id = run.id
-               AND confirm_decision.recommendation = 'needs-human'
+               AND (
+                 confirm_decision.recommendation IS NULL
+                 OR confirm_decision.recommendation NOT IN ('submit-candidate', 'drop')
+               )
           )`,
     ).run();
   }

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -1326,7 +1326,11 @@ export class MetadataStore {
       const members = parseJsonArray(row.members_json).filter((member): member is string => typeof member === "string");
       const linked = linkedFindingMetadata(findingsByProject.get(row.project_id), members);
       const input = operatorAdjudicatedDecisionInput(row as Record<string, unknown>, decisionsById);
-      const enforced = enforceSubmissionReadiness([input], { requireImpactInventory: false })[0] ?? input;
+      const reconciledInput = {
+        ...input,
+        humanGates: withoutStaleFrameworkSubmissionBlocker(input.humanGates) ?? undefined,
+      };
+      const enforced = enforceSubmissionReadiness([reconciledInput], { requireImpactInventory: false })[0] ?? reconciledInput;
       const evidenceLevel = decisionEvidenceLevel(enforced);
       const humanGates = enforced.recommendation === "submit-candidate"
         ? withoutStaleFrameworkSubmissionBlocker(enforced.humanGates ?? row.human_gates)

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -1348,6 +1348,11 @@ export class MetadataStore {
         WHERE kind = 'confirm'
           AND status = 'done'
           AND health_status = 'needs-human'
+          AND EXISTS (
+            SELECT 1
+              FROM confirm_decision
+             WHERE confirm_decision.run_id = run.id
+          )
           AND NOT EXISTS (
             SELECT 1
               FROM confirm_decision

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -1340,6 +1340,21 @@ export class MetadataStore {
         row.id,
       );
     }
+    this.db.prepare(
+      `UPDATE run
+          SET health_status = NULL,
+              health_reasons_json = NULL,
+              health_signals_json = NULL
+        WHERE kind = 'confirm'
+          AND status = 'done'
+          AND health_status = 'needs-human'
+          AND NOT EXISTS (
+            SELECT 1
+              FROM confirm_decision
+             WHERE confirm_decision.run_id = run.id
+               AND confirm_decision.recommendation = 'needs-human'
+          )`,
+    ).run();
   }
 
   private reconcileFindingReportRunIds(): void {

--- a/src/db/store.ts
+++ b/src/db/store.ts
@@ -928,6 +928,15 @@ function operatorAdjudicatedDecisionInput(
   };
 }
 
+function withoutStaleFrameworkSubmissionBlocker(value: string | null | undefined): string | null {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const marker = "Framework blocked submit-candidate:";
+  const markerIndex = text.indexOf(marker);
+  const cleaned = (markerIndex >= 0 ? text.slice(0, markerIndex) : text).trim();
+  return cleaned || null;
+}
+
 const CANONICAL_STATUS_RANK: Record<string, number> = {
   discharged: 0,
   refuted: 1,
@@ -1320,7 +1329,7 @@ export class MetadataStore {
       const enforced = enforceSubmissionReadiness([input], { requireImpactInventory: false })[0] ?? input;
       const evidenceLevel = decisionEvidenceLevel(enforced);
       const humanGates = enforced.recommendation === "submit-candidate"
-        ? null
+        ? withoutStaleFrameworkSubmissionBlocker(enforced.humanGates ?? row.human_gates)
         : enforced.humanGates ?? row.human_gates;
       update.run(
         enforced.recommendation ?? row.recommendation,

--- a/src/util/submission-readiness.ts
+++ b/src/util/submission-readiness.ts
@@ -23,6 +23,11 @@ export interface TechnicalClaimGateEvidence {
 const TECHNICAL_CLAIM_GATES: TechnicalClaimGate[] = ["attacker_reachability", "end_to_end_effect", "impact_bounds"];
 const DEFAULT_BOUNTY_GATES: BountyGate[] = ["scope", "live_impact", "known_issue", "payout"];
 const SOURCE_ONLY_BOUNTY_GATES: BountyGate[] = ["scope", "known_issue", "payout"];
+const TECHNICAL_GATE_SUBJECT = String.raw`(?:scope|authori[sz]\w*|permissions? to audit|target identity|source integrity|live (?:impact|deployment|target|funds?)|funded deployment|production deployment|current version|affected version|execution evidence|execution|reproduction|reproduc(?:e|ed|ibility)|verification|proof of concept|poc|exploit|local fork|fork)`;
+const UNRESOLVED_GATE_STATE = String.raw`(?:pending|missing|unknown|unclear|unverified|unconfirmed|failed|could not|cannot|not (?:been )?(?:reproduced|verified|confirmed|executed|run)|must (?:be )?(?:reproduced|verified|confirmed|executed|run)|requires? (?:reproduction|verification|confirmation|execution))`;
+const TECHNICAL_GATE_UNCERTAINTY = new RegExp(
+  `\\b${TECHNICAL_GATE_SUBJECT}\\b.{0,48}\\b${UNRESOLVED_GATE_STATE}\\b|\\b${UNRESOLVED_GATE_STATE}\\b.{0,48}\\b${TECHNICAL_GATE_SUBJECT}\\b`,
+);
 
 export interface SubmissionReadinessOptions {
   impactInventory?: unknown;
@@ -563,15 +568,16 @@ function programHumanGate(row: SubmissionDecisionLike, liveRequired: boolean): s
   const policyKind = normalizedWord(profile?.policy_kind ?? profile?.policyKind ?? profile?.kind);
   const privateReview = ["private_audit", "incident", "source_review"].includes(policyKind);
   const disclosureHandling = /\b(?:private|confidential|contact|embargo|duplicate|known issue|disclosure)\b/.test(normalized);
-  const technicalUncertainty = /\b(?:scope|authoriz|permission to audit|target identity|source integrity|live (?:impact|deployment|target|funds?)|funded deployment|production deployment|current version|affected version|execution evidence)\b/.test(normalized)
-    || /\b(?:reproduction|execution|technical confirmation)\b.{0,40}\b(?:pending|missing|unknown|unverified|failed|could not|not reproduced)\b/.test(normalized)
-    || /\b(?:pending|missing|unknown|unverified|failed|could not)\b.{0,40}\b(?:reproduction|execution|technical confirmation)\b/.test(normalized);
-  if (privateReview && disclosureHandling && !technicalUncertainty) return undefined;
-  const explicitlyHandlingOnly = /\bno mandatory (?:submission|program|policy) (?:gate|gates|blocker|blockers) remain(?:s|ing)?\b/.test(normalized)
+  const technicalUncertainty = TECHNICAL_GATE_UNCERTAINTY.test(normalized);
+  const mandatoryProgramTerms = /\b(?:mandatory|required)\b.{0,32}\b(?:embargo|submission window|deadline|scope|venue|eligibility|policy terms?|contest rules?|program requirements?)\b/.test(normalized)
+    || /\b(?:embargo|submission window|deadline|scope|venue|eligibility|policy terms?|contest rules?|program requirements?)\b.{0,48}\b(?:pending|missing|unknown|unclear|unverified|unconfirmed|not established|required|mandatory)\b/.test(normalized);
+  const explicitlyHandlingOnly = /\bno mandatory (?:submission|program|policy)(?: or (?:submission|program|policy))* (?:gate|gates|blocker|blockers) remain(?:s|ing)?\b/.test(normalized)
     && /\b(?:handling|disclosure|contact|duplicate|embargo)\b/.test(normalized)
     && !technicalUncertainty;
   if (explicitlyHandlingOnly) return undefined;
+  if (privateReview && disclosureHandling && !technicalUncertainty && !mandatoryProgramTerms) return undefined;
   if (technicalUncertainty) return text;
+  if (mandatoryProgramTerms) return text;
   const programTerms = /\b(?:scope|venue|eligib|embargo|submission window|deadline|policy terms?|contest rules?|mandatory requirement)\b/.test(normalized);
   const liveTerms = /\b(?:live|funded|funds|deployment|production|current version|affected version)\b/.test(normalized);
   const adjudicationOnly = /\b(?:known issue|known_issue|novelty|duplicate|payout|reward|bounty amount|collectible)\b/.test(normalized)
@@ -698,7 +704,7 @@ function hasUnsettledHumanGateText(value: string): boolean {
   if (!text) return false;
   if (/^(?:none|n\/a|not applicable|no remaining gates?|no human gates?)\.?$/.test(text)) return false;
   if (/\b(?:no|none)\b.{0,32}\b(?:remaining|open|unsettled|human)\b.{0,24}\b(?:gate|gates|blocker|blockers)\b/.test(text)) return false;
-  return /\b(?:scope|venue|eligib|bounty|reward|payout|collectible|live|funded|funds|deployment|production|current|human gate|needs?|requires?|not established|not confirmed|unknown|unclear|unverified|pending|review|cannot be settled|must)\b/.test(text);
+  return /\b(?:scope|venue|eligib|bounty|reward|payout|collectible|live|funded|funds|deployment|production|current|human gate|needs?|requires?|not established|not confirmed|unknown|unclear|unverified|unconfirmed|pending|missing|failed|review|cannot|authori[sz]\w*|permission|identity|integrity|verification|reproduc\w*|exploit|poc|fork|execution|embargo|deadline|window|must)\b/.test(text);
 }
 
 function bountyGateStatus(adjudication: unknown, gate: DecisionGate): string | undefined {

--- a/src/util/submission-readiness.ts
+++ b/src/util/submission-readiness.ts
@@ -28,6 +28,7 @@ const UNRESOLVED_GATE_STATE = String.raw`(?:pending|missing|unknown|unclear|unve
 const TECHNICAL_GATE_UNCERTAINTY = new RegExp(
   `\\b${TECHNICAL_GATE_SUBJECT}\\b.{0,48}\\b${UNRESOLVED_GATE_STATE}\\b|\\b${UNRESOLVED_GATE_STATE}\\b.{0,48}\\b${TECHNICAL_GATE_SUBJECT}\\b`,
 );
+const TECHNICAL_GATE_MENTION = new RegExp(`\\b${TECHNICAL_GATE_SUBJECT}\\b`);
 
 export interface SubmissionReadinessOptions {
   impactInventory?: unknown;
@@ -562,7 +563,7 @@ function programGateDetail(gate: "scope" | "live_impact", status: ProgramRequire
 
 function programHumanGate(row: SubmissionDecisionLike, liveRequired: boolean): string | undefined {
   const text = decisionHumanGates(row).trim();
-  if (!hasUnsettledHumanGateText(text)) return undefined;
+  if (isExplicitlyClosedHumanGateText(text)) return undefined;
   const normalized = text.toLowerCase();
   const profile = asRecord(decisionEngagementProfile(row));
   const policyKind = normalizedWord(profile?.policy_kind ?? profile?.policyKind ?? profile?.kind);
@@ -571,11 +572,21 @@ function programHumanGate(row: SubmissionDecisionLike, liveRequired: boolean): s
   const technicalUncertainty = TECHNICAL_GATE_UNCERTAINTY.test(normalized);
   const mandatoryProgramTerms = /\b(?:mandatory|required)\b.{0,32}\b(?:embargo|submission window|deadline|scope|venue|eligibility|policy terms?|contest rules?|program requirements?)\b/.test(normalized)
     || /\b(?:embargo|submission window|deadline|scope|venue|eligibility|policy terms?|contest rules?|program requirements?)\b.{0,48}\b(?:pending|missing|unknown|unclear|unverified|unconfirmed|not established|required|mandatory)\b/.test(normalized);
-  const explicitlyHandlingOnly = /\bno mandatory (?:submission|program|policy)(?: or (?:submission|program|policy))* (?:gate|gates|blocker|blockers) remain(?:s|ing)?\b/.test(normalized)
-    && /\b(?:handling|disclosure|contact|duplicate|embargo)\b/.test(normalized)
-    && !technicalUncertainty;
-  if (explicitlyHandlingOnly) return undefined;
-  if (privateReview && disclosureHandling && !technicalUncertainty && !mandatoryProgramTerms) return undefined;
+  const handlingOnlyPattern = /\bno mandatory (?:submission|program|policy)(?: or (?:submission|program|policy))* (?:gate|gates|blocker|blockers) remain(?:s|ing)?\b/;
+  const handlingOnlyRemainder = normalized.replace(handlingOnlyPattern, "");
+  const explicitlyHandlingOnly = handlingOnlyPattern.test(normalized)
+    && disclosureHandling
+    && !/\b(?:mandatory|required)\b/.test(handlingOnlyRemainder)
+    && !TECHNICAL_GATE_MENTION.test(handlingOnlyRemainder);
+  const separatedTechnicalPattern = /\b(?:this|the)?\s*(?:duplicate|disclosure|contact|embargo|handling|adjudication)?\s*(?:uncertainty|process|issue|note)?\s*(?:is|remains)?\s*(?:separate|independent) from (?:the )?technical (?:reproduction|verification|evidence|verdict|confirmation)\b/;
+  const separatedTechnicalRemainder = normalized.replace(separatedTechnicalPattern, "");
+  const explicitlySeparateDisclosureHandling = privateReview
+    && disclosureHandling
+    && separatedTechnicalPattern.test(normalized)
+    && !mandatoryProgramTerms
+    && !TECHNICAL_GATE_MENTION.test(separatedTechnicalRemainder);
+  const explicitlyResolvedTechnicalGate = /^(?:the )?(?:exploit reproduction|verification|authorization|execution evidence)\s+(?:is|was|has been)?\s*(?:complete|completed successfully|confirmed|sufficient|settled|resolved)\.?$/.test(normalized);
+  if (explicitlyHandlingOnly || explicitlySeparateDisclosureHandling || explicitlyResolvedTechnicalGate) return undefined;
   if (technicalUncertainty) return text;
   if (mandatoryProgramTerms) return text;
   const programTerms = /\b(?:scope|venue|eligib|embargo|submission window|deadline|policy terms?|contest rules?|mandatory requirement)\b/.test(normalized);
@@ -699,12 +710,10 @@ function structuredField(row: SubmissionDecisionLike, keys: string[]): unknown {
   return undefined;
 }
 
-function hasUnsettledHumanGateText(value: string): boolean {
+function isExplicitlyClosedHumanGateText(value: string): boolean {
   const text = value.trim().toLowerCase();
-  if (!text) return false;
-  if (/^(?:none|n\/a|not applicable|no remaining gates?|no human gates?)\.?$/.test(text)) return false;
-  if (/\b(?:no|none)\b.{0,32}\b(?:remaining|open|unsettled|human)\b.{0,24}\b(?:gate|gates|blocker|blockers)\b/.test(text)) return false;
-  return /\b(?:scope|venue|eligib|bounty|reward|payout|collectible|live|funded|funds|deployment|production|current|human gate|needs?|requires?|not (?:yet )?(?:been )?(?:established|confirmed|verified|reproduced|executed|run)|unknown|unclear|unverified|unconfirmed|incomplete|inconclusive|tbd|to be determined|pending|missing|failed|review|cannot|must)\b/.test(text);
+  if (!text) return true;
+  return /^(?:none|n\/a|not applicable|no remaining gates?|no human gates?)\.?$/.test(text);
 }
 
 function bountyGateStatus(adjudication: unknown, gate: DecisionGate): string | undefined {

--- a/src/util/submission-readiness.ts
+++ b/src/util/submission-readiness.ts
@@ -317,6 +317,7 @@ export function isBountyLikePolicy(row: SubmissionDecisionLike): boolean {
   const adjudication = asRecord(decisionAdjudication(row));
   const policyKind = normalizedWord(stringValue(profile?.policy_kind ?? profile?.policyKind ?? profile?.kind));
   if (policyKind.includes("bug_bounty") || policyKind.includes("bounty") || policyKind.includes("contest")) return true;
+  if (["private_audit", "incident", "source_review"].includes(policyKind)) return false;
   const requiredRaw = profile?.required_gates ?? profile?.requiredGates;
   const requiredGates = Array.isArray(requiredRaw) ? requiredRaw.map((entry) => normalizedWord(stringValue(entry))) : [];
   const adjudicationHasPayout = Boolean(adjudication && ("payout_estimate" in adjudication || "payoutEstimate" in adjudication || "reward_estimate" in adjudication || "rewardEstimate" in adjudication));
@@ -558,6 +559,12 @@ function programHumanGate(row: SubmissionDecisionLike, liveRequired: boolean): s
   const text = decisionHumanGates(row).trim();
   if (!hasUnsettledHumanGateText(text)) return undefined;
   const normalized = text.toLowerCase();
+  const profile = asRecord(decisionEngagementProfile(row));
+  const policyKind = normalizedWord(profile?.policy_kind ?? profile?.policyKind ?? profile?.kind);
+  const privateReview = ["private_audit", "incident", "source_review"].includes(policyKind);
+  const disclosureHandling = /\b(?:private|confidential|contact|embargo|duplicate|known issue|disclosure)\b/.test(normalized);
+  const technicalAuthorization = /\b(?:scope|authoriz|permission to audit|target identity|source integrity)\b/.test(normalized);
+  if (privateReview && disclosureHandling && !technicalAuthorization) return undefined;
   const explicitlyHandlingOnly = /\bno mandatory (?:submission|program|policy) (?:gate|gates|blocker|blockers) remain(?:s|ing)?\b/.test(normalized)
     && /\b(?:handling|disclosure|contact|duplicate|embargo)\b/.test(normalized);
   if (explicitlyHandlingOnly) return undefined;

--- a/src/util/submission-readiness.ts
+++ b/src/util/submission-readiness.ts
@@ -558,6 +558,9 @@ function programHumanGate(row: SubmissionDecisionLike, liveRequired: boolean): s
   const text = decisionHumanGates(row).trim();
   if (!hasUnsettledHumanGateText(text)) return undefined;
   const normalized = text.toLowerCase();
+  const explicitlyHandlingOnly = /\bno mandatory (?:submission|program|policy) (?:gate|gates|blocker|blockers) remain(?:s|ing)?\b/.test(normalized)
+    && /\b(?:handling|disclosure|contact|duplicate|embargo)\b/.test(normalized);
+  if (explicitlyHandlingOnly) return undefined;
   const programTerms = /\b(?:scope|venue|eligib|embargo|submission window|deadline|policy terms?|contest rules?|mandatory requirement)\b/.test(normalized);
   const liveTerms = /\b(?:live|funded|funds|deployment|production|current version|affected version)\b/.test(normalized);
   const adjudicationOnly = /\b(?:known issue|known_issue|novelty|duplicate|payout|reward|bounty amount|collectible)\b/.test(normalized)

--- a/src/util/submission-readiness.ts
+++ b/src/util/submission-readiness.ts
@@ -23,8 +23,8 @@ export interface TechnicalClaimGateEvidence {
 const TECHNICAL_CLAIM_GATES: TechnicalClaimGate[] = ["attacker_reachability", "end_to_end_effect", "impact_bounds"];
 const DEFAULT_BOUNTY_GATES: BountyGate[] = ["scope", "live_impact", "known_issue", "payout"];
 const SOURCE_ONLY_BOUNTY_GATES: BountyGate[] = ["scope", "known_issue", "payout"];
-const TECHNICAL_GATE_SUBJECT = String.raw`(?:scope|authori[sz]\w*|permissions? to audit|target identity|source integrity|live (?:impact|deployment|target|funds?)|funded deployment|production deployment|current version|affected version|execution evidence|execution|reproduction|reproduc(?:e|ed|ibility)|verification|proof of concept|poc|exploit|local fork|fork)`;
-const UNRESOLVED_GATE_STATE = String.raw`(?:pending|missing|unknown|unclear|unverified|unconfirmed|failed|could not|cannot|not (?:been )?(?:reproduced|verified|confirmed|executed|run)|must (?:be )?(?:reproduced|verified|confirmed|executed|run)|requires? (?:reproduction|verification|confirmation|execution))`;
+const TECHNICAL_GATE_SUBJECT = String.raw`(?:scope|authori[sz]ation|permissions? to audit|target identity|source integrity|live (?:impact|deployment|target|funds?)|funded deployment|production deployment|current version|affected version|execution evidence|execution|reproduction|reproduc(?:e|ed|ibility)|verification|technical confirmation|proof of concept|poc|exploit|local fork|fork)`;
+const UNRESOLVED_GATE_STATE = String.raw`(?:pending|missing|unknown|unclear|unverified|unconfirmed|incomplete|inconclusive|tbd|to be determined|failed|could not|cannot|not (?:yet )?(?:been )?(?:reproduced|verified|confirmed|executed|run)|must (?:be )?(?:reproduced|verified|confirmed|executed|run)|requires? (?:reproduction|verification|confirmation|execution))`;
 const TECHNICAL_GATE_UNCERTAINTY = new RegExp(
   `\\b${TECHNICAL_GATE_SUBJECT}\\b.{0,48}\\b${UNRESOLVED_GATE_STATE}\\b|\\b${UNRESOLVED_GATE_STATE}\\b.{0,48}\\b${TECHNICAL_GATE_SUBJECT}\\b`,
 );
@@ -704,7 +704,7 @@ function hasUnsettledHumanGateText(value: string): boolean {
   if (!text) return false;
   if (/^(?:none|n\/a|not applicable|no remaining gates?|no human gates?)\.?$/.test(text)) return false;
   if (/\b(?:no|none)\b.{0,32}\b(?:remaining|open|unsettled|human)\b.{0,24}\b(?:gate|gates|blocker|blockers)\b/.test(text)) return false;
-  return /\b(?:scope|venue|eligib|bounty|reward|payout|collectible|live|funded|funds|deployment|production|current|human gate|needs?|requires?|not established|not confirmed|unknown|unclear|unverified|unconfirmed|pending|missing|failed|review|cannot|authori[sz]\w*|permission|identity|integrity|verification|reproduc\w*|exploit|poc|fork|execution|embargo|deadline|window|must)\b/.test(text);
+  return /\b(?:scope|venue|eligib|bounty|reward|payout|collectible|live|funded|funds|deployment|production|current|human gate|needs?|requires?|not (?:yet )?(?:been )?(?:established|confirmed|verified|reproduced|executed|run)|unknown|unclear|unverified|unconfirmed|incomplete|inconclusive|tbd|to be determined|pending|missing|failed|review|cannot|must)\b/.test(text);
 }
 
 function bountyGateStatus(adjudication: unknown, gate: DecisionGate): string | undefined {

--- a/src/util/submission-readiness.ts
+++ b/src/util/submission-readiness.ts
@@ -23,12 +23,16 @@ export interface TechnicalClaimGateEvidence {
 const TECHNICAL_CLAIM_GATES: TechnicalClaimGate[] = ["attacker_reachability", "end_to_end_effect", "impact_bounds"];
 const DEFAULT_BOUNTY_GATES: BountyGate[] = ["scope", "live_impact", "known_issue", "payout"];
 const SOURCE_ONLY_BOUNTY_GATES: BountyGate[] = ["scope", "known_issue", "payout"];
-const TECHNICAL_GATE_SUBJECT = String.raw`(?:scope|authori[sz]ation|permissions? to audit|target identity|source integrity|live (?:impact|deployment|target|funds?)|funded deployment|production deployment|current version|affected version|execution evidence|execution|reproduction|reproduc(?:e|ed|ibility)|verification|technical confirmation|proof of concept|poc|exploit|local fork|fork)`;
+const TECHNICAL_GATE_SUBJECT = String.raw`(?:scope|authori[sz]ation|permissions? to audit|target identity|source integrity|live (?:impact|deployment|target|funds?)|funded deployment|production deployment|current version|affected version|execution evidence|execution|exploit reproduction|reproduction|reproduc(?:e|ed|ibility)|verification|technical confirmation|proof of concept|poc|exploit|local fork|fork)`;
 const UNRESOLVED_GATE_STATE = String.raw`(?:pending|missing|unknown|unclear|unverified|unconfirmed|incomplete|inconclusive|tbd|to be determined|failed|could not|cannot|not (?:yet )?(?:been )?(?:reproduced|verified|confirmed|executed|run)|must (?:be )?(?:reproduced|verified|confirmed|executed|run)|requires? (?:reproduction|verification|confirmation|execution))`;
+const RESOLVED_GATE_STATE = String.raw`(?:complete|completed successfully|confirmed|sufficient|settled|resolved|verified|reproduced(?: the (?:issue|finding|effect))?)`;
 const TECHNICAL_GATE_UNCERTAINTY = new RegExp(
   `\\b${TECHNICAL_GATE_SUBJECT}\\b.{0,48}\\b${UNRESOLVED_GATE_STATE}\\b|\\b${UNRESOLVED_GATE_STATE}\\b.{0,48}\\b${TECHNICAL_GATE_SUBJECT}\\b`,
 );
 const TECHNICAL_GATE_MENTION = new RegExp(`\\b${TECHNICAL_GATE_SUBJECT}\\b`);
+const EXPLICITLY_RESOLVED_TECHNICAL_GATE = new RegExp(
+  `^(?:the )?${TECHNICAL_GATE_SUBJECT}\\s+(?:(?:is|was|has been)\\s+)?${RESOLVED_GATE_STATE}\\.?$`,
+);
 
 export interface SubmissionReadinessOptions {
   impactInventory?: unknown;
@@ -585,8 +589,9 @@ function programHumanGate(row: SubmissionDecisionLike, liveRequired: boolean): s
     && separatedTechnicalPattern.test(normalized)
     && !mandatoryProgramTerms
     && !TECHNICAL_GATE_MENTION.test(separatedTechnicalRemainder);
-  const explicitlyResolvedTechnicalGate = /^(?:the )?(?:exploit reproduction|verification|authorization|execution evidence)\s+(?:is|was|has been)?\s*(?:complete|completed successfully|confirmed|sufficient|settled|resolved)\.?$/.test(normalized);
-  if (explicitlyHandlingOnly || explicitlySeparateDisclosureHandling || explicitlyResolvedTechnicalGate) return undefined;
+  const explicitlyDisclosureContactHandling = privateReview
+    && /^(?:the )?(?:(?:preferred|authorized|private|confidential|security|disclosure)\s+)*(?:contact and embargo handling|contact|disclosure (?:contact|channel|process)|embargo (?:process|handling))\s+(?:is|remain|remains)\s+(?:pending|unknown|unconfirmed|unresolved|to be decided)\.?$/.test(normalized);
+  if (explicitlyHandlingOnly || explicitlySeparateDisclosureHandling || explicitlyDisclosureContactHandling || EXPLICITLY_RESOLVED_TECHNICAL_GATE.test(normalized)) return undefined;
   if (technicalUncertainty) return text;
   if (mandatoryProgramTerms) return text;
   const programTerms = /\b(?:scope|venue|eligib|embargo|submission window|deadline|policy terms?|contest rules?|mandatory requirement)\b/.test(normalized);

--- a/src/util/submission-readiness.ts
+++ b/src/util/submission-readiness.ts
@@ -563,11 +563,15 @@ function programHumanGate(row: SubmissionDecisionLike, liveRequired: boolean): s
   const policyKind = normalizedWord(profile?.policy_kind ?? profile?.policyKind ?? profile?.kind);
   const privateReview = ["private_audit", "incident", "source_review"].includes(policyKind);
   const disclosureHandling = /\b(?:private|confidential|contact|embargo|duplicate|known issue|disclosure)\b/.test(normalized);
-  const technicalAuthorization = /\b(?:scope|authoriz|permission to audit|target identity|source integrity)\b/.test(normalized);
-  if (privateReview && disclosureHandling && !technicalAuthorization) return undefined;
+  const technicalUncertainty = /\b(?:scope|authoriz|permission to audit|target identity|source integrity|live (?:impact|deployment|target|funds?)|funded deployment|production deployment|current version|affected version|execution evidence)\b/.test(normalized)
+    || /\b(?:reproduction|execution|technical confirmation)\b.{0,40}\b(?:pending|missing|unknown|unverified|failed|could not|not reproduced)\b/.test(normalized)
+    || /\b(?:pending|missing|unknown|unverified|failed|could not)\b.{0,40}\b(?:reproduction|execution|technical confirmation)\b/.test(normalized);
+  if (privateReview && disclosureHandling && !technicalUncertainty) return undefined;
   const explicitlyHandlingOnly = /\bno mandatory (?:submission|program|policy) (?:gate|gates|blocker|blockers) remain(?:s|ing)?\b/.test(normalized)
-    && /\b(?:handling|disclosure|contact|duplicate|embargo)\b/.test(normalized);
+    && /\b(?:handling|disclosure|contact|duplicate|embargo)\b/.test(normalized)
+    && !technicalUncertainty;
   if (explicitlyHandlingOnly) return undefined;
+  if (technicalUncertainty) return text;
   const programTerms = /\b(?:scope|venue|eligib|embargo|submission window|deadline|policy terms?|contest rules?|mandatory requirement)\b/.test(normalized);
   const liveTerms = /\b(?:live|funded|funds|deployment|production|current version|affected version)\b/.test(normalized);
   const adjudicationOnly = /\b(?:known issue|known_issue|novelty|duplicate|payout|reward|bounty amount|collectible)\b/.test(normalized)

--- a/tests/db-store.test.mjs
+++ b/tests/db-store.test.mjs
@@ -1198,6 +1198,61 @@ test("store: startup keeps needs-human health when a completed confirm run has n
   }
 });
 
+test("store: startup clears confirm health only when every decision is explicitly settled", async () => {
+  const { dir, dbPath } = await tempDbPath();
+  const reasons = ["Some confirmation decisions are unresolved."];
+  const signals = { needsHuman: 2, decisions: 3 };
+  try {
+    let db = MetadataStore.openForOutput(dir);
+    const projectId = db.upsertProject({ name: "mixed-confirm-decisions" });
+    const confirmRun = db.startRun({ projectId, kind: "confirm", runDir: path.join(dir, "confirm") });
+    db.recordRunHealth(confirmRun, { status: "needs-human", reasons, signals });
+    db.finishRun(confirmRun, "done");
+    db.close();
+
+    let raw = new DatabaseSync(dbPath);
+    const insert = raw.prepare(
+      `INSERT INTO confirm_decision(project_id, run_id, bug, reproduced, recommendation, created_at)
+       VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+    );
+    insert.run(projectId, confirmRun, "Settled decision", "no", "drop");
+    insert.run(projectId, confirmRun, "Missing recommendation", null, null);
+    insert.run(projectId, confirmRun, "Unknown recommendation", null, "unknown");
+    raw.close();
+
+    db = MetadataStore.openForOutput(dir);
+    let health = db.getRun(confirmRun);
+    assert.equal(health.health_status, "needs-human");
+    assert.deepEqual(JSON.parse(health.health_reasons_json), reasons);
+    assert.deepEqual(JSON.parse(health.health_signals_json), signals);
+    db.close();
+
+    raw = new DatabaseSync(dbPath);
+    raw.prepare(
+      `UPDATE confirm_decision
+          SET recommendation = 'drop', reproduced = 'no'
+        WHERE run_id = ? AND recommendation IS NOT 'drop'`,
+    ).run(confirmRun);
+    raw.close();
+
+    db = MetadataStore.openForOutput(dir);
+    health = db.getRun(confirmRun);
+    assert.equal(health.health_status, null);
+    assert.equal(health.health_reasons_json, null);
+    assert.equal(health.health_signals_json, null);
+    db.close();
+
+    db = MetadataStore.openForOutput(dir);
+    health = db.getRun(confirmRun);
+    assert.equal(health.health_status, null);
+    assert.equal(health.health_reasons_json, null);
+    assert.equal(health.health_signals_json, null);
+    db.close();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("store: ambiguous reproduced decisions do not default to real-target evidence", async () => {
   const db = await tempDb();
   const projectId = db.upsertProject({ name: "p" });

--- a/tests/db-store.test.mjs
+++ b/tests/db-store.test.mjs
@@ -1145,6 +1145,11 @@ test("store: startup keeps command provenance when restoring a private-audit tec
         payout_estimate: { status: "not-applicable" },
       },
     }]);
+    db.recordRunHealth(confirmRun, {
+      status: "needs-human",
+      reasons: ["The private disclosure contact remains unresolved."],
+      signals: { needsHuman: 1 },
+    });
     db.finishRun(confirmRun, "done");
     const decisionId = Number(db.listConfirmDecisions(projectId)[0].id);
     db.close();
@@ -1164,6 +1169,7 @@ test("store: startup keeps command provenance when restoring a private-audit tec
     assert.equal(restored.evidence_level, "local-fork-reproduced");
     assert.equal(restored.repro_command_id, "cmd-private-fork");
     assert.equal(restored.human_gates, handlingNote);
+    assert.equal(db.getRun(confirmRun).health_status, null);
     db.close();
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/tests/db-store.test.mjs
+++ b/tests/db-store.test.mjs
@@ -1122,7 +1122,7 @@ test("store: startup keeps command provenance when restoring a private-audit tec
     }]);
     db.finishRun(auditRun, "done");
     const confirmRun = db.startRun({ projectId, kind: "confirm", runDir: path.join(dir, "confirm"), materialFingerprint: "sha256:private-audit" });
-    const handlingNote = "No mandatory submission gate remains under the supplied private-audit engagement. Maintainers must still confirm the private security contact/embargo and private duplicate status; those facts affect handling, not the demonstrated technical minimum.";
+    const handlingNote = "The team must confirm that this is not already known or privately reported and provide its preferred confidential contact/embargo process. This duplicate uncertainty is separate from technical reproduction. No public bounty or award terms were found, so no payout gate applies.";
     db.upsertConfirmDecisions(projectId, confirmRun, [{
       bug: "Private-audit fork reproduction",
       reproduced: "yes",

--- a/tests/db-store.test.mjs
+++ b/tests/db-store.test.mjs
@@ -1176,6 +1176,28 @@ test("store: startup keeps command provenance when restoring a private-audit tec
   }
 });
 
+test("store: startup keeps needs-human health when a completed confirm run has no decisions", async () => {
+  const { dir } = await tempDbPath();
+  try {
+    let db = MetadataStore.openForOutput(dir);
+    const projectId = db.upsertProject({ name: "confirm-without-decisions" });
+    const confirmRun = db.startRun({ projectId, kind: "confirm", runDir: path.join(dir, "confirm") });
+    db.recordRunHealth(confirmRun, {
+      status: "needs-human",
+      reasons: ["Confirmation could not produce a decision."],
+      signals: { needsHuman: 1 },
+    });
+    db.finishRun(confirmRun, "done");
+    db.close();
+
+    db = MetadataStore.openForOutput(dir);
+    assert.equal(db.getRun(confirmRun).health_status, "needs-human");
+    db.close();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("store: ambiguous reproduced decisions do not default to real-target evidence", async () => {
   const db = await tempDb();
   const projectId = db.upsertProject({ name: "p" });

--- a/tests/db-store.test.mjs
+++ b/tests/db-store.test.mjs
@@ -1109,6 +1109,67 @@ test("store: startup preserves operator-adjudicated fork evidence when safety no
   }
 });
 
+test("store: startup keeps command provenance when restoring a private-audit technical verdict", async () => {
+  const { dir, dbPath } = await tempDbPath();
+  try {
+    let db = MetadataStore.openForOutput(dir);
+    const projectId = db.upsertProject({ name: "private-audit-reproduced" });
+    const auditRun = db.startRun({ projectId, kind: "audit", runDir: path.join(dir, "audit"), materialFingerprint: "sha256:private-audit" });
+    db.upsertFindings(projectId, auditRun, [{
+      findingKey: "kprivatefork",
+      title: "Private-audit fork reproduction",
+      status: "confirmed-differential",
+    }]);
+    db.finishRun(auditRun, "done");
+    const confirmRun = db.startRun({ projectId, kind: "confirm", runDir: path.join(dir, "confirm"), materialFingerprint: "sha256:private-audit" });
+    const handlingNote = "No mandatory submission gate remains under the supplied private-audit engagement. Maintainers must still confirm the private security contact/embargo and private duplicate status; those facts affect handling, not the demonstrated technical minimum.";
+    db.upsertConfirmDecisions(projectId, confirmRun, [{
+      bug: "Private-audit fork reproduction",
+      reproduced: "yes",
+      recommendation: "needs-human",
+      members: ["kprivatefork"],
+      evidenceLevel: "local-fork-reproduced",
+      reproEvidence: "The deployed effect reproduced on a fixed local fork.",
+      reproCommandId: "cmd-private-fork",
+      humanGates: handlingNote,
+      engagementProfile: {
+        policy_kind: "private_audit",
+        policy_sources: ["SECURITY.md"],
+        evidence_requirement: "real_target",
+        required_gates: ["scope", "private disclosure channel"],
+      },
+      adjudication: {
+        gates: [{ id: "scope", status: "pass", evidence: "The deployed component is in the authorized audit scope." }],
+        scope_status: "pass",
+        known_issue_status: "unknown",
+        payout_estimate: { status: "not-applicable" },
+      },
+    }]);
+    db.finishRun(confirmRun, "done");
+    const decisionId = Number(db.listConfirmDecisions(projectId)[0].id);
+    db.close();
+
+    const legacy = new DatabaseSync(dbPath);
+    legacy.prepare(
+      `UPDATE confirm_decision
+          SET recommendation = 'needs-human',
+              human_gates = human_gates || ' Framework blocked submit-candidate: execution provenance was not restored'
+        WHERE id = ?`,
+    ).run(decisionId);
+    legacy.close();
+
+    db = MetadataStore.openForOutput(dir);
+    const restored = db.getConfirmDecision(decisionId);
+    assert.equal(restored.recommendation, "submit-candidate");
+    assert.equal(restored.evidence_level, "local-fork-reproduced");
+    assert.equal(restored.repro_command_id, "cmd-private-fork");
+    assert.equal(restored.human_gates, handlingNote);
+    db.close();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("store: ambiguous reproduced decisions do not default to real-target evidence", async () => {
   const db = await tempDb();
   const projectId = db.upsertProject({ name: "p" });

--- a/tests/submission-readiness.test.mjs
+++ b/tests/submission-readiness.test.mjs
@@ -184,19 +184,25 @@ test("private review does not turn resolved technical statements into open gates
     "Verification is complete.",
     "Authorization was confirmed.",
     "Execution evidence is sufficient.",
-    "The authorized disclosure contact remains pending; no mandatory program gates remain.",
+    "The authorized disclosure contact remains pending.",
+    "The preferred authorized security contact is pending.",
+    "Source integrity was verified.",
+    "The local fork reproduced the issue.",
   ];
 
   for (const humanGates of resolvedNotes) {
-    const summary = submissionDecisionSummary(privateAuditDecision(humanGates), { requireImpactInventory: false });
+    const row = privateAuditDecision(humanGates);
+    const summary = submissionDecisionSummary(row, { requireImpactInventory: false });
     assert.equal(summary.programCompliance.status, "met", humanGates);
     assert.equal(summary.submission.status, "eligible-to-submit", humanGates);
+    const [normalized] = enforceSubmissionReadiness([row], { requireImpactInventory: false });
+    assert.equal(normalized.recommendation, "submit-candidate", humanGates);
   }
 });
 
 test("private disclosure handling distinguishes preferred process from a mandatory embargo", () => {
   const handlingOnly = submissionDecisionSummary(privateAuditDecision(
-    "Preferred confidential contact and embargo handling remain pending. No mandatory submission or policy gates remain.",
+    "Preferred confidential contact and embargo handling remain pending.",
   ), { requireImpactInventory: false });
   assert.equal(handlingOnly.submission.status, "eligible-to-submit");
 

--- a/tests/submission-readiness.test.mjs
+++ b/tests/submission-readiness.test.mjs
@@ -69,7 +69,7 @@ test("private disclosure handling notes do not erase a local-fork technical verd
     recommendation: "needs-human",
     evidenceLevel: "local-fork-reproduced",
     reproCommandId: "cmd-fork-1",
-    humanGates: "No mandatory submission gate remains under the supplied private-audit engagement. Maintainers must still confirm the private security contact/embargo and whether this is an internal known issue or private duplicate; those facts affect handling, not the demonstrated technical minimum.",
+    humanGates: "The team must confirm that this is not already known or privately reported and provide its preferred confidential contact/embargo process. This duplicate uncertainty is separate from technical reproduction. No public bounty or award terms were found, so no payout gate applies.",
     engagementProfile: {
       policy_kind: "private_audit",
       policy_sources: ["SECURITY.md"],
@@ -91,7 +91,7 @@ test("private disclosure handling notes do not erase a local-fork technical verd
 
   const [normalized] = enforceSubmissionReadiness([row], { requireImpactInventory: false });
   assert.equal(normalized.recommendation, "submit-candidate");
-  assert.match(normalized.humanGates, /private security contact\/embargo/i);
+  assert.match(normalized.humanGates, /confidential contact\/embargo/i);
 });
 
 test("source execution cannot satisfy a program that requires a local fork", () => {

--- a/tests/submission-readiness.test.mjs
+++ b/tests/submission-readiness.test.mjs
@@ -94,6 +94,31 @@ test("private disclosure handling notes do not erase a local-fork technical verd
   assert.match(normalized.humanGates, /confidential contact\/embargo/i);
 });
 
+test("private disclosure handling does not hide an unresolved deployment reproduction gate", () => {
+  const row = {
+    ...sourceOnlyContest(),
+    evidenceLevel: "local-fork-reproduced",
+    humanGates: "The private disclosure contact is unresolved, and live deployment reproduction remains pending.",
+    engagementProfile: {
+      policy_kind: "private_audit",
+      policy_sources: ["SECURITY.md"],
+      evidence_requirement: "real_target",
+      required_gates: ["scope", "private disclosure channel"],
+    },
+    adjudication: {
+      gates: [{ id: "scope", status: "pass", evidence: "The affected component is authorized." }],
+      scope_status: "pass",
+      known_issue_status: "unknown",
+      payout_estimate: { status: "not-applicable" },
+    },
+  };
+
+  const summary = submissionDecisionSummary(row, { requireImpactInventory: false });
+  assert.equal(summary.programCompliance.status, "unknown");
+  assert.equal(summary.submission.status, "needs-human");
+  assert.match(summary.submission.rationale, /live deployment reproduction remains pending/i);
+});
+
 test("source execution cannot satisfy a program that requires a local fork", () => {
   const row = sourceOnlyContest({
     recommendation: "submit-candidate",

--- a/tests/submission-readiness.test.mjs
+++ b/tests/submission-readiness.test.mjs
@@ -41,6 +41,29 @@ function sourceOnlyContest(overrides = {}) {
   };
 }
 
+function privateAuditDecision(humanGates, overrides = {}) {
+  return sourceOnlyContest({
+    evidenceLevel: "local-fork-reproduced",
+    humanGates,
+    engagementProfile: {
+      policy_kind: "private_audit",
+      policy_sources: ["SECURITY.md"],
+      evidence_requirement: "real_target",
+      required_gates: ["scope", "private disclosure channel"],
+    },
+    adjudication: {
+      gates: [
+        { id: "scope", status: "pass", evidence: "The affected component is in the authorized audit scope." },
+        ...validTechnicalClaimGates(),
+      ],
+      scope_status: "pass",
+      known_issue_status: "unknown",
+      payout_estimate: { status: "not-applicable" },
+    },
+    ...overrides,
+  });
+}
+
 test("submission decision separates program compliance from evidence and reward uncertainty", () => {
   const summary = submissionDecisionSummary(sourceOnlyContest(), { requireImpactInventory: false });
 
@@ -117,6 +140,43 @@ test("private disclosure handling does not hide an unresolved deployment reprodu
   assert.equal(summary.programCompliance.status, "unknown");
   assert.equal(summary.submission.status, "needs-human");
   assert.match(summary.submission.rationale, /live deployment reproduction remains pending/i);
+});
+
+test("private review preserves unresolved technical gates across common wording", () => {
+  const unresolvedGates = [
+    "Private contact remains pending; exploit verification is missing.",
+    "The proof of concept remains unverified.",
+    "Fork reproduction is pending.",
+    "The exploit must be reproduced before disclosure.",
+    "Execution evidence is unknown.",
+    "Authorization remains pending.",
+    "Permission to audit has not been confirmed.",
+    "Target identity is unclear.",
+    "Source integrity is unverified.",
+    "The current version remains unconfirmed.",
+    "The affected version is unknown.",
+  ];
+
+  for (const humanGates of unresolvedGates) {
+    const summary = submissionDecisionSummary(privateAuditDecision(humanGates), { requireImpactInventory: false });
+    assert.equal(summary.programCompliance.status, "unknown", humanGates);
+    assert.equal(summary.submission.status, "needs-human", humanGates);
+    assert.match(summary.submission.rationale, new RegExp(humanGates.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"));
+  }
+});
+
+test("private disclosure handling distinguishes preferred process from a mandatory embargo", () => {
+  const handlingOnly = submissionDecisionSummary(privateAuditDecision(
+    "Preferred confidential contact and embargo handling remain pending. No mandatory submission or policy gates remain.",
+  ), { requireImpactInventory: false });
+  assert.equal(handlingOnly.submission.status, "eligible-to-submit");
+
+  const mandatoryEmbargo = submissionDecisionSummary(privateAuditDecision(
+    "The confidential disclosure embargo deadline remains pending.",
+  ), { requireImpactInventory: false });
+  assert.equal(mandatoryEmbargo.programCompliance.status, "unknown");
+  assert.equal(mandatoryEmbargo.submission.status, "needs-human");
+  assert.match(mandatoryEmbargo.submission.rationale, /embargo deadline remains pending/i);
 });
 
 test("source execution cannot satisfy a program that requires a local fork", () => {

--- a/tests/submission-readiness.test.mjs
+++ b/tests/submission-readiness.test.mjs
@@ -155,6 +155,9 @@ test("private review preserves unresolved technical gates across common wording"
     "Source integrity is unverified.",
     "The current version remains unconfirmed.",
     "The affected version is unknown.",
+    "The proof of concept status is TBD.",
+    "Technical confirmation is inconclusive.",
+    "Verification remains incomplete.",
   ];
 
   for (const humanGates of unresolvedGates) {
@@ -162,6 +165,22 @@ test("private review preserves unresolved technical gates across common wording"
     assert.equal(summary.programCompliance.status, "unknown", humanGates);
     assert.equal(summary.submission.status, "needs-human", humanGates);
     assert.match(summary.submission.rationale, new RegExp(humanGates.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"));
+  }
+});
+
+test("private review does not turn resolved technical statements into open gates", () => {
+  const resolvedNotes = [
+    "Exploit reproduction completed successfully.",
+    "Verification is complete.",
+    "Authorization was confirmed.",
+    "Execution evidence is sufficient.",
+    "The authorized disclosure contact remains pending.",
+  ];
+
+  for (const humanGates of resolvedNotes) {
+    const summary = submissionDecisionSummary(privateAuditDecision(humanGates), { requireImpactInventory: false });
+    assert.equal(summary.programCompliance.status, "met", humanGates);
+    assert.equal(summary.submission.status, "eligible-to-submit", humanGates);
   }
 });
 

--- a/tests/submission-readiness.test.mjs
+++ b/tests/submission-readiness.test.mjs
@@ -158,13 +158,23 @@ test("private review preserves unresolved technical gates across common wording"
     "The proof of concept status is TBD.",
     "Technical confirmation is inconclusive.",
     "Verification remains incomplete.",
+    "Proof of concept status is undecided.",
+    "Technical confirmation remains outstanding.",
+    "Exploit verification is awaiting completion.",
+    "Reproduction has yet to be performed.",
+    "The PoC has not passed verification.",
+    "Permission to audit is awaiting approval.",
+    "Source integrity remains undetermined.",
+    "No mandatory program gates remain; proof of concept status is undecided.",
   ];
 
   for (const humanGates of unresolvedGates) {
-    const summary = submissionDecisionSummary(privateAuditDecision(humanGates), { requireImpactInventory: false });
+    const row = privateAuditDecision(humanGates);
+    const summary = submissionDecisionSummary(row, { requireImpactInventory: false });
     assert.equal(summary.programCompliance.status, "unknown", humanGates);
     assert.equal(summary.submission.status, "needs-human", humanGates);
-    assert.match(summary.submission.rationale, new RegExp(humanGates.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"));
+    const [normalized] = enforceSubmissionReadiness([row], { requireImpactInventory: false });
+    assert.equal(normalized.recommendation, "needs-human", humanGates);
   }
 });
 
@@ -174,7 +184,7 @@ test("private review does not turn resolved technical statements into open gates
     "Verification is complete.",
     "Authorization was confirmed.",
     "Execution evidence is sufficient.",
-    "The authorized disclosure contact remains pending.",
+    "The authorized disclosure contact remains pending; no mandatory program gates remain.",
   ];
 
   for (const humanGates of resolvedNotes) {

--- a/tests/submission-readiness.test.mjs
+++ b/tests/submission-readiness.test.mjs
@@ -62,6 +62,38 @@ test("submission decision separates program compliance from evidence and reward 
   assert.match(normalized.humanGates, /Private duplicate and payout/);
 });
 
+test("private disclosure handling notes do not erase a local-fork technical verdict", () => {
+  const row = {
+    bug: "Shared backing can become undercollateralized",
+    reproduced: "yes",
+    recommendation: "needs-human",
+    evidenceLevel: "local-fork-reproduced",
+    reproCommandId: "cmd-fork-1",
+    humanGates: "No mandatory submission gate remains under the supplied private-audit engagement. Maintainers must still confirm the private security contact/embargo and whether this is an internal known issue or private duplicate; those facts affect handling, not the demonstrated technical minimum.",
+    engagementProfile: {
+      policy_kind: "private_audit",
+      policy_sources: ["SECURITY.md"],
+      evidence_requirement: "real_target",
+      required_gates: ["scope", "private disclosure channel"],
+    },
+    adjudication: {
+      gates: [{ id: "scope", status: "pass", evidence: "The deployed component is in the authorized audit scope." }],
+      scope_status: "pass",
+      known_issue_status: "unknown",
+      payout_estimate: { status: "not-applicable" },
+    },
+  };
+
+  const summary = submissionDecisionSummary(row, { requireImpactInventory: false });
+  assert.equal(summary.technicalEvidence.level, "local-fork-reproduced");
+  assert.equal(summary.programCompliance.status, "met");
+  assert.equal(summary.submission.status, "eligible-to-submit");
+
+  const [normalized] = enforceSubmissionReadiness([row], { requireImpactInventory: false });
+  assert.equal(normalized.recommendation, "submit-candidate");
+  assert.match(normalized.humanGates, /private security contact\/embargo/i);
+});
+
 test("source execution cannot satisfy a program that requires a local fork", () => {
   const row = sourceOnlyContest({
     recommendation: "submit-candidate",


### PR DESCRIPTION
## Summary

- preserve execution-backed confirmation evidence and command provenance during startup reconciliation
- separate technical verdicts from private disclosure, duplicate, and contact handling
- fail closed on ambiguous free-text human gates while recognizing explicitly resolved technical and disclosure-only states
- clear stale `needs-human` run health only when every confirm decision is explicitly settled

## Verification

- `npm run check`
- targeted confirmation, readiness, and store suites: 69/69 passed
- API catalog contract passed
- database upgrade contract passed (`v0.3.1` to current)
- mock audit passed
- public-surface and credential scans passed

`npm run verify` builds successfully and passes 399/403 tests. The remaining four API test files abort in Node 24.13.0 with the same native `InternalCallbackScope::Close` assertion on an unmodified `main` checkout, so they are a pre-existing environment/runtime failure rather than a regression in this branch.

## Review

- pre-landing review: clean after fixes
- independent coverage review: PASS
- plan completion: 4/4
- no prompt files changed